### PR TITLE
Implement process signal masks

### DIFF
--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -1627,9 +1627,9 @@ pub const VM = struct {
         try c.put(a, "SIG_ERR", .{ .int = -1 });
         try c.put(a, "WNOHANG", .{ .int = 1 });
         try c.put(a, "WUNTRACED", .{ .int = 2 });
-        try c.put(a, "SIG_BLOCK", .{ .int = 0 });
-        try c.put(a, "SIG_UNBLOCK", .{ .int = 1 });
-        try c.put(a, "SIG_SETMASK", .{ .int = 2 });
+        try c.put(a, "SIG_BLOCK", .{ .int = posix.SIG.BLOCK });
+        try c.put(a, "SIG_UNBLOCK", .{ .int = posix.SIG.UNBLOCK });
+        try c.put(a, "SIG_SETMASK", .{ .int = posix.SIG.SETMASK });
         try c.put(a, "FTP_ASCII", .{ .int = 1 });
         try c.put(a, "FTP_TEXT", .{ .int = 1 });
         try c.put(a, "FTP_BINARY", .{ .int = 2 });
@@ -3839,7 +3839,7 @@ pub const VM = struct {
                                 }
                             }
                         }
-                        const native_needs_refs = self.native_fns.contains(name) and (std.mem.eql(u8, name, "preg_match") or std.mem.eql(u8, name, "preg_match_all"));
+                        const native_needs_refs = self.native_fns.contains(name) and (std.mem.eql(u8, name, "preg_match") or std.mem.eql(u8, name, "preg_match_all") or std.mem.eql(u8, name, "pcntl_sigprocmask"));
                         if (native_needs_refs or function_needs_refs) {
                             var ref_args: [256]Value = undefined;
                             if (arr.entries.items.len > ref_args.len) return error.RuntimeError;
@@ -3894,7 +3894,7 @@ pub const VM = struct {
                                 }
                             }
                         }
-                        const native_needs_refs = self.native_fns.contains(name_val.string.bytes()) and (std.mem.eql(u8, name_val.string.bytes(), "preg_match") or std.mem.eql(u8, name_val.string.bytes(), "preg_match_all"));
+                        const native_needs_refs = self.native_fns.contains(name_val.string.bytes()) and (std.mem.eql(u8, name_val.string.bytes(), "preg_match") or std.mem.eql(u8, name_val.string.bytes(), "preg_match_all") or std.mem.eql(u8, name_val.string.bytes(), "pcntl_sigprocmask"));
                         if (native_needs_refs or function_needs_refs) {
                             var ref_args: [256]Value = undefined;
                             if (arr.entries.items.len > ref_args.len) return error.RuntimeError;

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -6223,7 +6223,10 @@ pub const VM = struct {
                         }
                         try self.objects.append(self.allocator, copy);
                         if (self.hasMethod(src.class_name, "__clone")) {
-                            _ = self.callMethod(copy, "__clone", &.{}) catch {};
+                            _ = self.callMethod(copy, "__clone", &.{}) catch {
+                                if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                return error.RuntimeError;
+                            };
                         }
                         self.push(.{ .object = copy });
                     } else {
@@ -8358,6 +8361,13 @@ pub const VM = struct {
                                     // name so the stack trace shows it at #0
                                     if (self.pending_exception) |exc| {
                                         if (!isFrameOutNative(mc_entry.full_name)) self.prependNativeFrameToTrace(exc, mc_entry.full_name, args_buf[0..ac]) catch {};
+                                        // Cached calls must dispatch pending callback exceptions
+                                        // just like uncached native calls, but only to a handler
+                                        // owned by this execution boundary.
+                                        if (self.dispatchPendingException(base_frame)) {
+                                            self.pending_native_name = null;
+                                            continue;
+                                        }
                                         self.pending_native_name = mc_entry.full_name;
                                         self.pending_native_is_instance = true;
                                     }

--- a/src/stdlib/curl.zig
+++ b/src/stdlib/curl.zig
@@ -26,14 +26,11 @@ pub const entries = .{
     .{ "curl_strerror", curlStrerror },
     .{ "curl_escape", curlEscape },
     .{ "curl_unescape", curlUnescape },
-    // curl_share_* - minimal stubs that return plausible values. real
-    // cross-handle sharing isn't supported but most code paths only use these
-    // for cookie / DNS jar setup and tolerate the no-op
     .{ "curl_share_init", curlShareInit },
     .{ "curl_share_close", curlShareClose },
     .{ "curl_share_setopt", curlShareSetopt },
     .{ "curl_share_errno", curlShareErrno },
-    .{ "curl_share_strerror", curlStrerror },
+    .{ "curl_share_strerror", curlShareStrerror },
     // curl_multi_* - real concurrent transfers via libcurl's multi interface
     .{ "curl_multi_init", curlMultiInit },
     .{ "curl_multi_add_handle", curlMultiAddHandle },
@@ -98,6 +95,8 @@ fn curlInit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try obj.set(ctx.allocator, "__header_out", .{ .bool = false });
     try obj.set(ctx.allocator, "__http_code", .{ .int = 0 });
 
+    try obj.set(ctx.allocator, "__share_state", .{ .int = 0 });
+
     // store slist pointers for cleanup
     try obj.set(ctx.allocator, "__slist_ptr", .{ .int = 0 });
 
@@ -119,11 +118,27 @@ fn curlSetopt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 }
 
 fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i64, value: Value) RuntimeError!Value {
+    if (option == c.CURLOPT_SHARE) {
+        // PHP ignores non-share values (including null); they do not detach.
+        if (value != .object or !std.mem.eql(u8, value.object.class_name, "CurlShareHandle")) return .{ .bool = true };
+        const share = getShareState(value.object) orelse return .{ .bool = false };
+        const code = c.curl_easy_setopt(handle, c.CURLOPT_SHARE, share.handle);
+        if (code == c.CURLE_OK) {
+            // Native references outlive PHP wrappers, including request sweeping
+            // in allocation order. reset preserves libcurl's share association.
+            share.refs += 1;
+            releaseEasyShare(obj);
+            obj.properties.getPtr("__share_state").?.* = .{ .int = @intCast(@intFromPtr(share)) };
+        }
+        try obj.set(ctx.allocator, "__errno", .{ .int = @intCast(code) });
+        return .{ .bool = code == c.CURLE_OK };
+    }
     // string options
     if (option == c.CURLOPT_URL or
         option == c.CURLOPT_USERAGENT or
         option == c.CURLOPT_REFERER or
         option == c.CURLOPT_COOKIE or
+        option == c.CURLOPT_COOKIELIST or
         option == c.CURLOPT_COOKIEFILE or
         option == c.CURLOPT_COOKIEJAR or
         option == c.CURLOPT_USERPWD or
@@ -388,18 +403,22 @@ fn curlClose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 pub fn cleanupHandle(obj: *PhpObject) void {
     if (obj.pooled) return;
+    // The property map belongs to the VM allocator (also used by native
+    // contexts). Cleanup only clears existing pointer slots: even put of an
+    // existing key can grow a full map, so it must not use page_allocator.
     // free slist
     const slist_v = obj.get("__slist_ptr");
     if (slist_v == .int and slist_v.int != 0) {
         const sl: *c.struct_curl_slist = @ptrFromInt(@as(usize, @intCast(slist_v.int)));
         c.curl_slist_free_all(sl);
-        obj.properties.put(std.heap.page_allocator, "__slist_ptr", .{ .int = 0 }) catch {};
+        obj.properties.getPtr("__slist_ptr").?.* = .{ .int = 0 };
     }
 
     // free curl handle
     if (getHandle(obj)) |handle| {
         c.curl_easy_cleanup(handle);
-        obj.properties.put(std.heap.page_allocator, "__curl_ptr", .{ .int = 0 }) catch {};
+        releaseEasyShare(obj);
+        obj.properties.getPtr("__curl_ptr").?.* = .{ .int = 0 };
     }
 }
 
@@ -431,6 +450,17 @@ fn curlGetinfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 }
 
 fn getInfoOption(ctx: *NativeContext, handle: *c.CURL, option: i64) RuntimeError!Value {
+    if (option == c.CURLINFO_COOKIELIST) {
+        var list: ?*c.struct_curl_slist = null;
+        if (c.curl_easy_getinfo(handle, c.CURLINFO_COOKIELIST, &list) != c.CURLE_OK) return .{ .bool = false };
+        defer c.curl_slist_free_all(list);
+        const arr = try ctx.createArray();
+        var node = list;
+        while (node) |item| : (node = item.next) {
+            try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(std.mem.span(item.data))) });
+        }
+        return .{ .array = arr };
+    }
     // string info types
     if (option == c.CURLINFO_EFFECTIVE_URL or
         option == c.CURLINFO_CONTENT_TYPE or
@@ -701,31 +731,114 @@ fn curlStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return .{ .string = Value.String.borrowed(owned) };
 }
 
