### PR TITLE
Compare compatibility output and exit status exactly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
           php-version: '8.5'
       - run: zig build
       - run: php --version
+      - run: python3 ./tests/compat_runner_test
       - run: ./tests/run
 
   examples:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test: ## Run zig unit tests
 
 .PHONY: compat
 compat: build ## Run PHP compatibility tests (requires PHP 8.4)
+	python3 ./tests/compat_runner_test
 	./tests/run
 
 .PHONY: pdo

--- a/src/main.zig
+++ b/src/main.zig
@@ -508,7 +508,7 @@ fn runWithVM(allocator: std.mem.Allocator, result: *CompileResult, script_path: 
                 if (vm.exit_requested) std.process.exit(vm.exit_code);
                 if (vm.pending_exception != null) {
                     const fallback = error_format.formatRuntimeError(allocator, vm);
-                    if (fallback.len > 0) try writeStderr(fallback);
+                    if (fallback.len > 0 and (vm.error_reporting_level & 1) != 0) try writeStderr(fallback);
                     std.process.exit(255);
                 }
                 return;
@@ -518,10 +518,12 @@ fn runWithVM(allocator: std.mem.Allocator, result: *CompileResult, script_path: 
         if (vm.output.items.len > 0) try writeStdout(vm.output.items);
         if (std.posix.getenv("ZPHP_DBG_PROFILE") != null) dumpProfile(vm);
         const msg = error_format.formatRuntimeError(allocator, vm);
-        if (msg.len > 0) {
-            try writeStderr(msg);
-        } else {
-            try writeStderr(vm.error_msg orelse "runtime error\n");
+        if ((vm.error_reporting_level & 1) != 0) {
+            if (msg.len > 0) {
+                try writeStderr(msg);
+            } else {
+                try writeStderr(vm.error_msg orelse "runtime error\n");
+            }
         }
         std.process.exit(255);
     };

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -61,6 +61,8 @@ pub const PharCacheEntry = struct {
 pub const OutputBufferLevel = struct {
     start: usize,
     callback: ?Value = null,
+    started: bool = false,
+    disabled: bool = false,
 };
 
 pub const ErrorHandlerEntry = struct { handler: Value, mask: i64 };
@@ -16184,6 +16186,10 @@ pub const VM = struct {
     }
 
     pub fn releaseCallbackRegistries(self: *VM) void {
+        for (self.ob_stack.items) |*level| {
+            if (level.callback) |cb| self.releaseValue(cb);
+            level.callback = null;
+        }
         for (self.shutdown_callbacks.items) |cb| self.releaseValue(cb);
         self.shutdown_callbacks.clearRetainingCapacity();
         for (self.autoload_callbacks.items) |cb| self.releaseValue(cb);

--- a/src/stdlib/http.zig
+++ b/src/stdlib/http.zig
@@ -51,36 +51,76 @@ fn native_ob_start(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         level.callback = args[0];
     }
     try ctx.vm.ob_stack.append(ctx.allocator, level);
+    if (level.callback) |cb| @import("../runtime/vm.zig").VM.retainValue(cb);
     return .{ .bool = true };
 }
 
-fn applyCallback(ctx: *NativeContext, level: OutputBufferLevel, content: []const u8) RuntimeError![]const u8 {
-    if (level.callback) |cb| {
-        const result = try ctx.invokeCallable(cb, &.{.{ .string = Value.String.borrowed(content) }});
-        if (result == .string) return result.string.bytes();
-        if (result == .null or result == .bool) return content;
+// Keep the handler on the stack during invocation (ob_get_level/contents can
+// observe it). Copy input into request-owned storage: callbacks may retain it.
+fn processBuffer(ctx: *NativeContext, clean: bool, final: bool, get: bool) RuntimeError!Value {
+    const len = ctx.vm.ob_stack.items.len;
+    if (len == 0) return .{ .bool = false };
+    const index = len - 1;
+    var level = ctx.vm.ob_stack.items[index];
+    if (level.disabled) level.start = ctx.vm.output.items.len;
+    const raw = try ctx.createString(ctx.vm.output.items[level.start..]);
+    var transformed: []const u8 = raw;
+    const discard = clean and !level.disabled;
+    if (if (level.disabled) null else level.callback) |cb| {
+        const phase: i64 = (if (level.started) @as(i64, 0) else 1) |
+            (if (clean) @as(i64, 2) else 0) |
+            (if (final) @as(i64, 8) else if (!clean) @as(i64, 4) else 0);
+        ctx.vm.ob_stack.items[index].started = true;
+        const result = ctx.invokeCallable(cb, &.{
+            .{ .string = Value.String.borrowed(raw) }, .{ .int = phase },
+        }) catch |err| {
+            // PHP disables a throwing handler. Clean discards input; flush
+            // forwards it unchanged. Final operations still remove the level.
+            ctx.vm.ob_stack.items[index].callback = null;
+            ctx.vm.ob_stack.items[index].disabled = true;
+            ctx.vm.releaseValue(cb);
+            ctx.vm.output.shrinkRetainingCapacity(level.start);
+            if (!clean) try ctx.vm.output.appendSlice(ctx.allocator, raw);
+            if (final) {
+                _ = ctx.vm.ob_stack.pop();
+            } else {
+                ctx.vm.ob_stack.items[index].start = ctx.vm.output.items.len;
+            }
+            return err;
+        };
+        // A false return disables future handler processing, including clean.
+        if (result == .bool and !result.bool) {
+            ctx.vm.ob_stack.items[index].disabled = true;
+        } else if (result == .bool or result == .null) {
+            transformed = "";
+        } else {
+            transformed = try @import("strings.zig").coerceToString(ctx, result);
+        }
     }
-    return content;
+    // Output produced inside a handler is not forwarded.
+    ctx.vm.output.shrinkRetainingCapacity(level.start);
+    if (!discard) try ctx.vm.output.appendSlice(ctx.allocator, transformed);
+    if (final) {
+        _ = ctx.vm.ob_stack.pop();
+        if (level.callback) |cb| ctx.vm.releaseValue(cb);
+    } else {
+        ctx.vm.ob_stack.items[index].start = ctx.vm.output.items.len;
+    }
+    return if (get) .{ .string = Value.String.borrowed(raw) } else .{ .bool = true };
 }
 
 fn native_ob_get_clean(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
-    const level = ctx.vm.ob_stack.pop().?;
-    const raw = try ctx.createString(ctx.vm.output.items[level.start..]);
-    ctx.vm.output.shrinkRetainingCapacity(level.start);
-    return .{ .string = Value.String.borrowed(raw) };
+    return processBuffer(ctx, true, true, true);
 }
 
 fn native_ob_end_clean(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
-    const level = ctx.vm.ob_stack.pop().?;
-    ctx.vm.output.shrinkRetainingCapacity(level.start);
-    return .{ .bool = true };
+    return processBuffer(ctx, true, true, false);
 }
 
 fn native_ob_get_contents(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
     const level = ctx.vm.ob_stack.getLast();
+    if (level.disabled) return .{ .string = Value.String.borrowed("") };
     return .{ .string = Value.String.borrowed(try ctx.createString(ctx.vm.output.items[level.start..])) };
 }
 
@@ -89,61 +129,25 @@ fn native_ob_get_level(ctx: *NativeContext, _: []const Value) RuntimeError!Value
 }
 
 fn native_ob_end_flush(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
-    const level = ctx.vm.ob_stack.pop().?;
-    if (level.callback) |_| {
-        const raw = try ctx.allocator.dupe(u8, ctx.vm.output.items[level.start..]);
-        defer ctx.allocator.free(raw);
-        ctx.vm.output.shrinkRetainingCapacity(level.start);
-        const transformed = try applyCallback(ctx, level, raw);
-        try ctx.vm.output.appendSlice(ctx.allocator, transformed);
-    }
-    return .{ .bool = true };
+    return processBuffer(ctx, false, true, false);
 }
 
 fn native_ob_get_flush(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
-    const level = ctx.vm.ob_stack.pop().?;
-    const raw = try ctx.allocator.dupe(u8, ctx.vm.output.items[level.start..]);
-    defer ctx.allocator.free(raw);
-    ctx.vm.output.shrinkRetainingCapacity(level.start);
-    const transformed = try applyCallback(ctx, level, raw);
-    const owned = try ctx.createString(transformed);
-    try ctx.vm.output.appendSlice(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return processBuffer(ctx, false, true, true);
 }
 
 fn native_ob_flush(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
-    const top = &ctx.vm.ob_stack.items[ctx.vm.ob_stack.items.len - 1];
-    if (top.callback) |_| {
-        const raw = try ctx.allocator.dupe(u8, ctx.vm.output.items[top.start..]);
-        defer ctx.allocator.free(raw);
-        ctx.vm.output.shrinkRetainingCapacity(top.start);
-        const transformed = try applyCallback(ctx, top.*, raw);
-        try ctx.vm.output.appendSlice(ctx.allocator, transformed);
-    }
-    if (ctx.vm.ob_stack.items.len >= 2) {
-        const current_start = ctx.vm.ob_stack.items[ctx.vm.ob_stack.items.len - 1].start;
-        ctx.vm.ob_stack.items[ctx.vm.ob_stack.items.len - 2].start = @min(
-            ctx.vm.ob_stack.items[ctx.vm.ob_stack.items.len - 2].start,
-            current_start,
-        );
-    }
-    ctx.vm.ob_stack.items[ctx.vm.ob_stack.items.len - 1].start = ctx.vm.output.items.len;
-    return .{ .bool = true };
+    return processBuffer(ctx, false, false, false);
 }
 
 fn native_ob_clean(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
-    const level = ctx.vm.ob_stack.getLast();
-    ctx.vm.output.shrinkRetainingCapacity(level.start);
-    return .{ .bool = true };
+    return processBuffer(ctx, true, false, false);
 }
 
 fn native_ob_get_length(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
     const level = ctx.vm.ob_stack.getLast();
+    if (level.disabled) return .{ .int = 0 };
     return .{ .int = @intCast(ctx.vm.output.items.len - level.start) };
 }
 

--- a/src/stdlib/strings.zig
+++ b/src/stdlib/strings.zig
@@ -421,7 +421,12 @@ fn strtolower(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 }
 
 fn strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (args.len != 1) {
+        const msg = try std.fmt.allocPrint(ctx.allocator, "strtoupper() expects exactly 1 argument, {d} given", .{args.len});
+        try ctx.strings.append(ctx.allocator, msg);
+        try ctx.vm.setPendingException("ArgumentCountError", msg);
+        return error.RuntimeError;
+    }
     if (try rejectArrayParam(ctx, args[0], "strtoupper")) return error.RuntimeError;
     const s = try coerceToString(ctx, args[0]);
     const buf = try ctx.allocator.alloc(u8, s.len);
@@ -4183,7 +4188,7 @@ fn rejectArrayParam(ctx: *NativeContext, v: Value, comptime func_name: []const u
     return false;
 }
 
-fn coerceToString(ctx: *NativeContext, v: Value) ![]const u8 {
+pub fn coerceToString(ctx: *NativeContext, v: Value) ![]const u8 {
     return switch (v) {
         .string => |s| s.bytes(),
         .int => |n| blk: {

--- a/tests/compat_runner_test
+++ b/tests/compat_runner_test
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class CompatRunnerTest(unittest.TestCase):
+    def check_runner(self, php, zphp, expected_status, expected_output):
+        with tempfile.TemporaryDirectory(prefix="zphp-compat-test-") as directory:
+            root = Path(directory)
+            shutil.copyfile(Path(__file__).with_name("run"), root / "run")
+            (root / "probe.php").write_text("<?php\n")
+            captures = root / "captures"
+            captures.mkdir()
+            for name, body in (("php", php), ("zphp", zphp)):
+                executable = root / name
+                executable.write_text("#!/bin/sh\n" + body + "\n")
+                executable.chmod(0o755)
+            env = dict(os.environ, PATH=directory + os.pathsep + os.environ["PATH"],
+                       ZPHP=str(root / "zphp"), TMPDIR=str(captures))
+            result = subprocess.run(["bash", str(root / "run")], env=env,
+                                    capture_output=True, timeout=10)
+            self.assertEqual(result.returncode, expected_status, result.stdout)
+            self.assertIn(expected_output, result.stdout)
+            self.assertEqual(list(captures.iterdir()), [])
+
+    def test_equal_output(self):
+        self.check_runner("printf 'hello\\n'; printf 'warning\\n' >&2",
+                          "printf 'hello\\n'; printf 'warning\\n' >&2",
+                          0, b"1 passed, 0 failed")
+
+    def test_equal_nonzero_status(self):
+        self.check_runner("exit 7", "exit 7", 0, b"1 passed, 0 failed")
+
+    def test_different_status(self):
+        self.check_runner("printf same", "printf same; exit 7", 1,
+                          b"exit status: php=0 zphp=7")
+
+    def test_different_stdout(self):
+        self.check_runner("printf expected", "printf actual", 1, b"stdout differs")
+
+    def test_different_stderr(self):
+        self.check_runner("printf expected >&2", "printf actual >&2", 1, b"stderr differs")
+
+    def test_output_on_wrong_stream(self):
+        self.check_runner("printf same", "printf same >&2", 1, b"1 failed")
+
+    def test_trailing_newlines(self):
+        self.check_runner("printf 'same\\n'", "printf 'same\\n\\n'", 1, b"stdout differs")
+
+    def test_missing_final_newline(self):
+        self.check_runner("printf 'same\\n'", "printf same", 1, b"stdout differs")
+
+    def test_stderr_trailing_newlines(self):
+        self.check_runner("printf 'same\\n' >&2", "printf 'same\\n\\n' >&2", 1,
+                          b"stderr differs")
+
+    def test_embedded_null(self):
+        self.check_runner("printf 'a\\000b'", "printf ab", 1, b"stdout differs")
+
+    def test_equal_binary_output(self):
+        self.check_runner("printf 'a\\000b\\n'", "printf 'a\\000b\\n'", 0,
+                          b"1 passed, 0 failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/output_handler_exceptions.php
+++ b/tests/output_handler_exceptions.php
@@ -1,0 +1,19 @@
+<?php
+foreach (['ob_clean', 'ob_flush', 'ob_end_clean', 'ob_get_clean', 'ob_end_flush', 'ob_get_flush'] as $op) {
+    ob_start();
+    ob_start(function ($s, $phase) { throw new Exception('handler failed'); });
+    echo 'raw';
+    try { $op(); echo 'unreachable'; }
+    catch (Exception $e) { echo '|', $e->getMessage(), ':', ob_get_level(), ':', ob_get_contents(), '|'; }
+    while (ob_get_level() > 1) ob_end_clean();
+    $output = ob_get_clean();
+    echo $op, '=', $output, "\n";
+}
+// Internal functions enforce their arity even when called as handlers.
+ob_start('strtoupper');
+echo 'discard';
+try { ob_end_clean(); echo 'unreachable'; }
+catch (ArgumentCountError $e) { echo get_class($e), ':', $e->getMessage(), ':', ob_get_level(), "\n"; }
+try { strtoupper(); }
+catch (ArgumentCountError $e) { echo $e->getMessage(), "\n"; }
+echo strtoupper('normal'), "\n";

--- a/tests/output_handler_hidden_fatal.php
+++ b/tests/output_handler_hidden_fatal.php
@@ -1,0 +1,7 @@
+<?php
+error_reporting(0);
+echo "before\n";
+ob_start('strtoupper');
+echo 'discarded';
+ob_end_clean();
+echo "unreachable\n";

--- a/tests/output_handler_phases.php
+++ b/tests/output_handler_phases.php
@@ -1,0 +1,42 @@
+<?php
+// Clean calls the handler too; START is used only on its first invocation.
+$events = [];
+ob_start(function ($s, $phase) use (&$events) {
+    $events[] = [$s, $phase, ob_get_level(), ob_get_contents()];
+    return strtoupper($s);
+});
+echo 'discard'; ob_clean();
+echo 'flush'; ob_flush();
+echo 'final'; $raw = ob_get_flush();
+echo "\n", $raw, "\n", json_encode($events), "\n";
+foreach (['ob_end_clean', 'ob_get_clean', 'ob_end_flush', 'ob_get_flush'] as $op) {
+    ob_start(function ($s, $phase) use (&$events) {
+        $events[] = [$s, $phase];
+        return 'converted';
+    });
+    echo 'original';
+    $result = $op();
+    echo $op, ':', json_encode($result), "\n";
+}
+echo json_encode($events), "\n";
+foreach ([false, null, true, 42, ''] as $result) {
+    ob_start(function ($s, $phase) use ($result) { return $result; });
+    echo 'raw'; ob_end_flush(); echo "|\n";
+}
+// A disabled handler passes later writes through even across clean operations.
+$calls = 0;
+ob_start(function ($s, $phase) use (&$calls) { ++$calls; return false; });
+echo 'a'; ob_flush(); echo 'b';
+var_dump(ob_get_contents(), ob_get_length());
+ob_clean(); echo 'c'; ob_end_clean(); echo ':', $calls, "\n";
+// Handler and retained input must outlive the original callable/buffer storage.
+class OutputHandlerOwner {
+    public $saved = '';
+    public function __invoke($s, $phase) { $this->saved = $s; return $s; }
+    public function __destruct() { echo 'released:', $this->saved, "\n"; }
+}
+$handler = new OutputHandlerOwner();
+ob_start($handler);
+unset($handler);
+echo 'owned'; ob_clean();
+echo 'last'; ob_end_clean();

--- a/tests/run
+++ b/tests/run
@@ -16,22 +16,35 @@ fi
 
 passed=0
 failed=0
-errors=""
+capture_dir=$(mktemp -d "${TMPDIR:-/tmp}/zphp-compat.XXXXXX")
+trap 'rm -rf "$capture_dir"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 for f in "$SCRIPT_DIR"/*.php; do
     name="$(basename "$f")"
     # skip tests that require external database servers
     case "$name" in pdo_mysql.php|pdo_pgsql.php) continue ;; esac
-    php_out="$(php -d error_reporting='E_ALL & ~E_DEPRECATED' -d display_errors=0 -d zend.exception_ignore_args=0 -d zend.exception_string_param_max_len=15 "$f" 2>&1)" || true
-    zphp_out="$("$ZPHP" run "$f" 2>&1)" || true
+    php_status=0
+    zphp_status=0
+    php -d error_reporting='E_ALL & ~E_DEPRECATED' -d display_errors=0 -d zend.exception_ignore_args=0 -d zend.exception_string_param_max_len=15 "$f" >"$capture_dir/php.stdout" 2>"$capture_dir/php.stderr" || php_status=$?
+    "$ZPHP" run "$f" >"$capture_dir/zphp.stdout" 2>"$capture_dir/zphp.stderr" || zphp_status=$?
 
-    if [ "$php_out" = "$zphp_out" ]; then
+    if [ "$php_status" -eq "$zphp_status" ] &&
+        cmp -s "$capture_dir/php.stdout" "$capture_dir/zphp.stdout" &&
+        cmp -s "$capture_dir/php.stderr" "$capture_dir/zphp.stderr"; then
         passed=$((passed + 1))
         echo "  pass  $name"
     else
         failed=$((failed + 1))
         echo "  FAIL  $name"
-        errors="$errors\n--- $name ---\nexpected (php):\n$php_out\ngot (zphp):\n$zphp_out\n"
+        printf '    exit status: php=%s zphp=%s\n' "$php_status" "$zphp_status"
+        for stream in stdout stderr; do
+            if ! cmp -s "$capture_dir/php.$stream" "$capture_dir/zphp.$stream"; then
+                printf '    %s differs (php / zphp):\n' "$stream"
+                diff -u "$capture_dir/php.$stream" "$capture_dir/zphp.$stream" || true
+            fi
+        done
     fi
 done
 
@@ -39,6 +52,5 @@ echo ""
 echo "$passed passed, $failed failed"
 
 if [ $failed -gt 0 ]; then
-    echo -e "$errors"
     exit 1
 fi


### PR DESCRIPTION
Compare stdout, stderr, and exit status separately in `tests/run`, preserving trailing newlines and binary output. Add runner regression tests to local checks and CI.

Deprecation suppression remains intentional. HTTP behavior and filesystem effects remain the responsibility of dedicated tests.

Closes #10