+// Separate native ownership keeps shares alive even when their PHP wrapper is
+// swept before an attached easy handle. No VM layout or GC changes are needed.
+const ShareState = struct {
+    handle: *c.CURLSH,
+    refs: usize = 1,
+    errno: c_uint = c.CURLSHE_OK,
+};
+
+fn getShareState(obj: *PhpObject) ?*ShareState {
+    const v = obj.get("__share_state");
+    if (v != .int or v.int == 0) return null;
+    return @ptrFromInt(@as(usize, @intCast(v.int)));
+}
+
+fn releaseShare(state: *ShareState) void {
+    state.refs -= 1;
+    if (state.refs == 0) {
+        _ = c.curl_share_cleanup(state.handle);
+        std.heap.page_allocator.destroy(state);
+    }
+}
+
+fn releaseEasyShare(obj: *PhpObject) void {
+    if (getShareState(obj)) |state| {
+        obj.properties.getPtr("__share_state").?.* = .{ .int = 0 };
+        releaseShare(state);
+    }
+}
+
+fn cleanupShare(obj: *PhpObject) bool {
+    if (!obj.pooled) releaseEasyShare(obj);
+    return true;
+}
+
+fn requireShare(ctx: *NativeContext, args: []const Value, name: []const u8) RuntimeError!*ShareState {
+    if (args.len > 0 and args[0] == .object and std.mem.eql(u8, args[0].object.class_name, "CurlShareHandle")) {
+        if (getShareState(args[0].object)) |state| return state;
+    }
+    const msg = try std.fmt.allocPrint(ctx.allocator, "{s}(): Argument #1 ($share_handle) must be of type CurlShareHandle", .{name});
+    try ctx.vm.setPendingException("TypeError", msg);
+    return error.RuntimeError;
+}
+
+fn curlShareConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    try ctx.vm.setPendingException("Error", "Cannot directly construct CurlShareHandle, use curl_share_init() instead");
+    return error.RuntimeError;
+}
+
+fn curlShareClone(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    // The VM copies properties before invoking __clone. Remove the borrowed
+    // native pointer so failed-clone teardown cannot release the original state.
+    if (getThis(ctx)) |obj| {
+        if (obj.properties.getPtr("__share_state")) |ptr| ptr.* = .{ .int = 0 };
+    }
+    try ctx.vm.setPendingException("Error", "Trying to clone an uncloneable object of class CurlShareHandle");
+    return error.RuntimeError;
+}
+
 fn curlShareInit(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    ensureGlobalInit();
+    const handle = c.curl_share_init() orelse return .{ .bool = false };
+    errdefer _ = c.curl_share_cleanup(handle);
+    const state = try std.heap.page_allocator.create(ShareState);
+    errdefer std.heap.page_allocator.destroy(state);
     const obj = try ctx.createObject("CurlShareHandle");
+    state.* = .{ .handle = handle };
+    try obj.set(ctx.allocator, "__share_state", .{ .int = @intCast(@intFromPtr(state)) });
     return .{ .object = obj };
 }
 
-fn curlShareClose(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn curlShareClose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    // Like PHP 8, close is a validated no-op; destruction owns cleanup.
+    _ = try requireShare(ctx, args, "curl_share_close");
     return .null;
 }
 
-fn curlShareSetopt(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    // sharing isn't actually wired through libcurl's share interface; accept
-    // any CURLSHOPT_* setopt call so userland doesn't see a hard failure
-    return .{ .bool = true };
+fn curlShareSetopt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const state = try requireShare(ctx, args, "curl_share_setopt");
+    if (args.len < 3) return .{ .bool = false };
+    const option = Value.toInt(args[1]);
+    if (option != c.CURLSHOPT_SHARE and option != c.CURLSHOPT_UNSHARE) {
+        state.errno = c.CURLSHE_BAD_OPTION;
+        try ctx.vm.setPendingException("ValueError", "curl_share_setopt(): Argument #2 ($option) is not a valid cURL share option");
+        return error.RuntimeError;
+    }
+    const data: c_int = @truncate(Value.toInt(args[2]));
+    state.errno = @intCast(c.curl_share_setopt(state.handle, @as(c_uint, @intCast(option)), data));
+    return .{ .bool = state.errno == c.CURLSHE_OK };
 }
 
-fn curlShareErrno(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn curlShareErrno(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    return .{ .int = (try requireShare(ctx, args, "curl_share_errno")).errno };
+}
+
+fn curlShareStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    if (args.len == 0) return .null;
+    const code: c_uint = @bitCast(@as(c_int, @truncate(Value.toInt(args[0]))));
+    const msg = c.curl_share_strerror(code);
+    if (msg == null) return .null;
+    return .{ .string = Value.String.borrowed(try ctx.createString(std.mem.span(msg))) };
 }
 
 // ---------------- curl_multi ----------------
 // each easy handle added to a multi handle gets a heap-allocated
 // WriteCallbackData so its response body survives from add_handle through
 // curl_multi_getcontent. the WCB pointers live in a side table keyed by the
-// easy CURL* - keeping them off PhpObject.properties avoids growing that
-// hashmap from a later native call's arena (which corrupts its allocator)
+// easy CURL*. The side table and callback buffers use page_allocator;
+// PhpObject property maps instead belong to the VM allocator.
 
 var multi_wcb_table: std.AutoHashMapUnmanaged(usize, *WriteCallbackData) = .{};
 
@@ -839,7 +952,7 @@ fn curlMultiClose(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len < 1 or args[0] != .object) return .null;
     const mh = getMultiHandle(args[0].object) orelse return .null;
     _ = c.curl_multi_cleanup(mh);
-    args[0].object.properties.put(std.heap.page_allocator, "__multi_ptr", .{ .int = 0 }) catch {};
+    args[0].object.properties.getPtr("__multi_ptr").?.* = .{ .int = 0 };
     return .null;
 }
 
@@ -1008,9 +1121,11 @@ pub fn register(vm: *VM, a: std.mem.Allocator) !void {
     try vm.classes.put(a, "CurlHandle", curl_def);
     _ = &curl_def;
 
-    var share_def = ClassDef{ .name = "CurlShareHandle" };
+    var share_def = ClassDef{ .name = "CurlShareHandle", .native_cleanup = cleanupShare };
     try vm.classes.put(a, "CurlShareHandle", share_def);
     _ = &share_def;
+    try vm.native_fns.put(a, "CurlShareHandle::__construct", curlShareConstruct);
+    try vm.native_fns.put(a, "CurlShareHandle::__clone", curlShareClone);
 
     var mh_def = ClassDef{ .name = "CurlMultiHandle" };
     try vm.classes.put(a, "CurlMultiHandle", mh_def);
@@ -1049,6 +1164,10 @@ pub fn register(vm: *VM, a: std.mem.Allocator) !void {
     try vm.php_constants.put(a, "CURL_LOCK_DATA_COOKIE", .{ .int = 2 });
     try vm.php_constants.put(a, "CURL_LOCK_DATA_DNS", .{ .int = 3 });
     try vm.php_constants.put(a, "CURL_LOCK_DATA_SSL_SESSION", .{ .int = 4 });
+
+    inline for (.{ "CURLSHOPT_UNSHARE", "CURL_LOCK_DATA_CONNECT", "CURL_LOCK_DATA_PSL", "CURLSHE_OK", "CURLSHE_BAD_OPTION", "CURLSHE_IN_USE", "CURLSHE_INVALID", "CURLSHE_NOMEM", "CURLSHE_NOT_BUILT_IN", "CURLOPT_SHARE", "CURLOPT_COOKIELIST", "CURLINFO_COOKIELIST" }) |name| {
+        try vm.php_constants.put(a, name, .{ .int = @field(c, name) });
+    }
 
     // CURLOPT constants
     try vm.php_constants.put(a, "CURLOPT_URL", .{ .int = c.CURLOPT_URL });
@@ -1146,6 +1265,48 @@ pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
         if (std.mem.eql(u8, obj.class_name, "CurlHandle")) {
             cleanupHandle(obj);
+        } else if (std.mem.eql(u8, obj.class_name, "CurlShareHandle")) {
+            _ = cleanupShare(obj);
         }
     }
+}
+
+test "curl property growth across native contexts and allocation-free cleanup" {
+    const a = std.testing.allocator;
+    const vm = try VM.initOnHeap(a);
+    defer a.destroy(vm);
+    defer vm.deinit();
+    var init_ctx = vm.makeContext("curl_init");
+    const easy = try curlInit(&init_ctx, &.{});
+    var later_ctx = vm.makeContext("curl_setopt");
+    const headers = try later_ctx.createArray();
+    try headers.append(later_ctx.allocator, .{ .string = Value.String.borrowed("X-Allocator-Test: yes") });
+    _ = try curlSetopt(&later_ctx, &.{ easy, .{ .int = c.CURLOPT_HTTPHEADER }, .{ .array = headers } });
+    // Fill to an exact capacity boundary, growing repeatedly using a later
+    // context. put(existing_key) would reserve count + 1 at this boundary.
+    var keys: [256][32]u8 = undefined;
+    const initial_capacity = easy.object.properties.capacity();
+    var i: usize = 0;
+    while (easy.object.properties.capacity() <= initial_capacity or
+        easy.object.properties.count() < easy.object.properties.capacity()) : (i += 1)
+    {
+        const key = try std.fmt.bufPrint(&keys[i], "test_property_{d}", .{i});
+        try easy.object.set(later_ctx.allocator, key, .{ .int = @intCast(i) });
+    }
+    const capacity = easy.object.properties.capacity();
+    _ = try curlClose(&later_ctx, &.{easy});
+    try std.testing.expectEqual(capacity, easy.object.properties.capacity());
+    try std.testing.expectEqual(@as(i64, 0), easy.object.get("__curl_ptr").int);
+    cleanupHandle(easy.object);
+
+    const multi = try curlMultiInit(&init_ctx, &.{});
+    i = 0;
+    while (multi.object.properties.count() < multi.object.properties.capacity()) : (i += 1) {
+        const key = try std.fmt.bufPrint(&keys[128 + i], "multi_property_{d}", .{i});
+        try multi.object.set(later_ctx.allocator, key, .null);
+    }
+    const multi_capacity = multi.object.properties.capacity();
+    _ = try curlMultiClose(&later_ctx, &.{multi});
+    try std.testing.expectEqual(multi_capacity, multi.object.properties.capacity());
+    _ = try curlMultiClose(&later_ctx, &.{multi});
 }

--- a/src/stdlib/mysqli.zig
+++ b/src/stdlib/mysqli.zig
@@ -17,6 +17,10 @@ const ClassDef = vm_mod.ClassDef;
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
+const mysql_headers = @cImport({
+    @cInclude("mysql.h");
+});
+
 const mysql = struct {
     const MYSQL = opaque {};
     const MYSQL_RES = opaque {};
@@ -26,6 +30,7 @@ const mysql = struct {
     extern "mysqlclient" fn mysql_real_connect(m: *MYSQL, host: ?[*:0]const u8, user: ?[*:0]const u8, passwd: ?[*:0]const u8, db: ?[*:0]const u8, port: c_uint, socket: ?[*:0]const u8, flags: c_ulong) callconv(.c) ?*MYSQL;
     extern "mysqlclient" fn mysql_close(m: *MYSQL) callconv(.c) void;
     extern "mysqlclient" fn mysql_error(m: *MYSQL) callconv(.c) [*:0]const u8;
+    extern "mysqlclient" fn mysql_sqlstate(m: *MYSQL) callconv(.c) [*:0]const u8;
     extern "mysqlclient" fn mysql_errno(m: *MYSQL) callconv(.c) c_uint;
     extern "mysqlclient" fn mysql_real_query(m: *MYSQL, q: [*]const u8, len: c_ulong) callconv(.c) c_int;
     extern "mysqlclient" fn mysql_store_result(m: *MYSQL) callconv(.c) ?*MYSQL_RES;
@@ -135,6 +140,7 @@ fn doConnect(ctx: *NativeContext, obj: *PhpObject, host: ?[]const u8, user: ?[]c
 
     if (mysql.mysql_real_connect(conn, host_z, user_z, pass_z, db_z, port, sock_z, 0) == null) {
         try setErrorState(ctx, obj, conn);
+        try reportFailure(ctx, conn, "mysqli_connect", true);
         return false;
     }
     try obj.set(ctx.allocator, "__connected", .{ .bool = true });
@@ -228,6 +234,7 @@ fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const sql = sql_arg.string.bytes();
     if (mysql.mysql_real_query(conn, sql.ptr, @intCast(sql.len)) != 0) {
         try setErrorState(ctx, link, conn);
+        try reportFailure(ctx, conn, "mysqli_query", false);
         return .{ .bool = false };
     }
     try setErrorState(ctx, link, conn);
@@ -240,6 +247,30 @@ fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try link.set(ctx.allocator, "insert_id", .{ .int = @intCast(mysql.mysql_insert_id(conn)) });
     // not all queries return a result set; for INSERT/UPDATE/DELETE return true
     const res_opt = mysql.mysql_store_result(conn);
+    if (res_opt == null and mysql.mysql_errno(conn) != 0) {
+        try setErrorState(ctx, link, conn);
+        try reportFailure(ctx, conn, "mysqli_query", false);
+        return .{ .bool = false };
+    }
+    // Use the installed client header rather than guessing MYSQL's ABI layout.
+    if (reportMode(ctx) & 4 != 0) {
+        const native: *mysql_headers.MYSQL = @ptrCast(@alignCast(conn));
+        const index: ?[]const u8 = if (native.server_status & 16 != 0) "Bad index" else if (native.server_status & 32 != 0) "No index" else null;
+        if (index) |label| {
+            const message = try std.fmt.allocPrint(ctx.allocator, "{s} used in query/prepared statement {s}", .{ label, sql });
+            try ctx.vm.strings.append(ctx.allocator, message);
+            if (reportMode(ctx) & 2 != 0) {
+                if (res_opt) |r| mysql.mysql_free_result(r);
+                const exception = try ctx.createObject("mysqli_sql_exception");
+                try exception.set(ctx.allocator, "message", .{ .string = Value.String.borrowed(message) });
+                try exception.set(ctx.allocator, "code", .{ .int = 0 });
+                try exception.set(ctx.allocator, "sqlstate", .{ .string = Value.String.borrowed("00000") });
+                ctx.vm.pending_exception = .{ .object = exception };
+                return error.RuntimeError;
+            }
+            ctx.vm.emitWarning(message);
+        }
+    }
     const res = res_opt orelse return .{ .bool = true };
 
     const result_obj = try ctx.createObject("mysqli_result");
@@ -409,6 +440,7 @@ fn mysqliSelectDb(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const rc = mysql.mysql_select_db(conn, db_z.ptr);
     if (rc != 0) {
         try setErrorState(ctx, link, conn);
+        try reportFailure(ctx, conn, "mysqli_select_db", false);
         return .{ .bool = false };
     }
     return .{ .bool = true };
@@ -491,7 +523,10 @@ fn mysqliPing(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
     const conn = getConn(link) orelse return .{ .bool = false };
     if (!isConnected(link)) return .{ .bool = false };
-    return .{ .bool = mysql.mysql_ping(conn) == 0 };
+    const ok = mysql.mysql_ping(conn) == 0;
+    try setErrorState(ctx, link, conn);
+    if (!ok) try reportFailure(ctx, conn, "mysqli_ping", false);
+    return .{ .bool = ok };
 }
 
 fn mysqliAutocommit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -500,21 +535,30 @@ fn mysqliAutocommit(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     if (!isConnected(link)) return .{ .bool = false };
     const mode_arg: Value = if (args.len > 0 and args[0] == .object) (if (args.len > 1) args[1] else .{ .bool = true }) else if (args.len > 0) args[0] else .{ .bool = true };
     const mode: u8 = if (mode_arg.isTruthy()) 1 else 0;
-    return .{ .bool = mysql.mysql_autocommit(conn, mode) == 0 };
+    const ok = mysql.mysql_autocommit(conn, mode) == 0;
+    try setErrorState(ctx, link, conn);
+    if (!ok) try reportFailure(ctx, conn, "mysqli_autocommit", false);
+    return .{ .bool = ok };
 }
 
 fn mysqliCommit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
     const conn = getConn(link) orelse return .{ .bool = false };
     if (!isConnected(link)) return .{ .bool = false };
-    return .{ .bool = mysql.mysql_commit(conn) == 0 };
+    const ok = mysql.mysql_commit(conn) == 0;
+    try setErrorState(ctx, link, conn);
+    if (!ok) try reportFailure(ctx, conn, "mysqli_commit", false);
+    return .{ .bool = ok };
 }
 
 fn mysqliRollback(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
     const conn = getConn(link) orelse return .{ .bool = false };
     if (!isConnected(link)) return .{ .bool = false };
-    return .{ .bool = mysql.mysql_rollback(conn) == 0 };
+    const ok = mysql.mysql_rollback(conn) == 0;
+    try setErrorState(ctx, link, conn);
+    if (!ok) try reportFailure(ctx, conn, "mysqli_rollback", false);
+    return .{ .bool = ok };
 }
 
 fn mysqliFreeResult(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -542,12 +586,60 @@ fn mysqliNumFields(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     return if (v == .int) v else .{ .int = 0 };
 }
 
-fn mysqliReport(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    // we don't emit warning streams driven by mysql_report() so accepting the
-    // call as a no-op is correct: a real run with REPORT_ERROR would have
-    // raised PHP warnings on every libmysql error, but we already surface
-    // errors via mysqli_error / errno
+// State belongs to the VM's class registry, not a process-global variable:
+// independent VMs and reset requests must not inherit another request's mode.
+fn reportMode(ctx: *NativeContext) i64 {
+    return ctx.vm.classes.get("mysqli_driver").?.static_props.get("__report_mode").?.int;
+}
+
+fn mysqliReport(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    if (args.len != 1) return reportArgumentError(ctx, "ArgumentCountError", "mysqli_report() expects exactly 1 argument");
+    if (args[0] == .array or args[0] == .object) return reportArgumentError(ctx, "TypeError", "mysqli_report(): Argument #1 ($flags) must be of type int");
+    try ctx.vm.classes.getPtr("mysqli_driver").?.static_props.put(ctx.allocator, "__report_mode", .{ .int = args[0].toInt() });
     return .{ .bool = true };
+}
+
+fn reportArgumentError(ctx: *NativeContext, class: []const u8, msg: []const u8) RuntimeError!Value {
+    const obj = try ctx.createObject(class);
+    try obj.set(ctx.allocator, "message", .{ .string = Value.String.borrowed(msg) });
+    try obj.set(ctx.allocator, "code", .{ .int = 0 });
+    ctx.vm.pending_exception = .{ .object = obj };
+    return error.RuntimeError;
+}
+
+fn driverGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    if (args.len > 0 and args[0] == .string and std.mem.eql(u8, args[0].string.bytes(), "report_mode")) return .{ .int = reportMode(ctx) };
+    return .null;
+}
+
+fn driverSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    if (args.len > 1 and args[0] == .string and std.mem.eql(u8, args[0].string.bytes(), "report_mode")) _ = try mysqliReport(ctx, args[1..2]);
+    return .null;
+}
+
+fn exceptionSqlState(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const obj = linkObj(ctx, args, 0) orelse return .null;
+    return obj.get("sqlstate");
+}
+
+fn reportFailure(ctx: *NativeContext, conn: *mysql.MYSQL, operation: []const u8, connection: bool) RuntimeError!void {
+    const mode = reportMode(ctx);
+    // PHP always reports connection failures; other errors require ERROR.
+    if (!connection and mode & 1 == 0) return;
+    const message = std.mem.span(mysql.mysql_error(conn));
+    const state = std.mem.span(mysql.mysql_sqlstate(conn));
+    const code = mysql.mysql_errno(conn);
+    if (mode & 2 != 0) {
+        const obj = try ctx.createObject("mysqli_sql_exception");
+        try obj.set(ctx.allocator, "message", .{ .string = Value.String.borrowed((try dupZ(ctx, message))) });
+        try obj.set(ctx.allocator, "sqlstate", .{ .string = Value.String.borrowed((try dupZ(ctx, state))) });
+        try obj.set(ctx.allocator, "code", .{ .int = code });
+        ctx.vm.pending_exception = .{ .object = obj };
+        return error.RuntimeError;
+    }
+    const warning = try std.fmt.allocPrint(ctx.allocator, "{s}(): ({s}/{d}): {s}", .{ operation, state, code, message });
+    defer ctx.allocator.free(warning);
+    ctx.vm.emitWarning(warning);
 }
 
 // ---------- class constructor ----------
@@ -674,9 +766,18 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try sc.methods.put(a, "__construct", .{ .name = "__construct", .arity = 2 });
     try vm.classes.put(a, "mysqli_stmt", sc);
 
-    try vm.classes.put(a, "mysqli_driver", ClassDef{ .name = "mysqli_driver" });
+    var driver = ClassDef{ .name = "mysqli_driver" };
+    try driver.static_props.put(a, "__report_mode", .{ .int = 3 });
+    try driver.methods.put(a, "__get", .{ .name = "__get", .arity = 1 });
+    try driver.methods.put(a, "__set", .{ .name = "__set", .arity = 2 });
+    try vm.classes.put(a, "mysqli_driver", driver);
+    try vm.native_fns.put(a, "mysqli_driver::__get", driverGet);
+    try vm.native_fns.put(a, "mysqli_driver::__set", driverSet);
     try vm.classes.put(a, "mysqli_warning", ClassDef{ .name = "mysqli_warning" });
-    try vm.classes.put(a, "mysqli_sql_exception", ClassDef{ .name = "mysqli_sql_exception", .parent = "RuntimeException" });
+    var exception = ClassDef{ .name = "mysqli_sql_exception", .parent = "RuntimeException" };
+    try exception.methods.put(a, "getSqlState", .{ .name = "getSqlState", .arity = 0 });
+    try vm.classes.put(a, "mysqli_sql_exception", exception);
+    try vm.native_fns.put(a, "mysqli_sql_exception::getSqlState", exceptionSqlState);
 }
 
 pub fn cleanupConnections(objects: std.ArrayListUnmanaged(*PhpObject)) void {

--- a/src/stdlib/pcntl.zig
+++ b/src/stdlib/pcntl.zig
@@ -284,8 +284,47 @@ fn native_pcntl_strerror(ctx: *NativeContext, args: []const Value) RuntimeError!
     return .{ .string = Value.String.borrowed(owned) };
 }
 
-fn native_pcntl_sigprocmask(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    // best-effort no-op: returns true. correct impl would translate the mask array
+fn maskFailure() Value {
+    last_errno = std.c._errno().*;
+    return .{ .bool = false };
+}
+
+fn native_pcntl_sigprocmask(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    if (args.len < 2 or args[0] != .int or args[1] != .array) {
+        last_errno = @intFromEnum(posix.E.INVAL);
+        return .{ .bool = false };
+    }
+    const how = std.math.cast(c_int, args[0].int) orelse {
+        last_errno = @intFromEnum(posix.E.INVAL);
+        return .{ .bool = false };
+    };
+    // Use libc's sigset_t and helpers: Darwin's set is a scalar, Linux's
+    // is an array, and the libc ABI need not match the kernel syscall ABI.
+    var set: std.c.sigset_t = undefined;
+    if (std.c.sigemptyset(&set) != 0) return maskFailure();
+    for (args[1].array.entries.items) |entry| {
+        const sig = std.math.cast(c_int, entry.value.toInt()) orelse {
+            last_errno = @intFromEnum(posix.E.INVAL);
+            return .{ .bool = false };
+        };
+        // Darwin's libc helpers do not reject every out-of-range signal.
+        if (sig <= 0 or sig >= std.c.NSIG) {
+            last_errno = @intFromEnum(posix.E.INVAL);
+            return .{ .bool = false };
+        }
+        if (std.c.sigaddset(&set, sig) != 0) return maskFailure();
+    }
+    var old: std.c.sigset_t = undefined;
+    if (std.c.sigprocmask(how, &set, &old) != 0) return maskFailure();
+    if (args.len > 2) {
+        const result = try ctx.createArray();
+        var sig: c_int = 1;
+        while (sig < std.c.NSIG) : (sig += 1) {
+            if (std.c.sigismember(&old, sig) == 1)
+                try result.append(ctx.allocator, .{ .int = sig });
+        }
+        ctx.setCallerVar(2, args.len, .{ .array = result });
+    }
     return .{ .bool = true };
 }
 

--- a/src/stdlib/pdo.zig
+++ b/src/stdlib/pdo.zig
@@ -26,6 +26,7 @@ const sqlite = struct {
 
     extern "sqlite3" fn sqlite3_open(filename: [*:0]const u8, ppDb: *?*Db) callconv(.c) c_int;
     extern "sqlite3" fn sqlite3_close_v2(db: *Db) callconv(.c) c_int;
+    extern "sqlite3" fn sqlite3_free(ptr: ?*anyopaque) callconv(.c) void;
     extern "sqlite3" fn sqlite3_exec(db: *Db, sql: [*:0]const u8, callback: ?*anyopaque, arg: ?*anyopaque, errmsg: ?*[*:0]u8) callconv(.c) c_int;
     extern "sqlite3" fn sqlite3_prepare_v2(db: *Db, sql: [*:0]const u8, nByte: c_int, ppStmt: *?*Stmt, pzTail: ?*[*:0]const u8) callconv(.c) c_int;
     extern "sqlite3" fn sqlite3_step(stmt: *Stmt) callconv(.c) c_int;
@@ -76,6 +77,7 @@ const sqlite = struct {
         xDestroy: ?*const fn (?*anyopaque) callconv(.c) void,
     ) callconv(.c) c_int;
 
+    extern "sqlite3" fn sqlite3_aggregate_context(ctx: *Context, size: c_int) callconv(.c) ?*anyopaque;
     extern "sqlite3" fn sqlite3_user_data(ctx: *Context) callconv(.c) ?*anyopaque;
 
     extern "sqlite3" fn sqlite3_value_type(v: *Value_t) callconv(.c) c_int;
@@ -214,6 +216,14 @@ fn getStmtPtr(obj: *PhpObject) ?*sqlite.Stmt {
     return getOpaquePtr(sqlite.Stmt, obj, "__stmt_ptr");
 }
 
+// SQLite callbacks cannot unwind through C. Re-throw their pending PHP
+// exception at every stepping boundary, including fetch loops and silent mode.
+fn stepSqlite(ctx: *NativeContext, stmt: *sqlite.Stmt) RuntimeError!c_int {
+    const rc = sqlite.sqlite3_step(stmt);
+    if (ctx.vm.pending_exception != null) return error.RuntimeError;
+    return rc;
+}
+
 // build the SQLSTATE-prefixed message PHP's PDO uses for sqlite errors:
 // "SQLSTATE[HY000]: General error: <sqlite_errcode> <sqlite_errmsg>"
 fn pdoSqlMsg(ctx: *NativeContext, db: *sqlite.Db, raw: []const u8) ![]const u8 {
@@ -224,6 +234,7 @@ fn pdoSqlMsg(ctx: *NativeContext, db: *sqlite.Db, raw: []const u8) ![]const u8 {
 }
 
 pub fn throwPdo(ctx: *NativeContext, msg: []const u8) RuntimeError!Value {
+    if (ctx.vm.pending_exception != null) return error.RuntimeError;
     // honor ATTR_ERRMODE: silent (0) returns false, warning (1) returns false,
     // exception (2) throws PDOException. default in PHP 8 is exception, but for
     // backward-compat zphp defaults the construct path to exception too
@@ -367,12 +378,12 @@ pub fn register(vm: *VM, a: Allocator) !void {
     // hit "class not found" (used by WP's sqlite-database-integration)
     inline for (.{ "Sqlite", "SQLite", "Mysql", "MySql", "Pgsql", "PgSql", "Odbc", "ODBC", "Firebird", "Dblib" }) |driver| {
         const fqn = "PDO\\" ++ driver;
-        var sub_def = ClassDef{ .name = fqn, .parent = "PDO" };
+        var sub_def = ClassDef{ .name = fqn, .parent = "PDO", .native_cleanup = cleanupConnection };
         try sub_def.methods.put(a, "__construct", .{ .name = "__construct", .arity = 3 });
         // Sqlite-specific extension methods (user-defined SQL function /
-        // aggregate / collation hooks). registered as no-ops so frameworks
+        // aggregate / collation hooks). Backed by SQLite callbacks so frameworks
         // that conditionally call them (WordPress's sqlite-database-integration)
-        // can boot. callbacks aren't dispatched into SQLite yet
+        // can register real SQL callbacks.
         try sub_def.methods.put(a, "createFunction", .{ .name = "createFunction", .arity = 2 });
         try sub_def.methods.put(a, "createAggregate", .{ .name = "createAggregate", .arity = 3 });
         try sub_def.methods.put(a, "createCollation", .{ .name = "createCollation", .arity = 2 });
@@ -382,6 +393,12 @@ pub fn register(vm: *VM, a: Allocator) !void {
         try vm.native_fns.put(a, fqn ++ "::createAggregate", pdoSqliteCreateAggregate);
         try vm.native_fns.put(a, fqn ++ "::createCollation", pdoSqliteCreateCollation);
     }
+
+    // PHP's documented spelling; class construction currently uses exact keys.
+    var sqlite_alias = ClassDef{ .name = "Pdo\\Sqlite", .parent = "PDO\\Sqlite", .native_cleanup = cleanupConnection };
+    try sqlite_alias.methods.put(a, "__construct", .{ .name = "__construct", .arity = 3 });
+    try vm.classes.put(a, "Pdo\\Sqlite", sqlite_alias);
+    try vm.native_fns.put(a, "Pdo\\Sqlite::__construct", pdoConstruct);
 
     try vm.native_fns.put(a, "PDO::__construct", pdoConstruct);
     try vm.native_fns.put(a, "PDO::connect", pdoConnect);
@@ -526,6 +543,8 @@ fn cleanupConnection(obj: *PhpObject) bool {
     } else if (std.mem.eql(u8, drv, "pgsql")) {
         pdo_pgsql.cleanupConnection(obj);
     } else if (getDbPtr(obj)) |db| {
+        // v2 defers destruction until outstanding statements are finalized;
+        // sqlite3_close would return BUSY and leak the connection/registrations.
         _ = sqlite.sqlite3_close_v2(db);
     }
     if (obj.properties.getPtr("__db_ptr")) |slot| slot.* = .{ .int = 0 };
@@ -552,7 +571,7 @@ pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
         if (obj.pooled) continue;
         // PDO base class plus the PHP 8.4 driver subclasses live under PDO\
-        if (std.mem.eql(u8, obj.class_name, "PDO") or std.mem.startsWith(u8, obj.class_name, "PDO\\")) {
+        if (std.mem.eql(u8, obj.class_name, "PDO") or (obj.class_name.len >= 4 and std.ascii.eqlIgnoreCase(obj.class_name[0..4], "PDO\\"))) {
             const drv = getDriver(obj);
             if (std.mem.eql(u8, drv, "mysql")) {
                 pdo_mysql.cleanupConnection(obj);
@@ -629,14 +648,147 @@ fn pdoSqliteCreateFunction(ctx: *NativeContext, args: []const Value) RuntimeErro
     return .{ .bool = true };
 }
 
-// aggregates require xStep + xFinal + per-row context state. PHP's signature
-// is createAggregate(string, callable $step, callable $final, int $argc = -1).
-// not commonly used by frameworks (WordPress's SQLite plugin doesn't register
-// aggregates), so we register the function name and accept the call without
-// surfacing an error - the actual SQL would fail with "no such function" if a
-// query references the registered aggregate, which mirrors a registration miss
-fn pdoSqliteCreateAggregate(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+// SQLite owns registrations; each aggregate group owns an independent PHP
+// accumulator until xFinal (also called on reset/finalize after a failed step).
+const UserSqlAggregate = struct { vm: *VM, step: Value, final: Value };
+const AggregateGroup = struct { value: Value = .null, row: i64 = 0, failed: bool = false };
+
+fn aggregateDestroy(p: ?*anyopaque) callconv(.c) void {
+    const registration: *UserSqlAggregate = @ptrCast(@alignCast(p orelse return));
+    registration.vm.releaseValue(registration.step);
+    registration.vm.releaseValue(registration.final);
+    registration.vm.allocator.destroy(registration);
+}
+
+fn aggregateGroup(ctx: *sqlite.Context, vm: *VM) ?*AggregateGroup {
+    // SQLite zero-initializes this pointer slot, not a tagged Zig Value.
+    const slot: *?*AggregateGroup = @ptrCast(@alignCast(sqlite.sqlite3_aggregate_context(ctx, @sizeOf(?*AggregateGroup)) orelse return null));
+    if (slot.* == null) {
+        const group = vm.allocator.create(AggregateGroup) catch return null;
+        group.* = .{};
+        slot.* = group;
+    }
+    return slot.*;
+}
+
+fn aggregateStep(ctx: *sqlite.Context, argc: c_int, argv: [*]?*sqlite.Value_t) callconv(.c) void {
+    const reg: *UserSqlAggregate = @ptrCast(@alignCast(sqlite.sqlite3_user_data(ctx).?));
+    const group = aggregateGroup(ctx, reg.vm) orelse {
+        sqlite.sqlite3_result_error(ctx, "out of memory", 13);
+        return;
+    };
+    if (group.failed) return;
+    const n: usize = @intCast(@max(argc, 0));
+    const args = reg.vm.allocator.alloc(Value, n + 2) catch {
+        group.failed = true;
+        sqlite.sqlite3_result_error(ctx, "out of memory", 13);
+        return;
+    };
+    defer reg.vm.allocator.free(args);
+    group.row += 1;
+    args[0] = group.value;
+    args[1] = .{ .int = group.row };
+    var nc = reg.vm.makeContext(null);
+    for (args[2..], 0..) |*arg, i| {
+        const v = argv[i] orelse {
+            arg.* = .null;
+            continue;
+        };
+        arg.* = switch (sqlite.sqlite3_value_type(v)) {
+            sqlite.INTEGER => .{ .int = sqlite.sqlite3_value_int64(v) },
+            sqlite.FLOAT => .{ .float = sqlite.sqlite3_value_double(v) },
+            sqlite.NULL => .null,
+            else => blk: {
+                const ptr = sqlite.sqlite3_value_text(v) orelse break :blk .null;
+                const text = nc.createString(ptr[0..@intCast(@max(sqlite.sqlite3_value_bytes(v), 0))]) catch {
+                    group.failed = true;
+                    sqlite.sqlite3_result_error(ctx, "out of memory", 13);
+                    return;
+                };
+                break :blk .{ .string = Value.String.borrowed(text) };
+            },
+        };
+    }
+    const result = nc.invokeCallable(reg.step, args) catch {
+        group.failed = true;
+        sqlite.sqlite3_result_error(ctx, "callback failed", 15);
+        return;
+    };
+    // Call results are borrowed-deferred: pin before releasing the old context.
+    VM.retainValue(result);
+    reg.vm.releaseValue(group.value);
+    group.value = result;
+}
+
+fn aggregateFinal(ctx: *sqlite.Context) callconv(.c) void {
+    const reg: *UserSqlAggregate = @ptrCast(@alignCast(sqlite.sqlite3_user_data(ctx).?));
+    const group = aggregateGroup(ctx, reg.vm) orelse {
+        sqlite.sqlite3_result_error(ctx, "out of memory", 13);
+        return;
+    };
+    defer {
+        reg.vm.releaseValue(group.value);
+        reg.vm.allocator.destroy(group);
+        const slot: *?*AggregateGroup = @ptrCast(@alignCast(sqlite.sqlite3_aggregate_context(ctx, 0).?));
+        slot.* = null;
+    }
+    if (group.failed or reg.vm.pending_exception != null) return;
+    var nc = reg.vm.makeContext(null);
+    // PHP increments the row counter for final too, including empty groups.
+    const result = nc.invokeCallable(reg.final, &.{ group.value, .{ .int = group.row + 1 } }) catch {
+        sqlite.sqlite3_result_error(ctx, "callback failed", 15);
+        return;
+    };
+    VM.retainValue(result);
+    defer reg.vm.releaseValue(result);
+    switch (result) {
+        .null => sqlite.sqlite3_result_null(ctx),
+        .int => |v| sqlite.sqlite3_result_int64(ctx, v),
+        .float => |v| sqlite.sqlite3_result_double(ctx, v),
+        .object => |obj| {
+            const text = reg.vm.objectToString(obj) catch {
+                sqlite.sqlite3_result_error(ctx, "callback result conversion failed", 33);
+                return;
+            };
+            sqlite.sqlite3_result_text(ctx, text.ptr, @intCast(text.len), sqlite.TRANSIENT());
+        },
+        else => {
+            var buffer: std.ArrayListUnmanaged(u8) = .empty;
+            defer buffer.deinit(reg.vm.allocator);
+            result.format(&buffer, reg.vm.allocator) catch {
+                sqlite.sqlite3_result_error(ctx, "callback result conversion failed", 33);
+                return;
+            };
+            const text = buffer.items;
+            sqlite.sqlite3_result_text(ctx, text.ptr, @intCast(text.len), sqlite.TRANSIENT());
+        },
+    }
+}
+
+fn pdoSqliteCreateAggregate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    if (args.len < 3 or args[0] != .string) return .{ .bool = false };
+    for (args[1..3], 2..) |callback, position| {
+        const valid = try ctx.callFunction("is_callable", &.{callback});
+        if (!valid.isTruthy()) {
+            const message = try std.fmt.allocPrint(ctx.allocator, "PDO::sqliteCreateAggregate(): Argument #{d} (${s}) must be a valid callback", .{ position, if (position == 2) "step" else "finalize" });
+            defer ctx.allocator.free(message);
+            _ = try ctx.vm.throwBuiltinException("TypeError", message);
+            return error.RuntimeError;
+        }
+    }
+    const this = getThis(ctx) orelse return .{ .bool = false };
+    const db = getDbPtr(this) orelse return .{ .bool = false };
+    const count = if (args.len > 3) args[3].toInt() else -1;
+    const num_args = std.math.cast(c_int, count) orelse return .{ .bool = false };
+    const name = try ctx.allocator.dupeZ(u8, args[0].string.bytes());
+    defer ctx.allocator.free(name);
+    const reg = try ctx.allocator.create(UserSqlAggregate);
+    reg.* = .{ .vm = ctx.vm, .step = args[1], .final = args[2] };
+    VM.retainValue(reg.step);
+    VM.retainValue(reg.final);
+    // v2 invokes the destructor even when registration fails.
+    const rc = sqlite.sqlite3_create_function_v2(db, name, num_args, sqlite.UTF8, reg, null, aggregateStep, aggregateFinal, aggregateDestroy);
+    return .{ .bool = rc == sqlite.OK };
 }
 
 fn pdoSqliteCreateCollation(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -657,7 +809,7 @@ fn pdoSqliteCreateCollation(ctx: *NativeContext, args: []const Value) RuntimeErr
 
     const rc = sqlite.sqlite3_create_collation_v2(db, @ptrCast(name_buf.ptr), sqlite.UTF8, @ptrCast(state), sqliteCollationTrampoline, sqliteFuncDestroy);
     if (rc != 0) {
-        ctx.vm.allocator.destroy(state);
+        sqliteFuncDestroy(state);
         return .{ .bool = false };
     }
     return .{ .bool = true };
@@ -722,6 +874,8 @@ fn pdoExec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const sql_z = try dupeZ(ctx, args[0].string.bytes());
     var errmsg: ?[*:0]u8 = null;
     const rc = sqlite.sqlite3_exec(db, sql_z, null, null, @ptrCast(&errmsg));
+    defer if (errmsg) |message| sqlite.sqlite3_free(message);
+    if (ctx.vm.pending_exception != null) return error.RuntimeError;
     if (rc != sqlite.OK) {
         const raw = if (errmsg) |e| std.mem.span(e) else "SQL execution error";
         const result = try throwPdo(ctx, try pdoSqlMsg(ctx, db, raw));
@@ -752,7 +906,9 @@ fn pdoQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try stmt_obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(db)) });
     try stmt_obj.set(ctx.allocator, "__pdo", .{ .object = obj });
     // step once to position on first row
-    const step_rc = sqlite.sqlite3_step(stmt_ptr.?);
+    const step_rc = try stepSqlite(ctx, stmt_ptr.?);
+    if (step_rc != sqlite.ROW and step_rc != sqlite.DONE)
+        return throwPdo(ctx, try pdoSqlMsg(ctx, db, std.mem.span(sqlite.sqlite3_errmsg(db))));
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = step_rc == sqlite.ROW });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = true });
 
@@ -919,7 +1075,7 @@ fn stmtExecute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try bindParams(ctx, stmt, args[0].array);
     }
 
-    const rc = sqlite.sqlite3_step(stmt);
+    const rc = try stepSqlite(ctx, stmt);
     try obj.set(ctx.allocator, "__has_row", .{ .bool = rc == sqlite.ROW });
     try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
 
@@ -955,7 +1111,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     // if not yet stepped (shouldn't happen after execute), step now
     if (stepped != .bool or !stepped.bool) {
-        const rc = sqlite.sqlite3_step(stmt);
+        const rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = rc == sqlite.ROW });
         try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
         if (rc != sqlite.ROW) return .{ .bool = false };
@@ -967,7 +1123,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     if (mode == 5) {
         const row = try fetchRowAsObject(ctx, stmt);
-        const next_rc = sqlite.sqlite3_step(stmt);
+        const next_rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
         return row;
     }
@@ -981,7 +1137,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (!std.mem.eql(u8, class_name, "stdClass")) {
             try invokeCtorWithArgs(ctx, inst, class_name, if (ctor_args_v == .array) ctor_args_v.array else null);
         }
-        const next_rc = sqlite.sqlite3_step(stmt);
+        const next_rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
         return inst;
     }
@@ -989,7 +1145,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (mode == 9) {
         const target_v = obj.get("__fetch_into");
         if (target_v == .object) try populateObjectFromRow(ctx, target_v.object, stmt);
-        const next_rc = sqlite.sqlite3_step(stmt);
+        const next_rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
         return target_v;
     }
@@ -997,7 +1153,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const row = try fetchRow(ctx, stmt, mode);
 
     // advance to next row
-    const next_rc = sqlite.sqlite3_step(stmt);
+    const next_rc = try stepSqlite(ctx, stmt);
     try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
 
     return .{ .array = row };
@@ -1027,7 +1183,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const stepped_pre0 = obj.get("__stepped");
             const start_with_row0 = first and stepped_pre0 == .bool and stepped_pre0.bool and has_row_pre0 == .bool and has_row_pre0.bool;
             if (!start_with_row0) {
-                const rc = sqlite.sqlite3_step(stmt);
+                const rc = try stepSqlite(ctx, stmt);
                 if (rc != sqlite.ROW) break;
             }
             first = false;
@@ -1106,14 +1262,14 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
             try result.append(ctx.allocator, inst);
         }
-        var rc = sqlite.sqlite3_step(stmt);
+        var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             const inst = try fetchRowAsClass(ctx, stmt, class_name);
             if (!is_stdclass) {
                 if (ctor_args_arr) |ca| try invokeCtorWithArgs(ctx, inst, class_name, ca) else try invokeCtorWithArgs(ctx, inst, class_name, null);
             }
             try result.append(ctx.allocator, inst);
-            rc = sqlite.sqlite3_step(stmt);
+            rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
         return .{ .array = result };
@@ -1131,11 +1287,11 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try populateObjectFromRow(ctx, target, stmt);
             try result.append(ctx.allocator, .{ .object = target });
         }
-        var rc = sqlite.sqlite3_step(stmt);
+        var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             try populateObjectFromRow(ctx, target, stmt);
             try result.append(ctx.allocator, .{ .object = target });
-            rc = sqlite.sqlite3_step(stmt);
+            rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
         return .{ .array = result };
@@ -1155,7 +1311,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const r = try ctx.invokeCallable(callable, call_args);
             try result.append(ctx.allocator, r);
         }
-        var rc = sqlite.sqlite3_step(stmt);
+        var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             var call_args = try ctx.allocator.alloc(Value, @intCast(col_count));
             defer ctx.allocator.free(call_args);
@@ -1163,7 +1319,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             while (i < col_count) : (i += 1) call_args[@intCast(i)] = try columnToValue(ctx, stmt, i);
             const r = try ctx.invokeCallable(callable, call_args);
             try result.append(ctx.allocator, r);
-            rc = sqlite.sqlite3_step(stmt);
+            rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
         return .{ .array = result };
@@ -1181,7 +1337,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             };
             try result.set(ctx.allocator, ak, val_v);
         }
-        var rc = sqlite.sqlite3_step(stmt);
+        var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             const key_v = try columnToValue(ctx, stmt, 0);
             const val_v = try columnToValue(ctx, stmt, 1);
@@ -1191,7 +1347,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 else => .{ .int = Value.toInt(key_v) },
             };
             try result.set(ctx.allocator, ak, val_v);
-            rc = sqlite.sqlite3_step(stmt);
+            rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
         return .{ .array = result };
@@ -1204,11 +1360,11 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const val_v = try columnToValue(ctx, stmt, col_idx);
             try result.append(ctx.allocator, val_v);
         }
-        var rc = sqlite.sqlite3_step(stmt);
+        var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             const val_v = try columnToValue(ctx, stmt, col_idx);
             try result.append(ctx.allocator, val_v);
-            rc = sqlite.sqlite3_step(stmt);
+            rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
         return .{ .array = result };
@@ -1218,21 +1374,21 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const stepped = obj.get("__stepped");
 
     if (stepped != .bool or !stepped.bool) {
-        var rc = sqlite.sqlite3_step(stmt);
+        var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             const row = try fetchRow(ctx, stmt, mode);
             try result.append(ctx.allocator, .{ .array = row });
-            rc = sqlite.sqlite3_step(stmt);
+            rc = try stepSqlite(ctx, stmt);
         }
     } else {
         if (has_row == .bool and has_row.bool) {
             const row = try fetchRow(ctx, stmt, mode);
             try result.append(ctx.allocator, .{ .array = row });
-            var rc = sqlite.sqlite3_step(stmt);
+            var rc = try stepSqlite(ctx, stmt);
             while (rc == sqlite.ROW) {
                 const next_row = try fetchRow(ctx, stmt, mode);
                 try result.append(ctx.allocator, .{ .array = next_row });
-                rc = sqlite.sqlite3_step(stmt);
+                rc = try stepSqlite(ctx, stmt);
             }
         }
     }
@@ -1254,7 +1410,7 @@ fn stmtFetchColumn(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     const stepped = obj.get("__stepped");
 
     if (stepped != .bool or !stepped.bool) {
-        const rc = sqlite.sqlite3_step(stmt);
+        const rc = try stepSqlite(ctx, stmt);
         if (rc != sqlite.ROW) return .{ .bool = false };
     } else if (has_row != .bool or !has_row.bool) {
         return .{ .bool = false };
@@ -1262,7 +1418,7 @@ fn stmtFetchColumn(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
 
     const val = try columnToValue(ctx, stmt, col);
 
-    const next_rc = sqlite.sqlite3_step(stmt);
+    const next_rc = try stepSqlite(ctx, stmt);
     try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
     try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
 
@@ -1538,21 +1694,21 @@ fn fetchAllAsObjects(ctx: *NativeContext, stmt: *sqlite.Stmt, result: *PhpArray,
     const stepped = obj_parent.get("__stepped");
 
     if (stepped != .bool or !stepped.bool) {
-        var rc = sqlite.sqlite3_step(stmt);
+        var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             const row = try fetchRowAsObject(ctx, stmt);
             try result.append(ctx.allocator, row);
-            rc = sqlite.sqlite3_step(stmt);
+            rc = try stepSqlite(ctx, stmt);
         }
     } else {
         if (has_row == .bool and has_row.bool) {
             const row = try fetchRowAsObject(ctx, stmt);
             try result.append(ctx.allocator, row);
-            var rc = sqlite.sqlite3_step(stmt);
+            var rc = try stepSqlite(ctx, stmt);
             while (rc == sqlite.ROW) {
                 const next_row = try fetchRowAsObject(ctx, stmt);
                 try result.append(ctx.allocator, next_row);
-                rc = sqlite.sqlite3_step(stmt);
+                rc = try stepSqlite(ctx, stmt);
             }
         }
     }

--- a/tests/clone_callback_exception.php
+++ b/tests/clone_callback_exception.php
@@ -1,0 +1,13 @@
+<?php
+class RejectClone {
+    public function __clone() { throw new RuntimeException('clone rejected'); }
+}
+foreach ([new RejectClone(), curl_share_init()] as $object) {
+    try {
+        $copy = clone $object;
+        echo "unexpected clone\n";
+    } catch (Throwable $e) {
+        echo get_class($e), ':', $e->getMessage(), "\n";
+    }
+}
+echo "done\n";

--- a/tests/curl_share_lifetime.php
+++ b/tests/curl_share_lifetime.php
@@ -1,0 +1,27 @@
+<?php
+function handles() {
+    $s = curl_share_init();
+    curl_share_setopt($s, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
+    $a = curl_init(); $b = curl_init();
+    curl_setopt($a, CURLOPT_SHARE, $s);
+    curl_setopt($a, CURLOPT_SHARE, $s); // same-share replacement balances ownership
+    curl_setopt($b, CURLOPT_SHARE, $s);
+    curl_setopt($a, CURLOPT_COOKIELIST, "example.test\tFALSE\t/\tFALSE\t0\tkey\tvalue");
+    return [$a, $b];
+}
+for ($i = 0; $i < 100; $i++) {
+    $pair = handles();
+    $a = $pair[0]; $b = $pair[1];
+    unset($pair);
+    unset($a);
+    curl_reset($b);
+    if (count(curl_getinfo($b, CURLINFO_COOKIELIST)) !== 1) echo "lost cookie\n";
+    unset($b);
+}
+echo "lifetime ok\n";
+try { new CurlShareHandle(); } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// Easy allocated before share tests the reverse request-sweep order.
+$a = curl_init(); $s = curl_share_init();
+curl_share_setopt($s, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
+curl_setopt($a, CURLOPT_SHARE, $s);
+echo "done\n";

--- a/tests/curl_share_native.php
+++ b/tests/curl_share_native.php
@@ -1,0 +1,37 @@
+<?php
+// No sockets: libcurl's cookie-list API proves actual cross-handle state.
+$s = curl_share_init();
+var_dump(get_class($s), curl_share_errno($s));
+var_dump(curl_share_setopt($s, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE));
+var_dump(curl_share_setopt($s, CURLSHOPT_SHARE, 99999), curl_share_errno($s));
+try { curl_share_setopt($s, 99999, 2); } catch (ValueError $e) { echo $e->getMessage(), "\n"; }
+var_dump(curl_share_errno($s));
+var_dump(curl_share_setopt($s, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS), curl_share_errno($s));
+$a = curl_init(); $b = curl_init();
+var_dump(curl_setopt($a, CURLOPT_SHARE, $s), curl_setopt_array($b, [CURLOPT_SHARE => $s]));
+var_dump(curl_share_setopt($s, CURLSHOPT_UNSHARE, CURL_LOCK_DATA_COOKIE), curl_share_errno($s));
+var_dump(curl_share_close($s));
+var_dump(curl_setopt($a, CURLOPT_COOKIELIST, "example.test\tFALSE\t/\tFALSE\t0\tshared\tyes"));
+var_dump(curl_getinfo($b, CURLINFO_COOKIELIST));
+curl_reset($b);
+var_dump(curl_getinfo($b, CURLINFO_COOKIELIST));
+// PHP ignores null rather than detaching the share.
+var_dump(curl_setopt($b, CURLOPT_SHARE, null));
+var_dump(curl_getinfo($b, CURLINFO_COOKIELIST));
+$s2 = curl_share_init();
+curl_share_setopt($s2, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
+var_dump(curl_setopt($b, CURLOPT_SHARE, $s2));
+var_dump(curl_getinfo($b, CURLINFO_COOKIELIST));
+unset($s, $s2);
+var_dump(curl_getinfo($a, CURLINFO_COOKIELIST));
+curl_setopt($b, CURLOPT_COOKIELIST, "example.test\tFALSE\t/\tFALSE\t0\tother\tok");
+var_dump(curl_getinfo($b, CURLINFO_COOKIELIST));
+unset($a, $b);
+foreach ([0, 1, 2, 3, 4, 5, -1, 99999] as $code) { var_dump(curl_share_strerror($code)); }
+$s = curl_share_init();
+var_dump(curl_share_setopt($s, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE));
+var_dump(curl_share_setopt($s, CURLSHOPT_UNSHARE, CURL_LOCK_DATA_COOKIE));
+var_dump(curl_share_errno($s));
+// Leave wrappers and associated native resources for the request sweep.
+$a = curl_init(); curl_setopt($a, CURLOPT_SHARE, $s);
+echo "done\n";

--- a/tests/mysqli_report_modes.php
+++ b/tests/mysqli_report_modes.php
@@ -1,0 +1,37 @@
+<?php
+// A nonexistent Unix socket needs neither a listener nor a database fixture.
+$socket = __DIR__ . '/mysqli-report-missing/socket';
+$a = new mysqli_driver();
+$b = new mysqli_driver();
+var_dump($a->report_mode);
+foreach ([MYSQLI_REPORT_OFF, MYSQLI_REPORT_ERROR, MYSQLI_REPORT_STRICT,
+          MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT, MYSQLI_REPORT_ALL,
+          MYSQLI_REPORT_INDEX] as $mode) {
+    var_dump(mysqli_report($mode));
+    var_dump($a->report_mode, $b->report_mode);
+    try {
+        $result = @mysqli_connect('localhost', 'nobody', '', '', 3306, $socket);
+        var_dump($result);
+    } catch (mysqli_sql_exception $e) {
+        echo get_class($e), ':', $e->getCode() > 0 ? 'code' : 'no-code', ':', strlen($e->getSqlState()), "\n";
+    }
+}
+$a->report_mode = MYSQLI_REPORT_STRICT;
+var_dump($b->report_mode);
+$link = mysqli_init();
+try {
+    @$link->real_connect('localhost', 'nobody', '', '', 3306, $socket);
+    echo "missing exception\n";
+} catch (mysqli_sql_exception $e) {
+    echo "method caught\n";
+}
+mysqli_close($link);
+try {
+    $link = @new mysqli('localhost', 'nobody', '', '', 3306, $socket);
+    echo "missing constructor exception\n";
+} catch (mysqli_sql_exception $e) {
+    echo "constructor caught\n";
+}
+$b->report_mode = MYSQLI_REPORT_OFF;
+var_dump($a->report_mode);
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);

--- a/tests/native_callback_exception_cache.php
+++ b/tests/native_callback_exception_cache.php
@@ -1,0 +1,36 @@
+<?php
+// Repeat the same native method call site: the second call uses the method IC.
+// Both callbacks that return before a later callback throws and immediate
+// throws must reach the caller's catch without consuming an outer handler.
+error_reporting(E_ALL & ~E_DEPRECATED);
+function callbackQuery($db) {
+    return $db->query('SELECT callback_fail(1)');
+}
+function checkCallbackCatch($db, $nested) {
+    try {
+        if ($nested) callbackQuery($db);
+        else $db->query('SELECT callback_fail(1)');
+        echo "lost exception\n";
+    } catch (RuntimeException $e) {
+        echo $e->getMessage(), "\n";
+    } finally {
+        echo "finally\n";
+    }
+    echo $db->query('SELECT 42')->fetchColumn(), "\n";
+}
+foreach (['step', 'final'] as $phase) {
+    $db = new PDO('sqlite::memory:');
+    $db->sqliteCreateAggregate('callback_fail',
+        $phase === 'step' ? function ($c, $n, $v) { throw new RuntimeException('step'); } : fn($c, $n, $v) => $v,
+        $phase === 'final' ? function ($c, $n) { throw new RuntimeException('final'); } : fn($c, $n) => $c, 1);
+    foreach ([false, true] as $nested) {
+        for ($i = 0; $i < 3; $i++) {
+            try {
+                checkCallbackCatch($db, $nested);
+            } catch (Throwable $e) {
+                echo "wrong outer catch\n";
+            }
+        }
+    }
+}
+echo "done\n";

--- a/tests/pcntl_sigprocmask.php
+++ b/tests/pcntl_sigprocmask.php
@@ -1,0 +1,70 @@
+<?php
+// covers: pcntl_sigprocmask OS masks, previous-mask writeback, all operations
+function check_mask($condition) {
+    if (!$condition) throw new Exception('signal mask check failed');
+}
+
+$original = null;
+check_mask(pcntl_sigprocmask(SIG_BLOCK, [SIGUSR1], $original));
+try {
+    // The reported mask is the PREVIOUS mask, not the requested one.
+    $current = [];
+    check_mask(pcntl_sigprocmask(SIG_UNBLOCK, [SIGUSR1], $current));
+    check_mask(in_array(SIGUSR1, $current, true));
+    $copy = $current;
+    check_mask(pcntl_sigprocmask(SIG_BLOCK, [SIGUSR2], $current));
+    check_mask(!in_array(SIGUSR1, $current, true));
+    check_mask(in_array(SIGUSR1, $copy, true));
+
+    check_mask(pcntl_sigprocmask(SIG_SETMASK, [SIGUSR1], $current));
+    check_mask(in_array(SIGUSR2, $current, true));
+    check_mask(pcntl_sigprocmask(SIG_BLOCK, [SIGUSR1], $current));
+    check_mask($current === [SIGUSR1]);
+
+    // Function-local output and writeback through a by-reference wrapper.
+    function read_mask(&$out) {
+        $local = null;
+        check_mask(pcntl_sigprocmask(SIG_BLOCK, [SIGUSR1], $local));
+        check_mask($local === [SIGUSR1]);
+        check_mask(pcntl_sigprocmask(SIG_BLOCK, [SIGUSR1], $out));
+    }
+    $wrapped = null;
+    read_mask($wrapped);
+    check_mask($wrapped === [SIGUSR1]);
+
+    // Variable calls and explicitly referenced spread args.
+    $fn = 'pcntl_sigprocmask';
+    $local = null;
+    check_mask($fn(SIG_BLOCK, [SIGUSR1], $local));
+    check_mask($local === [SIGUSR1]);
+    $spread = [SIG_BLOCK, [SIGUSR1], &$local];
+    $local = null;
+    check_mask(pcntl_sigprocmask(...$spread));
+    check_mask($local === [SIGUSR1]);
+    $local = null;
+    check_mask($fn(...$spread));
+    check_mask($local === [SIGUSR1]);
+
+    // Invalid operations/signals fail without replacing the output or mask.
+    $untouched = ['sentinel'];
+    try {
+        check_mask(@pcntl_sigprocmask(-1, [SIGUSR2], $untouched) === false);
+        check_mask(pcntl_get_last_error() !== 0);
+    } catch (ValueError $e) {
+        // PHP versions differ in argument-validation policy.
+    }
+    check_mask($untouched === ['sentinel']);
+    try {
+        check_mask(@pcntl_sigprocmask(SIG_BLOCK, [0], $untouched) === false);
+        check_mask(pcntl_get_last_error() !== 0);
+    } catch (ValueError $e) {
+    }
+    check_mask($untouched === ['sentinel']);
+    check_mask(pcntl_sigprocmask(SIG_BLOCK, [SIGUSR1], $current));
+    check_mask($current === [SIGUSR1]);
+} finally {
+    // Restoration may legitimately use an empty inherited mask. This test
+    // does not assert a version-specific empty-input validation policy.
+    pcntl_sigprocmask(SIG_SETMASK, $original);
+}
+echo "ok\n";

--- a/tests/pdo_sqlite_aggregate.php
+++ b/tests/pdo_sqlite_aggregate.php
@@ -1,0 +1,49 @@
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+function step_total($context, $row, $value) {
+    return ($context ?? 0) + $value;
+}
+function final_total($context, $row) { return json_encode([$context, $row]); }
+$db = new PDO('sqlite::memory:');
+$db->exec('CREATE TABLE items (g TEXT, v INTEGER)');
+$db->exec("INSERT INTO items VALUES ('a',2),('a',3),('b',7)");
+var_dump($db->sqliteCreateAggregate('total_php', 'step_total', 'final_total', 1));
+foreach ($db->query('SELECT g, total_php(v) AS total FROM items GROUP BY g ORDER BY g')->fetchAll(PDO::FETCH_ASSOC) as $row) echo json_encode($row), "\n";
+echo $db->query('SELECT total_php(v) FROM items WHERE 0')->fetchColumn(), "\n";
+$db->sqliteCreateAggregate('state_php', function ($c, $n, $v) { $c[] = [$n, $v]; gc_collect_cycles(); return $c; }, function ($c, $n) { return json_encode([$c, $n]); }, 1);
+gc_collect_cycles();
+echo $db->query('SELECT state_php(v) FROM items')->fetchColumn(), "\n";
+$db->sqliteCreateAggregate('total_php', fn($c, $n, $v) => ($c ?? '') . $v, fn($c, $n) => $c, 1);
+echo $db->query('SELECT total_php(v) FROM items')->fetchColumn(), "\n";
+$db->sqliteCreateAggregate('types_php', fn($c, $n, $a, $b, $d) => [$a,$b,$d], fn($c,$n) => json_encode($c));
+echo $db->query("SELECT types_php(NULL, 1.25, CAST(x'610062' AS BLOB))")->fetchColumn(), "\n";
+$db->sqliteCreateAggregate('fail_php', function($c,$n,$v) { throw new RuntimeException('step failed'); }, fn($c,$n) => $c, 1);
+try { $db->query('SELECT fail_php(v) FROM items'); } catch (RuntimeException $e) { echo $e->getMessage(), "\n"; }
+$db->sqliteCreateAggregate('fail_php', fn($c,$n,$v) => $v, function($c,$n) { throw new RuntimeException('final failed'); }, 1);
+try { $db->query('SELECT fail_php(v) FROM items'); } catch (RuntimeException $e) { echo $e->getMessage(), "\n"; }
+echo $db->query('SELECT total_php(v) FROM items')->fetchColumn(), "\n";
+var_dump($db->sqliteCreateAggregate('invalid_arity', 'step_total', 'final_total', -2));
+if (class_exists('Pdo\\Sqlite')) {
+    $alias = new Pdo\Sqlite('sqlite::memory:');
+    var_dump($alias->createAggregate('alias_php', 'step_total', 'final_total', 1));
+    echo $alias->query('SELECT alias_php(9)')->fetchColumn(), "\n";
+}
+class AggregateCallbacks {
+    public function step($c, $n, $v) { return ($c ?? 0) + $v; }
+    public function finish($c, $n) { return $c; }
+}
+$callbacks = new AggregateCallbacks();
+$db->sqliteCreateAggregate('object_php', [$callbacks, 'step'], [$callbacks, 'finish'], 1);
+unset($callbacks); gc_collect_cycles();
+$stmt = $db->prepare('SELECT object_php(v) FROM items WHERE v > ?');
+$stmt->execute([2]); var_dump($stmt->fetchColumn());
+$stmt->execute([6]); var_dump($stmt->fetchColumn());
+$db->sqliteCreateAggregate('bool_php', fn($c,$n,$v) => $v, fn($c,$n) => false, 1);
+var_dump($db->query('SELECT bool_php(v) FROM items')->fetchColumn());
+try { $db->sqliteCreateAggregate('bad_callback', 'no_such_callback', 'final_total', 1); } catch (TypeError $e) { echo "invalid callback caught\n"; }
+$db->sqliteCreateFunction('scalar_php', fn($v) => $v * 3, 1);
+var_dump($db->query('SELECT scalar_php(4)')->fetchColumn());
+$db->sqliteCreateCollation('reverse_php', fn($a,$b) => strcmp($b,$a));
+echo json_encode($db->query('SELECT g FROM items ORDER BY g COLLATE reverse_php')->fetchAll(PDO::FETCH_COLUMN)), "\n";
+unset($db); gc_collect_cycles();
+echo "done\n";

--- a/tests/pdo_sqlite_aggregate_exceptions.php
+++ b/tests/pdo_sqlite_aggregate_exceptions.php
@@ -1,0 +1,175 @@
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+$db = new PDO('sqlite::memory:');
+$db->sqliteCreateAggregate('agg', function($c,$n,$v) { throw new RuntimeException('step'); }, fn($c,$n) => $c, 1);
+$db->setAttribute(PDO::ATTR_ERRMODE, 0);
+try {
+    $db->query('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:step:query:", $e->getMessage(), "\n";
+}
+try {
+    $db->exec('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:step:exec:", $e->getMessage(), "\n";
+}
+try {
+    $db->prepare('SELECT agg(1)')->execute();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:step:execute:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetch();
+    $stmt->fetch();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:step:fetch:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchColumn();
+    $stmt->fetchColumn();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:step:fetchColumn:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchAll();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:step:fetchAll:", $e->getMessage(), "\n";
+}
+$db->setAttribute(PDO::ATTR_ERRMODE, 2);
+try {
+    $db->query('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:step:query:", $e->getMessage(), "\n";
+}
+try {
+    $db->exec('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:step:exec:", $e->getMessage(), "\n";
+}
+try {
+    $db->prepare('SELECT agg(1)')->execute();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:step:execute:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetch();
+    $stmt->fetch();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:step:fetch:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchColumn();
+    $stmt->fetchColumn();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:step:fetchColumn:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchAll();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:step:fetchAll:", $e->getMessage(), "\n";
+}
+echo $db->query("SELECT 42")->fetchColumn(), "\n";
+$db->sqliteCreateAggregate('agg', fn($c,$n,$v) => $v, function($c,$n) { throw new RuntimeException('final'); }, 1);
+$db->setAttribute(PDO::ATTR_ERRMODE, 0);
+try {
+    $db->query('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:final:query:", $e->getMessage(), "\n";
+}
+try {
+    $db->exec('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:final:exec:", $e->getMessage(), "\n";
+}
+try {
+    $db->prepare('SELECT agg(1)')->execute();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:final:execute:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetch();
+    $stmt->fetch();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:final:fetch:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchColumn();
+    $stmt->fetchColumn();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:final:fetchColumn:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchAll();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "0:final:fetchAll:", $e->getMessage(), "\n";
+}
+$db->setAttribute(PDO::ATTR_ERRMODE, 2);
+try {
+    $db->query('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:final:query:", $e->getMessage(), "\n";
+}
+try {
+    $db->exec('SELECT agg(1)');
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:final:exec:", $e->getMessage(), "\n";
+}
+try {
+    $db->prepare('SELECT agg(1)')->execute();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:final:execute:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetch();
+    $stmt->fetch();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:final:fetch:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchColumn();
+    $stmt->fetchColumn();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:final:fetchColumn:", $e->getMessage(), "\n";
+}
+try {
+    $stmt = $db->query('SELECT 0 UNION ALL SELECT agg(1)');
+    $stmt->fetchAll();
+    echo "lost exception\n";
+} catch (RuntimeException $e) {
+    echo "2:final:fetchAll:", $e->getMessage(), "\n";
+}
+echo $db->query("SELECT 42")->fetchColumn(), "\n";

--- a/tests/pdo_sqlite_aggregate_lifetime.php
+++ b/tests/pdo_sqlite_aggregate_lifetime.php
@@ -1,0 +1,17 @@
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+$db = new Pdo\Sqlite('sqlite::memory:');
+$step = fn($c,$n,$v) => ($c ?? 0) + $v;
+$final = fn($c,$n) => $c;
+var_dump($db->createAggregate('agg', $step, $final, 1));
+$stmt = $db->query('SELECT agg(2) UNION ALL SELECT agg(3)');
+// Active statements reject replacement; SQLite destroys only the new registration.
+var_dump($db->createAggregate('agg', $step, fn($c,$n) => 99, 1));
+var_dump($stmt->fetchAll(PDO::FETCH_COLUMN));
+var_dump($db->createAggregate('agg', $step, fn($c,$n) => 99, 1));
+var_dump($db->createAggregate('invalid', $step, $final, -2));
+$stmt = $db->query('SELECT agg(4) UNION ALL SELECT agg(5)');
+unset($db); gc_collect_cycles();
+var_dump($stmt->fetchAll(PDO::FETCH_COLUMN));
+unset($stmt); gc_collect_cycles();
+echo "done\n";


### PR DESCRIPTION
Replace the `pcntl_sigprocmask()` no-op with operating-system signal-mask operations. Return the previous mask through `$old_signals` and add PHP comparison tests for blocking, unblocking, and replacing masks.

Closes #11.