### PR TITLE
Fix property hook semantics and reflection

### DIFF
--- a/src/bytecode_format.zig
+++ b/src/bytecode_format.zig
@@ -10,7 +10,9 @@ const TypeHint = compiler.TypeHint;
 const Allocator = std.mem.Allocator;
 
 const MAGIC = "ZPHPC\x00";
-const FORMAT_VERSION: u16 = 9;
+// v10 adds property-hook metadata and interface_decl property operands.
+// Older chunks cannot be decoded by the current VM.
+pub const FORMAT_VERSION: u16 = 10;
 
 // tag bytes for serialized values
 const TAG_NULL: u8 = 0;
@@ -748,4 +750,27 @@ pub fn detectEmbeddedBytecode(allocator: Allocator) ?[]const u8 {
         return null;
     }
     return bc;
+}
+
+test "property hook interface bytecode rejects pre-hook format" {
+    const allocator = std.testing.allocator;
+    var ast = try @import("pipeline/parser.zig").parse(
+        allocator,
+        "<?php interface CachedContract { public int $value { get; } }",
+    );
+    defer ast.deinit();
+    var compiled = try compiler.compile(&ast, allocator);
+    defer compiled.deinit();
+    const data = try serialize(allocator, &compiled);
+    defer allocator.free(data);
+
+    var decoded = try deserialize(allocator, data);
+    defer decoded.deinit();
+    try std.testing.expectEqualSlices(u8, compiled.chunk.code.items, decoded.chunk.code.items);
+
+    // A v9 cache can have the same source identity but lacks the new operands.
+    // Reject it at the header, rather than passing incompatible code to the VM.
+    data[MAGIC.len] = 9;
+    data[MAGIC.len + 1] = 0;
+    try std.testing.expectError(error.InvalidFormat, deserialize(allocator, data));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -152,7 +152,7 @@ fn dumpProfile(vm: *@import("runtime/vm.zig").VM) void {
     }
 }
 
-const compile_cache_dir = "bytecode-v9";
+const compile_cache_dir = std.fmt.comptimePrint("bytecode-v{d}", .{bytecode_format.FORMAT_VERSION});
 
 fn compileCachePath(allocator: std.mem.Allocator, path: []const u8, stat: std.fs.File.Stat, closure_counter: u32) ![]u8 {
     var digest: [32]u8 = undefined;

--- a/src/pipeline/ast.zig
+++ b/src/pipeline/ast.zig
@@ -126,7 +126,7 @@ pub const Ast = struct {
             class_decl, // main_token = class name, lhs = extra index -> {count, member_nodes...}, rhs = extra index -> {parent_node, implements_count, implements_nodes...}
             class_method, // main_token = method name, lhs = extra index -> {count, param...}, rhs = body block
             class_property, // main_token = property variable, lhs = default value (0 = none)
-            class_property_hooks, // main_token = property variable, lhs = extra index -> {default, get_body, set_body, set_param_tok, get_short, set_short}, rhs = visibility flags
+            class_property_hooks, // main_token = property variable, lhs = extra index -> {default, get_body, set_body, set_param_tok, get_flags, set_flags, set_type_start, set_type_end} (hook flags: bit 0 short, bit 1 generator, bit 2 reference, bit 3 abstract, bit 4 final, bit 5 backed), rhs = visibility flags
 
             static_class_method, // same as class_method but static
             static_class_property, // same as class_property but static

--- a/src/pipeline/bytecode.zig
+++ b/src/pipeline/bytecode.zig
@@ -300,6 +300,9 @@ pub const OpCode = enum(u8) {
     // hoisted at registration time, matching PHP's early binding
     declare_fn,
     array_push_assign,
+    // Stack-name variants: pop property name and object, push fetched value.
+    ensure_array_prop_dynamic,
+    get_prop_coalesce_dynamic,
 
     pub fn width(self: OpCode) usize {
         return switch (self) {
@@ -409,6 +412,8 @@ pub const OpCode = enum(u8) {
             .array_get_coalesce,
             .array_get_vivify,
             .get_prop_dynamic,
+            .ensure_array_prop_dynamic,
+            .get_prop_coalesce_dynamic,
             .isset_prop_dynamic,
             .array_elem_inc,
             .array_elem_dec,

--- a/src/pipeline/compiler_class.zig
+++ b/src/pipeline/compiler_class.zig
@@ -12,6 +12,9 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const Allocator = std.mem.Allocator;
 const Error = Allocator.Error || error{CompileError};
+// Declaration dependencies must use the same alias/absolute/namespace-relative
+// resolution as expressions, including the early-binding eligibility pass.
+const resolveNodeClassName = @import("compiler_expr.zig").resolveNodeClassName;
 const compiler_stmt = @import("compiler_stmt.zig");
 
 const ParsedAttr = struct {
@@ -1184,10 +1187,7 @@ fn classDeclEarlyBindable(self: *Compiler, node: Ast.Node) bool {
     const parent_node = self.ast.extra_data[rhs_base + 1];
     if (parent_node != 0) {
         const pnode = self.ast.nodes[parent_node];
-        const parent_name = if (pnode.tag == .qualified_name)
-            (self.buildQualifiedString(self.ast.extraSlice(pnode.data.lhs)) catch return false)
-        else
-            self.resolveClassName(self.ast.tokenSlice(pnode.main_token));
+        const parent_name = resolveNodeClassName(self, pnode) catch return false;
         if (!self.hoisted_names.contains(parent_name) and
             !@import("../stdlib/builtin_classes.zig").contains(parent_name)) return false;
     }
@@ -1236,10 +1236,7 @@ fn interfaceDeclEarlyBindable(self: *Compiler, node: Ast.Node) bool {
         const parent_count = self.ast.extra_data[node.data.rhs];
         for (0..parent_count) |i| {
             const pnode = self.ast.nodes[self.ast.extra_data[node.data.rhs + 1 + i]];
-            const pname = if (pnode.tag == .qualified_name)
-                (self.buildQualifiedString(self.ast.extraSlice(pnode.data.lhs)) catch return false)
-            else
-                self.resolveClassName(self.ast.tokenSlice(pnode.main_token));
+            const pname = resolveNodeClassName(self, pnode) catch return false;
             if (!self.hoisted_names.contains(pname)) return false;
         }
     }
@@ -1299,13 +1296,13 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
     var impl_names: [16][]const u8 = undefined;
     for (0..impl_count) |i| {
         const impl_node = self.ast.nodes[self.ast.extra_data[rhs_base + 3 + i]];
-        impl_names[i] = if (impl_node.tag == .qualified_name) (self.buildQualifiedString(self.ast.extraSlice(impl_node.data.lhs)) catch self.ast.tokenSlice(impl_node.main_token)) else self.resolveClassName(self.ast.tokenSlice(impl_node.main_token));
+        impl_names[i] = try resolveNodeClassName(self, impl_node);
     }
 
     const prev_parent = self.current_parent;
     self.current_parent = if (parent_node != 0) blk: {
         const pnode = self.ast.nodes[parent_node];
-        break :blk if (pnode.tag == .qualified_name) (self.buildQualifiedString(self.ast.extraSlice(pnode.data.lhs)) catch self.ast.tokenSlice(pnode.main_token)) else self.resolveClassName(self.ast.tokenSlice(pnode.main_token));
+        break :blk try resolveNodeClassName(self, pnode);
     } else "";
     defer self.current_parent = prev_parent;
 
@@ -1630,7 +1627,7 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
 
     if (parent_node != 0) {
         const pnode = self.ast.nodes[parent_node];
-        const parent_name = if (pnode.tag == .qualified_name) try self.buildQualifiedString(self.ast.extraSlice(pnode.data.lhs)) else self.resolveClassName(self.ast.tokenSlice(pnode.main_token));
+        const parent_name = try resolveNodeClassName(self, pnode);
         const parent_idx = try self.addConstant(.{ .string = Value.String.borrowed(parent_name) });
         try self.emitU16(parent_idx);
     } else {
@@ -1909,7 +1906,7 @@ pub fn compileAnonymousClass(self: *Compiler, node: Ast.Node) Error!void {
     var impl_names: [16][]const u8 = undefined;
     for (0..impl_count) |i| {
         const impl_node = self.ast.nodes[self.ast.extra_data[ctor_args_start + ctor_arg_count + 2 + i]];
-        impl_names[i] = if (impl_node.tag == .qualified_name) (self.buildQualifiedString(self.ast.extraSlice(impl_node.data.lhs)) catch self.ast.tokenSlice(impl_node.main_token)) else self.resolveClassName(self.ast.tokenSlice(impl_node.main_token));
+        impl_names[i] = try resolveNodeClassName(self, impl_node);
     }
 
     var method_count: u16 = 0;
@@ -2095,7 +2092,7 @@ pub fn compileAnonymousClass(self: *Compiler, node: Ast.Node) Error!void {
 
     if (parent_node != 0) {
         const apnode = self.ast.nodes[parent_node];
-        const parent_name = if (apnode.tag == .qualified_name) try self.buildQualifiedString(self.ast.extraSlice(apnode.data.lhs)) else self.resolveClassName(self.ast.tokenSlice(apnode.main_token));
+        const parent_name = try resolveNodeClassName(self, apnode);
         const parent_idx = try self.addConstant(.{ .string = Value.String.borrowed(parent_name) });
         try self.emitU16(parent_idx);
     } else {
@@ -2237,7 +2234,7 @@ pub fn compileInterfaceDecl(self: *Compiler, node: Ast.Node) Error!void {
         try self.emitByte(@intCast(parent_count));
         for (0..parent_count) |i| {
             const pnode = self.ast.nodes[self.ast.extra_data[node.data.rhs + 1 + i]];
-            const parent_name = if (pnode.tag == .qualified_name) try self.buildQualifiedString(self.ast.extraSlice(pnode.data.lhs)) else self.resolveClassName(self.ast.tokenSlice(pnode.main_token));
+            const parent_name = try resolveNodeClassName(self, pnode);
             const pidx = try self.addConstant(.{ .string = Value.String.borrowed(parent_name) });
             try self.emitU16(pidx);
         }

--- a/src/pipeline/compiler_class.zig
+++ b/src/pipeline/compiler_class.zig
@@ -1327,12 +1327,12 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
             const set_short = self.ast.extra_data[ext + 5];
             var prop_name = self.ast.tokenSlice(member.main_token);
             if (prop_name.len > 0 and prop_name[0] == '$') prop_name = prop_name[1..];
-            if (get_body != 0) {
-                try compilePropertyHook(self, class_name, prop_name, get_body, .get, get_short != 0, 0);
+            if (get_body != 0 or (self.ast.extra_data[ext + 4] & 8) != 0) {
+                try compilePropertyHook(self, class_name, prop_name, get_body, .get, get_short, 0, member);
                 method_count += 1;
             }
-            if (set_body != 0) {
-                try compilePropertyHook(self, class_name, prop_name, set_body, .set, set_short != 0, set_param_tok);
+            if (set_body != 0 or (self.ast.extra_data[ext + 5] & 8) != 0) {
+                try compilePropertyHook(self, class_name, prop_name, set_body, .set, set_short, set_param_tok, member);
                 method_count += 1;
             }
         }
@@ -1382,13 +1382,13 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
         const set_short = self.ast.extra_data[ext + 5];
         var prop_name = self.ast.tokenSlice(tmember.main_token);
         if (prop_name.len > 0 and prop_name[0] == '$') prop_name = prop_name[1..];
-        if (get_body != 0) {
-            try compilePropertyHook(self, class_name, prop_name, get_body, .get, get_short != 0, 0);
+        if (get_body != 0 or (self.ast.extra_data[ext + 4] & 8) != 0) {
+            try compilePropertyHook(self, class_name, prop_name, get_body, .get, get_short, 0, tmember);
             method_count += 1;
             try trait_hook_members.append(self.allocator, tpi);
         }
-        if (set_body != 0) {
-            try compilePropertyHook(self, class_name, prop_name, set_body, .set, set_short != 0, set_param_tok);
+        if (set_body != 0 or (self.ast.extra_data[ext + 5] & 8) != 0) {
+            try compilePropertyHook(self, class_name, prop_name, set_body, .set, set_short, set_param_tok, tmember);
             method_count += 1;
             // mark second slot for emitting set-method metadata too
             try trait_hook_members.append(self.allocator, tpi | 0x80000000);
@@ -1486,7 +1486,7 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
             const set_body = self.ast.extra_data[ext + 2];
             var prop_name = self.ast.tokenSlice(member.main_token);
             if (prop_name.len > 0 and prop_name[0] == '$') prop_name = prop_name[1..];
-            if (get_body != 0) {
+            if (get_body != 0 or (self.ast.extra_data[ext + 4] & 8) != 0) {
                 const hk_name = try std.fmt.allocPrint(self.allocator, "{s}$hook_get", .{prop_name});
                 try self.string_allocs.append(self.allocator, hk_name);
                 const mname_idx = try self.addConstant(.{ .string = Value.String.borrowed(hk_name) });
@@ -1494,9 +1494,9 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
                 try self.emitByte(0); // arity
                 try self.emitByte(0); // not static
                 try self.emitByte(2); // private vis
-                try self.emitByte(0); // flags
+                try self.emitByte(@intCast((self.ast.extra_data[ext + 4] >> 3) & 3)); // abstract/final
             }
-            if (set_body != 0) {
+            if (set_body != 0 or (self.ast.extra_data[ext + 5] & 8) != 0) {
                 const hk_name = try std.fmt.allocPrint(self.allocator, "{s}$hook_set", .{prop_name});
                 try self.string_allocs.append(self.allocator, hk_name);
                 const mname_idx = try self.addConstant(.{ .string = Value.String.borrowed(hk_name) });
@@ -1504,7 +1504,7 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
                 try self.emitByte(1); // arity
                 try self.emitByte(0); // not static
                 try self.emitByte(2); // private vis
-                try self.emitByte(0); // flags
+                try self.emitByte(@intCast((self.ast.extra_data[ext + 5] >> 3) & 3)); // abstract/final
             }
         } else if (member.tag == .interface_method) {
             const method_name_str = self.ast.tokenSlice(member.main_token);
@@ -1533,7 +1533,7 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
         try self.emitByte(if (is_set) @as(u8, 1) else @as(u8, 0));
         try self.emitByte(0); // not static
         try self.emitByte(2); // private vis
-        try self.emitByte(0); // flags
+        try self.emitByte(@intCast((self.ast.extra_data[tmember.data.lhs + @as(u32, if (is_set) 5 else 4)] >> 3) & 3));
     }
 
     try self.emitU16(prop_count);
@@ -1554,7 +1554,7 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
             const pname_idx = try self.addConstant(.{ .string = Value.String.borrowed(prop_name) });
             try self.emitU16(pname_idx);
             const default_idx = self.ast.extra_data[member.data.lhs];
-            try self.emitByte(if (default_idx != 0) @as(u8, 1) else @as(u8, 0));
+            try self.emitByte((if (default_idx != 0) @as(u8, 1) else @as(u8, 0)) | propertyVirtualFlag(self, member));
             try self.emitByte(@intCast(member.data.rhs & 0xff));
             try self.emitU16(try propertyTypeConst(self, member.data.rhs));
             try self.emitU16(try docCommentConst(self, member.main_token));
@@ -1571,7 +1571,7 @@ pub fn compileClassDecl(self: *Compiler, node: Ast.Node) Error!void {
             const default_idx = self.ast.extra_data[tmember.data.lhs];
             break :blk if (default_idx != 0) @as(u8, 1) else @as(u8, 0);
         } else if (tmember.data.lhs != 0) @as(u8, 1) else @as(u8, 0);
-        try self.emitByte(has_default);
+        try self.emitByte(has_default | propertyVirtualFlag(self, tmember));
         try self.emitByte(@intCast(tmember.data.rhs & 0xff));
         try self.emitU16(try propertyTypeConst(self, tmember.data.rhs));
         try self.emitU16(try docCommentConst(self, tmember.main_token));
@@ -2285,6 +2285,34 @@ pub fn compileInterfaceDecl(self: *Compiler, node: Ast.Node) Error!void {
     }
     for (methods_with_attrs.items) |ma| freeAttrSlice(self.allocator, ma.attrs);
 
+    // Property contracts carry their own metadata, not callable dummy methods.
+    var property_count: u16 = 0;
+    for (members) |m| {
+        if (self.ast.nodes[m].tag == .class_property_hooks) property_count += 1;
+    }
+    try self.emitU16(property_count);
+    for (members) |m| {
+        const member = self.ast.nodes[m];
+        if (member.tag != .class_property_hooks) continue;
+        const prop_name = self.ast.tokenSlice(member.main_token)[1..];
+        try self.emitU16(try self.addConstant(.{ .string = Value.String.borrowed(prop_name) }));
+        try self.emitU16(try propertyTypeConst(self, member.data.rhs));
+        try self.emitU16(try docCommentConst(self, member.main_token));
+        const ext = member.data.lhs;
+        const mask: u8 = (if ((self.ast.extra_data[ext + 4] & 8) != 0) @as(u8, 1) else 0) |
+            (if ((self.ast.extra_data[ext + 5] & 8) != 0) @as(u8, 2) else 0);
+        try self.emitByte(mask);
+        for ([_][]const u8{ "$hook_get", "$hook_set" }, 0..) |suffix, i| {
+            if (mask & (@as(u8, 1) << @intCast(i)) == 0) continue;
+            const hook = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ prop_name, suffix });
+            try self.string_allocs.append(self.allocator, hook);
+            try self.emitU16(try self.addConstant(.{ .string = Value.String.borrowed(hook) }));
+        }
+        const attrs = extractAttributes(self, member.main_token);
+        try emitAttributeData(self, attrs);
+        freeAttrSlice(self.allocator, attrs);
+    }
+
     // set interface constants after interface_decl so self:: references resolve
     for (members) |m| {
         const member = self.ast.nodes[m];
@@ -2304,6 +2332,11 @@ pub fn compileInterfaceDecl(self: *Compiler, node: Ast.Node) Error!void {
         const member = self.ast.nodes[m];
         if (member.tag == .interface_method) {
             try compileInterfaceMethodStub(self, iface_name, member);
+        } else if (member.tag == .class_property_hooks) {
+            const ext = member.data.lhs;
+            const prop_name = self.ast.tokenSlice(member.main_token)[1..];
+            if ((self.ast.extra_data[ext + 4] & 8) != 0) try compilePropertyHook(self, iface_name, prop_name, 0, .get, self.ast.extra_data[ext + 4], 0, member);
+            if ((self.ast.extra_data[ext + 5] & 8) != 0) try compilePropertyHook(self, iface_name, prop_name, 0, .set, self.ast.extra_data[ext + 5], self.ast.extra_data[ext + 3], member);
         }
     }
 }
@@ -2401,9 +2434,8 @@ pub fn compileTraitDecl(self: *Compiler, node: Ast.Node) Error!void {
     // compile defaults for own properties last (popped first by VM)
     for (own_props.items) |pi| {
         const pmember = self.ast.nodes[pi];
-        if (pmember.data.lhs != 0) {
-            try self.compileNode(pmember.data.lhs);
-        }
+        const default = if (pmember.tag == .class_property_hooks) self.ast.extra_data[pmember.data.lhs] else pmember.data.lhs;
+        if (default != 0) try self.compileNode(default);
     }
 
     const name_idx = try self.addConstant(.{ .string = Value.String.borrowed(trait_name) });
@@ -2421,7 +2453,8 @@ pub fn compileTraitDecl(self: *Compiler, node: Ast.Node) Error!void {
         if (pname.len > 0 and pname[0] == '$') pname = pname[1..];
         const pname_idx = try self.addConstant(.{ .string = Value.String.borrowed(pname) });
         try self.emitU16(pname_idx);
-        try self.emitByte(if (pmember.data.lhs != 0) @as(u8, 1) else @as(u8, 0));
+        const default = if (pmember.tag == .class_property_hooks) self.ast.extra_data[pmember.data.lhs] else pmember.data.lhs;
+        try self.emitByte(if (default != 0) @as(u8, 1) else @as(u8, 0));
         try self.emitByte(@intCast(pmember.data.rhs & 0xff));
     }
     try self.emitByte(@intCast(static_props.items.len));
@@ -2863,12 +2896,32 @@ fn compileClassMethodBody(self: *Compiler, class_name: []const u8, member: Ast.N
     sub.new_defaults.deinit(self.allocator);
 }
 
+fn propertyVirtualFlag(self: *Compiler, member: Ast.Node) u8 {
+    return if (member.tag == .class_property_hooks and (self.ast.extra_data[member.data.lhs + 4] & 32) == 0) 2 else 0;
+}
+
 const HookKind = enum { get, set };
 
-fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []const u8, body_idx: u32, kind: HookKind, is_short: bool, set_param_tok: u32) Error!void {
+fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []const u8, body_idx: u32, kind: HookKind, hook_flags: u32, set_param_tok: u32, member: Ast.Node) Error!void {
+    const is_short = (hook_flags & 1) != 0;
+    const is_generator = (hook_flags & 2) != 0;
     const suffix = if (kind == .get) "$hook_get" else "$hook_set";
     const full_name = try std.fmt.allocPrint(self.allocator, "{s}::{s}{s}", .{ class_name, prop_name, suffix });
     try self.string_allocs.append(self.allocator, full_name);
+
+    const type_extra = member.data.rhs >> 16;
+    const prop_type = if (type_extra != 0)
+        try buildTypeString(self, self.ast.extra_data[type_extra - 1], self.ast.extra_data[type_extra])
+    else
+        "";
+    const ext = member.data.lhs;
+    const param_types = try self.allocator.alloc([]const u8, if (kind == .set) 1 else 0);
+    if (kind == .set) {
+        const start = self.ast.extra_data[ext + 6];
+        const end = self.ast.extra_data[ext + 7];
+        param_types[0] = if (end > start) try buildTypeString(self, start, end) else prop_type;
+    }
+    try self.type_hints.append(self.allocator, .{ .name = full_name, .param_types = param_types, .return_type = if (kind == .get) prop_type else "void" });
 
     var param_names_list = std.ArrayListUnmanaged([]const u8){};
     defer param_names_list.deinit(self.allocator);
@@ -2902,6 +2955,8 @@ fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []con
         .use_aliases = self.use_aliases,
         .use_fn_aliases = self.use_fn_aliases,
         .use_const_aliases = self.use_const_aliases,
+        .is_generator = is_generator,
+        .returns_ref = (hook_flags & 4) != 0,
         .current_class = class_name,
         .current_function = full_name,
     };
@@ -2921,8 +2976,10 @@ fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []con
 
     if (is_short) {
         if (kind == .get) {
-            try sub.compileNode(body_idx);
-            try sub.emitOp(.return_val);
+            if (!(sub.returns_ref and !is_generator and try sub.tryCompileRefReturn(body_idx))) {
+                try sub.compileNode(body_idx);
+                try sub.emitOp(if (is_generator) .generator_return else .return_val);
+            }
         } else {
             // set short form: $this->prop = expr (raw write since hook guard is active)
             const this_slot = sub.local_slots.get("$this") orelse 0;
@@ -2934,7 +2991,7 @@ fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []con
             try sub.emitU16(prop_idx);
             try sub.emitOp(.pop);
         }
-    } else {
+    } else if (body_idx != 0) {
         try sub.compileNode(body_idx);
     }
     for (sub.pending_gotos.items) |pg| {
@@ -2943,7 +3000,7 @@ fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []con
     sub.pending_gotos.deinit(self.allocator);
     sub.labels.deinit(self.allocator);
     try sub.emitOp(.op_null);
-    try sub.emitOp(.return_val);
+    try sub.emitOp(if (is_generator) .generator_return else .return_val);
     sub.break_jumps.deinit(self.allocator);
     sub.continue_jumps.deinit(self.allocator);
 
@@ -2953,7 +3010,7 @@ fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []con
     const local_count = sub.next_slot;
     sub.local_slots.deinit(self.allocator);
 
-    const method_lo = !needsVarSync(&sub.chunk) and sub.closure_count == 0;
+    const method_lo = !is_generator and !needsVarSync(&sub.chunk) and sub.closure_count == 0;
 
     try self.functions.append(self.allocator, .{
         .name = full_name,
@@ -2963,11 +3020,13 @@ fn compilePropertyHook(self: *Compiler, class_name: []const u8, prop_name: []con
         .defaults = defaults,
         .ref_params = ref_flags,
         .chunk = sub.chunk,
+        .is_generator = is_generator,
         .locals_only = method_lo,
         .local_count = local_count,
         .slot_names = slot_names,
         .file_path = self.file_path,
         .start_line = if (body_idx != 0) lineForToken(self, self.ast.nodes[body_idx].main_token) else 0,
+        .returns_ref = (hook_flags & 4) != 0,
     });
 
     for (sub.functions.items) |f| try self.functions.append(self.allocator, f);

--- a/src/pipeline/compiler_expr.zig
+++ b/src/pipeline/compiler_expr.zig
@@ -226,12 +226,16 @@ pub fn compileAssign(self: *Compiler, node: Ast.Node) Error!void {
                 try self.emitOp(.array_set_chain);
                 return;
             }
-            if (target_lhs.tag == .property_access and !self.isDynamicProp(target_lhs)) {
+            if (target_lhs.tag == .property_access) {
                 try self.compileNode(target_lhs.data.lhs); // push $obj
-                const prop_name = self.propName(target_lhs);
-                const cidx = try self.addConstant(.{ .string = Value.String.borrowed(prop_name) });
-                try self.emitOp(.constant);
-                try self.emitU16(cidx); // push prop name
+                if (self.isDynamicProp(target_lhs)) {
+                    try self.compileNode(target_lhs.data.rhs);
+                } else {
+                    const prop_name = self.propName(target_lhs);
+                    const cidx = try self.addConstant(.{ .string = Value.String.borrowed(prop_name) });
+                    try self.emitOp(.constant);
+                    try self.emitU16(cidx); // push prop name
+                }
                 try self.compileNode(target.data.rhs); // push inner key
                 try self.compileNode(node.data.rhs); // push value
                 try self.emitOp(.prop_set_chain);
@@ -705,14 +709,19 @@ fn compileCoalesceFetch(self: *Compiler, node_idx: u32) Error!void {
         try self.emitOp(.array_get_coalesce);
         return;
     }
-    // a static-name property read under `??` uses isset-semantics: an
+    // A property read under `??` uses isset-semantics: an
     // uninitialized typed property must read as null, not throw. recurse so a
     // chain `$a->b->c ?? x` is non-throwing all the way down
-    if (n.tag == .property_access and !self.isDynamicProp(n)) {
+    if (n.tag == .property_access) {
         try compileCoalesceFetch(self, n.data.lhs);
-        const name_idx = try self.addConstant(.{ .string = Value.String.borrowed(self.propName(n)) });
-        try self.emitOp(.get_prop_coalesce);
-        try self.emitU16(name_idx);
+        if (self.isDynamicProp(n)) {
+            try self.compileNode(n.data.rhs);
+            try self.emitOp(.get_prop_coalesce_dynamic);
+        } else {
+            const name_idx = try self.addConstant(.{ .string = Value.String.borrowed(self.propName(n)) });
+            try self.emitOp(.get_prop_coalesce);
+            try self.emitU16(name_idx);
+        }
         return;
     }
     try self.compileNode(node_idx);
@@ -837,38 +846,11 @@ pub fn compileCall(self: *Compiler, node: Ast.Node) Error!void {
                         try self.emitU16(prop_idx);
                     }
                 } else if (arg.tag == .array_access) {
-                    const lhs_node = self.ast.nodes[arg.data.lhs];
-                    if (lhs_node.tag == .property_access and !self.isDynamicProp(lhs_node)) {
-                        // for isset($obj->prop[key]), PHP first calls __isset('prop')
-                        // and short-circuits to false without calling __get when the
-                        // property isn't set. emit: obj, dup, isset_prop, branch on
-                        // false (drop the obj, push false), else get_prop and isset_index
-                        try self.compileNode(lhs_node.data.lhs);
-                        try self.emitOp(.dup);
-                        const prop_name = self.propName(lhs_node);
-                        const prop_idx = try self.addConstant(.{ .string = Value.String.borrowed(prop_name) });
-                        try self.emitOp(.isset_prop);
-                        try self.emitU16(prop_idx);
-                        // stack: [obj, bool]
-                        const false_jump = try self.emitJump(.jump_if_false);
-                        try self.emitOp(.pop); // drop true bool → [obj]
-                        try self.emitOp(.get_prop);
-                        try self.emitU16(prop_idx);
-                        try self.compileNode(arg.data.rhs);
-                        try self.emitOp(.isset_index); // → [bool]
-                        const done_jump = try self.emitJump(.jump);
-                        self.patchJump(false_jump);
-                        // stack: [obj, false] — swap and drop obj to leave [false]
-                        try self.emitOp(.swap);
-                        try self.emitOp(.pop);
-                        self.patchJump(done_jump);
-                    } else {
-                        // use coalesce fetch for the LHS chain so nested
-                        // isset($a[x][y]) doesn't warn on the inner read
-                        try compileCoalesceFetch(self, arg.data.lhs);
-                        try self.compileNode(arg.data.rhs);
-                        try self.emitOp(.isset_index);
-                    }
+                    // Fetch each chain link once: hooks are reads, not a separate
+                    // existence probe followed by another getter invocation.
+                    try compileCoalesceFetch(self, arg.data.lhs);
+                    try self.compileNode(arg.data.rhs);
+                    try self.emitOp(.isset_index);
                 } else {
                     try self.compileNode(arg_idx);
                     try self.emitOp(.op_null);
@@ -1171,13 +1153,18 @@ pub fn compileVivifyChain(self: *Compiler, node_idx: u32) Error!void {
     } else if (node.tag == .variable or node.tag == .identifier) {
         const name = self.ast.tokenSlice(node.main_token);
         try emitEnsureArray(self, name);
-    } else if (node.tag == .property_access and !self.isDynamicProp(node)) {
+    } else if (node.tag == .property_access) {
         // $obj->prop[]=x / $obj->prop[k] op= v: load the property array for
         // in-place write with COW separation + write-back (ensure_array_prop)
         try self.compileNode(node.data.lhs);
-        const prop_idx = try self.addConstant(.{ .string = Value.String.borrowed(self.propName(node)) });
-        try self.emitOp(.ensure_array_prop);
-        try self.emitU16(prop_idx);
+        if (self.isDynamicProp(node)) {
+            try self.compileNode(node.data.rhs);
+            try self.emitOp(.ensure_array_prop_dynamic);
+        } else {
+            const prop_idx = try self.addConstant(.{ .string = Value.String.borrowed(self.propName(node)) });
+            try self.emitOp(.ensure_array_prop);
+            try self.emitU16(prop_idx);
+        }
     } else if (node.tag == .static_prop_access and self.ast.nodes[node.data.lhs].tag != .variable) {
         // Class::$prop[]=x: load the static-prop array for in-place write with
         // COW separation + write-back (ensure_array_static_prop). dynamic

--- a/src/pipeline/parser.zig
+++ b/src/pipeline/parser.zig
@@ -1652,25 +1652,15 @@ const Parser = struct {
             } else if (self.peek() == .kw_const) {
                 try methods.append(self.allocator, try self.parseConstDecl());
             } else {
-                // PHP 8.4 interface property hooks: `public T $name { get; }` or
-                // `public T $name { get; set; }`. we accept the syntax for parse
-                // compatibility but don't store the contract since hooks are
-                // already validated at the class level.
-                if (self.isTypeName() or self.peek() == .question) self.skipTypeHint();
-                if (self.peek() == .variable) {
-                    _ = self.advance();
-                    if (self.peek() == .l_brace) {
-                        var depth: u32 = 1;
-                        _ = self.advance();
-                        while (depth > 0 and self.peek() != .eof) : (_ = self.advance()) {
-                            if (self.peek() == .l_brace) depth += 1 else if (self.peek() == .r_brace) depth -= 1;
-                        }
-                    } else if (self.peek() == .semicolon) {
-                        _ = self.advance();
-                    }
-                } else {
-                    _ = self.advance();
+                const tr = self.collectTypeHint();
+                if (self.peek() != .variable) return error.ParseError;
+                const prop = try self.parseClassProperty();
+                if (self.nodes.items[prop].tag != .class_property_hooks) return error.ParseError;
+                if (tr[0] != tr[1]) {
+                    const ext = try self.addExtra(&tr);
+                    self.nodes.items[prop].data.rhs = (ext + 1) << 16;
                 }
+                try methods.append(self.allocator, prop);
             }
         }
         _ = try self.expect(.r_brace);
@@ -2109,10 +2099,14 @@ const Parser = struct {
         var set_param_tok: u32 = 0;
         var get_short: u32 = 0;
         var set_short: u32 = 0;
+        var set_type_start: u32 = 0;
+        var set_type_end: u32 = 0;
+        const hook_nodes_start = self.nodes.items.len;
         while (self.peek() != .r_brace and self.peek() != .eof) {
             // skip attributes / final / & before the hook name
             self.skipAttributes();
-            if (self.peek() == .kw_final) _ = self.advance();
+            const is_final = self.peek() == .kw_final;
+            if (is_final) _ = self.advance();
             const is_ref = self.peek() == .amp;
             if (is_ref) _ = self.advance();
             if (self.peek() != .identifier) {
@@ -2133,7 +2127,9 @@ const Parser = struct {
             if (is_set and self.peek() == .l_paren) {
                 _ = self.advance();
                 if (self.peek() != .r_paren) {
+                    set_type_start = self.pos;
                     self.skipTypeHint();
+                    set_type_end = self.pos;
                     if (self.peek() == .amp) _ = self.advance();
                     if (self.peek() == .variable) {
                         local_set_param = self.advance();
@@ -2141,6 +2137,10 @@ const Parser = struct {
                 }
                 _ = try self.expect(.r_paren);
             }
+
+            const prev_yield = self.found_yield;
+            self.found_yield = false;
+            defer self.found_yield = prev_yield;
 
             if (self.peek() == .fat_arrow) {
                 _ = self.advance();
@@ -2163,15 +2163,39 @@ const Parser = struct {
                     set_param_tok = local_set_param;
                 }
             } else if (self.peek() == .semicolon) {
-                // abstract hook in interface (rare); skip
+                // Preserve body-less hooks independently from absent hooks.
+                if (is_get) get_short |= 8 else set_short |= 8;
+                if (is_set) set_param_tok = local_set_param;
                 _ = self.advance();
             } else {
                 _ = self.advance();
             }
+            if (is_final) {
+                if (is_get) get_short |= 16 else set_short |= 16;
+            }
+            if (is_get and is_ref) get_short |= 4;
+            // Hook flags: bit 0 = short expression, bit 1 = generator, bit 2 = reference.
+            if (self.found_yield) {
+                if (is_get) get_short |= 2 else set_short |= 2;
+            }
         }
         _ = try self.expect(.r_brace);
 
-        const extra_idx = try self.addExtra(&[_]u32{ default, get_body, set_body, set_param_tok, get_short, set_short });
+        // Backing is a syntactic access to this property's storage in either body.
+        // A short setter implicitly writes that storage.
+        var backed = (set_short & 1) != 0;
+        for (self.nodes.items[hook_nodes_start..]) |n| {
+            if (n.tag != .property_access) continue;
+            const receiver = self.nodes.items[n.data.lhs];
+            if (receiver.tag != .variable or !std.mem.eql(u8, self.tokens[receiver.main_token].lexeme(self.source), "$this")) continue;
+            const prop_node = self.nodes.items[n.data.rhs];
+            if (n.main_token == 0 or self.tokens[prop_node.main_token].tag == .variable) continue;
+            const property = self.tokens[prop_node.main_token].lexeme(self.source);
+            if (std.mem.eql(u8, property, self.tokens[name_tok].lexeme(self.source)[1..])) backed = true;
+        }
+        if (backed) get_short |= 32;
+
+        const extra_idx = try self.addExtra(&[_]u32{ default, get_body, set_body, set_param_tok, get_short, set_short, set_type_start, set_type_end });
         return self.addNode(.{ .tag = .class_property_hooks, .main_token = name_tok, .data = .{ .lhs = extra_idx } });
     }
 

--- a/src/pipeline/parser_tests.zig
+++ b/src/pipeline/parser_tests.zig
@@ -767,3 +767,63 @@ test "php84 abbreviated promoted asymmetric visibility parses" {
     defer ast.deinit();
     try std.testing.expectEqual(@as(usize, 0), ast.errors.len);
 }
+
+test "property hook generator flags are scoped independently" {
+    var ast = try parse(std.testing.allocator,
+        \\<?php function factory() {
+        \\    class Sequence {
+        \\        public $block { get { yield 1; } set { echo $value; } }
+        \\        public $short { get => yield 2; }
+        \\        public $closure { get => function () { yield 3; }; }
+        \\    }
+        \\    return new Sequence();
+        \\}
+    );
+    defer ast.deinit();
+    try std.testing.expectEqual(@as(usize, 0), ast.errors.len);
+    var hooks: usize = 0;
+    for (ast.nodes) |node| {
+        if (node.tag == .function_decl) {
+            try std.testing.expectEqual(@as(u32, 0), node.data.rhs & 0x80000000);
+        }
+        if (node.tag != .class_property_hooks) continue;
+        const expected: u32 = switch (hooks) {
+            0 => 2, // block generator
+            1 => 3, // short generator
+            2 => 1, // nested generator does not mark the hook
+            else => unreachable,
+        };
+        try std.testing.expectEqual(expected, ast.extra_data[node.data.lhs + 4]);
+        try std.testing.expectEqual(@as(u32, 0), ast.extra_data[node.data.lhs + 5]);
+        hooks += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 3), hooks);
+}
+
+test "property hook abstract final reference and setter type metadata" {
+    var ast = try parse(std.testing.allocator,
+        \\<?php
+        \\abstract class HookFlags {
+        \\    abstract public string $name { get; set(string $input); }
+        \\    public array $items { final &get => $this->items; }
+        \\}
+    );
+    defer ast.deinit();
+    try std.testing.expectEqual(@as(usize, 0), ast.errors.len);
+    var count: usize = 0;
+    for (ast.nodes) |node| {
+        if (node.tag != .class_property_hooks) continue;
+        const ext = node.data.lhs;
+        if (count == 0) {
+            try std.testing.expectEqual(@as(u32, 8), ast.extra_data[ext + 4]);
+            try std.testing.expectEqual(@as(u32, 8), ast.extra_data[ext + 5]);
+            try std.testing.expectEqualStrings("$input", ast.tokenSlice(ast.extra_data[ext + 3]));
+            try std.testing.expectEqualStrings("string", ast.tokenSlice(ast.extra_data[ext + 6]));
+            try std.testing.expectEqual(ast.extra_data[ext + 6] + 1, ast.extra_data[ext + 7]);
+        } else {
+            try std.testing.expectEqual(@as(u32, 53), ast.extra_data[ext + 4]);
+        }
+        count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 2), count);
+}

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -382,6 +382,7 @@ pub const ClassDef = struct {
         is_readonly: bool = false,
         is_final: bool = false,
         is_promoted: bool = false,
+        is_virtual: bool = false,
         type_str: []const u8 = "",
         doc_comment: []const u8 = "",
     };
@@ -4354,7 +4355,30 @@ pub const VM = struct {
                     const obj = base.object;
                     const pname = prop_key.string.bytes();
                     const ik = Value.toArrayKey(inner_key);
-                    const existing = obj.get(pname);
+                    // Hook reads must precede vivification/COW. A by-value hook
+                    // may expose an object for offsetSet, but not writable array storage.
+                    obj.refcount +%= 1;
+                    defer self.releaseValue(.{ .object = obj });
+                    var existing = obj.get(pname);
+                    var hook_cell: ?*Value = null;
+                    defer if (hook_cell) |cell| self.unbindCell(cell);
+                    if (self.hasPropHook(obj.class_name, pname, .get) and !self.inPropHook(obj, pname)) {
+                        self.setReturnRef(null);
+                        existing = (self.callPropHook(obj, pname, .get, .null) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        }) orelse .null;
+                        if (try self.propGetReturnsRef(obj, pname)) {
+                            hook_cell = try self.takeHookReturnCell();
+                            if (hook_cell) |cell| existing = try self.prepareHookArray(cell);
+                        }
+                        if (existing != .object and !try self.propGetReturnsRef(obj, pname)) {
+                            const msg = try std.fmt.allocPrint(self.allocator, "Indirect modification of {s}::${s} is not allowed", .{ obj.class_name, pname });
+                            try self.strings.append(self.allocator, msg);
+                            if (try self.throwBuiltinException("Error", msg)) continue;
+                            return error.RuntimeError;
+                        }
+                    }
                     if (existing == .string) {
                         const s = existing.string.bytes();
                         var idx: i64 = switch (ik) {
@@ -4387,7 +4411,11 @@ pub const VM = struct {
                         if (new_len > s.len) @memset(buf[s.len..], ' ');
                         buf[target_idx] = write_byte;
                         try self.strings.append(self.allocator, buf);
-                        try self.objectSetOwned(obj, pname, .{ .string = Value.String.borrowed(buf) });
+                        if (hook_cell) |cell| {
+                            const result = Value{ .string = Value.String.borrowed(buf) };
+                            self.setCell(cell, result);
+                            try self.propagateCellWrite(cell, result);
+                        } else try self.objectSetOwned(obj, pname, .{ .string = Value.String.borrowed(buf) });
                         self.push(v);
                         continue;
                     }
@@ -4398,7 +4426,7 @@ pub const VM = struct {
                         var ea = existing;
                         // a referenced property (`$r=&$obj->prop`) is shared on
                         // purpose - mutate in place, never separate a copy
-                        const inner = if (self.propIsReferenced(obj, pname)) existing.array else try self.cowSeparate(existing.array);
+                        const inner = if (hook_cell != null or self.propIsReferenced(obj, pname)) existing.array else try self.cowSeparate(existing.array);
                         if (inner != existing.array) {
                             try obj.set(self.allocator, pname, .{ .array = inner });
                             inner.refcount -= 1;
@@ -4415,7 +4443,10 @@ pub const VM = struct {
                         new_arr.* = .{};
                         try self.arrays.append(self.allocator, new_arr);
                         try new_arr.set(self.allocator, ik, v);
-                        try obj.set(self.allocator, pname, .{ .array = new_arr });
+                        if (hook_cell) |cell| {
+                            self.setCell(cell, .{ .array = new_arr });
+                            try self.propagateCellWrite(cell, cell.*);
+                        } else try obj.set(self.allocator, pname, .{ .array = new_arr });
                         self.push(v);
                         continue;
                     }
@@ -4918,20 +4949,45 @@ pub const VM = struct {
                     self.push(new_val);
                 },
 
-                .ensure_array_prop => {
+                .ensure_array_prop, .ensure_array_prop_dynamic => {
                     // load an object's property array for in-place write
                     // ($obj->prop[]=x, $obj->prop[k] op= v). COW-separate it
                     // from co-holders and write the unshared array back to the
                     // property; vivify null/false to a fresh array
-                    const name_idx = self.readU16();
-                    const prop_name = self.currentChunk().constants.items[name_idx].string.bytes();
+                    const prop_name = if (op == .ensure_array_prop_dynamic) try self.valueToString(self.pop()) else blk: {
+                        const name_idx = self.readU16();
+                        break :blk self.currentChunk().constants.items[name_idx].string.bytes();
+                    };
                     const obj_val = self.pop();
                     if (obj_val != .object) {
                         self.push(.null);
                         continue;
                     }
                     const eap_obj = obj_val.object;
-                    const cur = eap_obj.get(prop_name);
+                    // Hook reads must precede vivification/COW. A by-value hook
+                    // may expose an object for offsetSet, but not writable array storage.
+                    eap_obj.refcount +%= 1;
+                    defer self.releaseValue(.{ .object = eap_obj });
+                    var cur = eap_obj.get(prop_name);
+                    var hook_cell: ?*Value = null;
+                    defer if (hook_cell) |cell| self.unbindCell(cell);
+                    if (self.hasPropHook(eap_obj.class_name, prop_name, .get) and !self.inPropHook(eap_obj, prop_name)) {
+                        self.setReturnRef(null);
+                        cur = (self.callPropHook(eap_obj, prop_name, .get, .null) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        }) orelse .null;
+                        if (try self.propGetReturnsRef(eap_obj, prop_name)) {
+                            hook_cell = try self.takeHookReturnCell();
+                            if (hook_cell) |cell| cur = try self.prepareHookArray(cell);
+                        }
+                        if (cur != .object and !try self.propGetReturnsRef(eap_obj, prop_name)) {
+                            const msg = try std.fmt.allocPrint(self.allocator, "Indirect modification of {s}::${s} is not allowed", .{ eap_obj.class_name, prop_name });
+                            try self.strings.append(self.allocator, msg);
+                            if (try self.throwBuiltinException("Error", msg)) continue;
+                            return error.RuntimeError;
+                        }
+                    }
                     if (cur == .int or cur == .float or (cur == .bool and cur.bool)) {
                         if (try self.throwBuiltinException("Error", "Cannot use a scalar value as an array")) continue;
                         return error.RuntimeError;
@@ -4939,7 +4995,7 @@ pub const VM = struct {
                     if (cur == .array) {
                         // a referenced property (`$r=&$obj->prop`) is shared on
                         // purpose - write through it in place, never separate
-                        if (self.propIsReferenced(eap_obj, prop_name)) {
+                        if (hook_cell != null or self.propIsReferenced(eap_obj, prop_name)) {
                             self.push(cur);
                             continue;
                         }
@@ -4971,7 +5027,10 @@ pub const VM = struct {
                     new_arr.* = .{};
                     try self.arrays.append(self.allocator, new_arr);
                     // obj.set retains -> refcount 1 (the property slot owns it)
-                    try eap_obj.set(self.allocator, prop_name, .{ .array = new_arr });
+                    if (hook_cell) |cell| {
+                        self.setCell(cell, .{ .array = new_arr });
+                        try self.propagateCellWrite(cell, cell.*);
+                    } else try eap_obj.set(self.allocator, prop_name, .{ .array = new_arr });
                     self.push(.{ .array = new_arr });
                 },
 
@@ -5524,6 +5583,12 @@ pub const VM = struct {
                     const source_name = self.currentChunk().constants.items[source_idx].string.bytes();
                     const obj_val = self.pop();
                     if (obj_val == .object) {
+                        if (!self.inPropHook(obj_val.object, prop_name) and
+                            (self.hasPropHook(obj_val.object.class_name, prop_name, .get) or self.hasPropHook(obj_val.object.class_name, prop_name, .set)))
+                        {
+                            if (try self.throwBuiltinException("Error", "Cannot assign by reference to overloaded object")) continue;
+                            return error.RuntimeError;
+                        }
                         const frame = self.currentFrame();
                         const cell = try self.getOrCreateVarCell(frame, source_name);
                         try self.objectSetOwned(obj_val.object, prop_name, cell.*);
@@ -5546,10 +5611,32 @@ pub const VM = struct {
                         try self.bindRefSlot(&frame.ref_slots, dst_name, c);
                     } else {
                         const obj_ptr = obj_val.object;
+                        if (self.hasPropHook(obj_ptr.class_name, prop_name, .get) and !self.inPropHook(obj_ptr, prop_name) and !try self.propGetReturnsRef(obj_ptr, prop_name)) {
+                            obj_ptr.refcount +%= 1;
+                            defer self.releaseValue(.{ .object = obj_ptr });
+                            _ = self.callPropHook(obj_ptr, prop_name, .get, .null) catch {
+                                if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                return error.RuntimeError;
+                            };
+                            const msg = try std.fmt.allocPrint(self.allocator, "Indirect modification of {s}::${s} is not allowed", .{ obj_ptr.class_name, prop_name });
+                            try self.strings.append(self.allocator, msg);
+                            if (try self.throwBuiltinException("Error", msg)) continue;
+                            return error.RuntimeError;
+                        }
                         const has_prop = obj_ptr.properties.contains(prop_name) or (obj_ptr.slots != null and obj_ptr.getSlotIndex(prop_name) != null);
-                        if (!has_prop and self.hasMethod(obj_ptr.class_name, "__get")) {
+                        const ref_hook = self.hasPropHook(obj_ptr.class_name, prop_name, .get) and !self.inPropHook(obj_ptr, prop_name);
+                        if (ref_hook or (!has_prop and self.hasMethod(obj_ptr.class_name, "__get"))) {
+                            obj_ptr.refcount +%= 1;
+                            defer self.releaseValue(.{ .object = obj_ptr });
                             self.setReturnRef(null);
-                            _ = try self.callMagicGet(obj_ptr, prop_name);
+                            if (ref_hook) {
+                                _ = self.callPropHook(obj_ptr, prop_name, .get, .null) catch {
+                                    if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                    return error.RuntimeError;
+                                };
+                            } else {
+                                _ = try self.callMagicGet(obj_ptr, prop_name);
+                            }
                             if (self.last_return_ref) |cell| {
                                 try self.bindRefSlot(&frame.ref_slots, dst_name, cell);
                                 const owner = try self.ensureRefOwner(frame);
@@ -5563,8 +5650,16 @@ pub const VM = struct {
                                 continue;
                             }
                         }
-                        const cell = try self.newRefCell();
-                        self.setCell(cell, obj_ptr.get(prop_name));
+                        const cell = blk: {
+                            if (self.ref_index) |ri| {
+                                if (ri.prop_rev.get(.{ .object = obj_ptr, .class_name = "", .prop_name = prop_name })) |cells| {
+                                    if (cells.items.len > 0) break :blk cells.items[0];
+                                }
+                            }
+                            const fresh = try self.newRefCell();
+                            self.setCell(fresh, obj_ptr.get(prop_name));
+                            break :blk fresh;
+                        };
 
                         try self.bindRefSlot(&frame.ref_slots, dst_name, cell);
                         try self.regRefObject(try self.ensureRefOwner(frame), cell, obj_ptr, prop_name);
@@ -5589,10 +5684,32 @@ pub const VM = struct {
                         // dupe so the binding's prop_name outlives the temporary
                         const prop_owned = try self.allocator.dupe(u8, prop_str);
                         try self.strings.append(self.allocator, prop_owned);
+                        if (self.hasPropHook(obj_ptr.class_name, prop_owned, .get) and !self.inPropHook(obj_ptr, prop_owned) and !try self.propGetReturnsRef(obj_ptr, prop_owned)) {
+                            obj_ptr.refcount +%= 1;
+                            defer self.releaseValue(.{ .object = obj_ptr });
+                            _ = self.callPropHook(obj_ptr, prop_owned, .get, .null) catch {
+                                if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                return error.RuntimeError;
+                            };
+                            const msg = try std.fmt.allocPrint(self.allocator, "Indirect modification of {s}::${s} is not allowed", .{ obj_ptr.class_name, prop_owned });
+                            try self.strings.append(self.allocator, msg);
+                            if (try self.throwBuiltinException("Error", msg)) continue;
+                            return error.RuntimeError;
+                        }
                         const has_prop = obj_ptr.properties.contains(prop_owned) or (obj_ptr.slots != null and obj_ptr.getSlotIndex(prop_owned) != null);
-                        if (!has_prop and self.hasMethod(obj_ptr.class_name, "__get")) {
+                        const ref_hook = self.hasPropHook(obj_ptr.class_name, prop_owned, .get) and !self.inPropHook(obj_ptr, prop_owned);
+                        if (ref_hook or (!has_prop and self.hasMethod(obj_ptr.class_name, "__get"))) {
+                            obj_ptr.refcount +%= 1;
+                            defer self.releaseValue(.{ .object = obj_ptr });
                             self.setReturnRef(null);
-                            _ = try self.callMagicGet(obj_ptr, prop_owned);
+                            if (ref_hook) {
+                                _ = self.callPropHook(obj_ptr, prop_owned, .get, .null) catch {
+                                    if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                    return error.RuntimeError;
+                                };
+                            } else {
+                                _ = try self.callMagicGet(obj_ptr, prop_owned);
+                            }
                             if (self.last_return_ref) |cell| {
                                 try self.bindRefSlot(&frame.ref_slots, dst_name, cell);
                                 const owner = try self.ensureRefOwner(frame);
@@ -5606,8 +5723,16 @@ pub const VM = struct {
                                 continue;
                             }
                         }
-                        const cell = try self.newRefCell();
-                        self.setCell(cell, obj_ptr.get(prop_owned));
+                        const cell = blk: {
+                            if (self.ref_index) |ri| {
+                                if (ri.prop_rev.get(.{ .object = obj_ptr, .class_name = "", .prop_name = prop_owned })) |cells| {
+                                    if (cells.items.len > 0) break :blk cells.items[0];
+                                }
+                            }
+                            const fresh = try self.newRefCell();
+                            self.setCell(fresh, obj_ptr.get(prop_owned));
+                            break :blk fresh;
+                        };
 
                         try self.bindRefSlot(&frame.ref_slots, dst_name, cell);
                         try self.regRefObject(try self.ensureRefOwner(frame), cell, obj_ptr, prop_owned);
@@ -6126,6 +6251,16 @@ pub const VM = struct {
                     const obj_val = self.pop();
                     if (obj_val == .object) {
                         const obj = obj_val.object;
+                        if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
+                            obj.refcount +%= 1;
+                            defer self.releaseValue(.{ .object = obj });
+                            const result = self.callPropHook(obj, prop_name, .get, .null) catch {
+                                if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                return error.RuntimeError;
+                            };
+                            self.push(.{ .bool = (result orelse .null) != .null });
+                            continue;
+                        }
                         if (obj.properties.contains(prop_name) or (obj.slots != null and obj.getSlotIndex(prop_name) != null)) {
                             self.push(.{ .bool = obj.get(prop_name) != .null });
                         } else if (self.hasMethod(obj.class_name, "__isset")) {
@@ -6144,6 +6279,16 @@ pub const VM = struct {
                     if (obj_val == .object and prop_name_val == .string) {
                         const obj = obj_val.object;
                         const prop_name = prop_name_val.string.bytes();
+                        if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
+                            obj.refcount +%= 1;
+                            defer self.releaseValue(.{ .object = obj });
+                            const result = self.callPropHook(obj, prop_name, .get, .null) catch {
+                                if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                return error.RuntimeError;
+                            };
+                            self.push(.{ .bool = (result orelse .null) != .null });
+                            continue;
+                        }
                         if (obj.properties.contains(prop_name) or (obj.slots != null and obj.getSlotIndex(prop_name) != null)) {
                             self.push(.{ .bool = obj.get(prop_name) != .null });
                         } else if (self.hasMethod(obj.class_name, "__isset")) {
@@ -7030,6 +7175,42 @@ pub const VM = struct {
                         try def.method_attributes.put(self.allocator, ma_name, ma_attrs);
                     }
 
+                    const property_count = self.readU16();
+                    for (0..property_count) |_| {
+                        const prop_name = self.currentChunk().constants.items[self.readU16()].string.bytes();
+                        const type_idx = self.readU16();
+                        const doc_idx = self.readU16();
+                        try def.properties.append(self.allocator, .{
+                            .name = prop_name,
+                            .default = .null,
+                            .is_virtual = true,
+                            .type_str = if (type_idx == 0xffff) "" else self.currentChunk().constants.items[type_idx].string.bytes(),
+                            .doc_comment = if (doc_idx == 0xffff) "" else self.currentChunk().constants.items[doc_idx].string.bytes(),
+                        });
+                        const mask = self.readByte();
+                        for (0..2) |i| {
+                            if (mask & (@as(u8, 1) << @intCast(i)) == 0) continue;
+                            const hook = self.currentChunk().constants.items[self.readU16()].string.bytes();
+                            try idef.methods.append(self.allocator, hook);
+                            try def.methods.put(self.allocator, hook, .{ .name = hook, .arity = @intCast(i), .is_abstract = true });
+                        }
+                        const attrs = try self.readAttributeDefs();
+                        if (attrs.len > 0) try def.property_attributes.put(self.allocator, prop_name, attrs);
+                    }
+                    // Interfaces inherit contracts from every parent, including
+                    // diamonds. Keep local declarations authoritative.
+                    for (idef.parents.items) |parent| {
+                        if (!self.interfaces.contains(parent)) try self.tryAutoload(parent);
+                        if (self.classes.get(parent)) |base| {
+                            _ = base;
+                            if (self.interfaces.get(parent)) |parent_iface| {
+                                for (parent_iface.methods.items) |method| {
+                                    if (std.mem.indexOf(u8, method, "$hook_") != null) try idef.methods.append(self.allocator, method);
+                                }
+                            }
+                        }
+                    }
+
                     if (self.classes.fetchRemove(iface_name)) |old| {
                         var od = old.value;
                         od.deinit(self.allocator);
@@ -7606,13 +7787,17 @@ pub const VM = struct {
                     self.push(.{ .object = obj });
                 },
 
-                .get_prop => {
+                .get_prop, .get_prop_dynamic => {
                     const gp_ip = self.currentFrame().ip;
-                    const name_idx = self.readU16();
-                    const prop_name = self.currentChunk().constants.items[name_idx].string.bytes();
+                    const prop_name = if (op == .get_prop_dynamic) try self.valueToString(self.pop()) else blk: {
+                        const name_idx = self.readU16();
+                        break :blk self.currentChunk().constants.items[name_idx].string.bytes();
+                    };
                     const obj_val = self.pop();
                     if (obj_val == .object) {
                         const obj = obj_val.object;
+                        obj.refcount +%= 1;
+                        defer self.releaseValue(.{ .object = obj });
 
                         if (obj.lazy_initializer != .null) try self.triggerLazyInit(obj);
 
@@ -7632,7 +7817,7 @@ pub const VM = struct {
                         // IC: slot-indexed fast path. skip the cache when the
                         // property was explicitly unset - the slot still holds
                         // a value, but we need to fall through to __get
-                        if (self.ic) |ic| {
+                        if (if (op == .get_prop) self.ic else null) |ic| {
                             const gp_idx = InlineCache.propIndex(@intFromPtr(self.currentChunk()), gp_ip);
                             const gp_entry = &ic.prop[gp_idx];
                             const gp_chunk_key = @intFromPtr(self.currentChunk());
@@ -7701,7 +7886,7 @@ pub const VM = struct {
                                 if (try self.throwBuiltinException("Error", msg)) continue;
                                 return error.RuntimeError;
                             }
-                            if (self.ic) |ic| {
+                            if (if (op == .get_prop) self.ic else null) |ic| {
                                 if (vr.visibility == .public) {
                                     const gp_idx = InlineCache.propIndex(@intFromPtr(self.currentChunk()), gp_ip);
                                     const si = if (obj.slot_layout != null) obj.getSlotIndex(prop_name) orelse @as(u16, 0xFFFF) else @as(u16, 0xFFFF);
@@ -7730,15 +7915,19 @@ pub const VM = struct {
                     }
                 },
 
-                .get_prop_coalesce => {
+                .get_prop_coalesce, .get_prop_coalesce_dynamic => {
                     // non-throwing property read for `??` / `??=`. an
                     // uninitialized typed property reads as a null slot value,
                     // which `??` then routes to the RHS - no error
-                    const name_idx = self.readU16();
-                    const prop_name = self.currentChunk().constants.items[name_idx].string.bytes();
+                    const prop_name = if (op == .get_prop_coalesce_dynamic) try self.valueToString(self.pop()) else blk: {
+                        const name_idx = self.readU16();
+                        break :blk self.currentChunk().constants.items[name_idx].string.bytes();
+                    };
                     const obj_val = self.pop();
                     if (obj_val == .object) {
                         const obj = obj_val.object;
+                        obj.refcount +%= 1;
+                        defer self.releaseValue(.{ .object = obj });
                         if (obj.lazy_initializer != .null) try self.triggerLazyInit(obj);
                         if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
                             const hook_result = self.callPropHook(obj, prop_name, .get, .null) catch {
@@ -7762,6 +7951,16 @@ pub const VM = struct {
                             const cvr = self.findPropertyVisibility(obj.class_name, prop_name);
                             if (!self.checkVisibility(cvr.defining_class, cvr.visibility)) {
                                 if (self.hasMethod(obj.class_name, "__get")) {
+                                    if (self.hasMethod(obj.class_name, "__isset")) {
+                                        const present = self.callMethod(obj, "__isset", &.{.{ .string = Value.String.borrowed(prop_name) }}) catch {
+                                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                            return error.RuntimeError;
+                                        };
+                                        if (!present.isTruthy()) {
+                                            self.push(.null);
+                                            continue;
+                                        }
+                                    }
                                     self.push(try self.callMagicGet(obj, prop_name));
                                 } else {
                                     self.push(.null);
@@ -7770,6 +7969,16 @@ pub const VM = struct {
                                 self.push(val);
                             }
                         } else if (self.hasMethod(obj.class_name, "__get")) {
+                            if (self.hasMethod(obj.class_name, "__isset")) {
+                                const present = self.callMethod(obj, "__isset", &.{.{ .string = Value.String.borrowed(prop_name) }}) catch {
+                                    if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                    return error.RuntimeError;
+                                };
+                                if (!present.isTruthy()) {
+                                    self.push(.null);
+                                    continue;
+                                }
+                            }
                             self.push(try self.callMagicGet(obj, prop_name));
                         } else {
                             self.push(.null);
@@ -7779,50 +7988,12 @@ pub const VM = struct {
                     }
                 },
 
-                .get_prop_dynamic => {
-                    const prop_name_val = self.pop();
-                    const obj_val = self.pop();
-                    if (obj_val == .object and prop_name_val == .string) {
-                        const obj = obj_val.object;
-                        const prop_name = prop_name_val.string.bytes();
-                        const val = obj.get(prop_name);
-                        if (val != .null or obj.properties.contains(prop_name) or (obj.slots != null and obj.getSlotIndex(prop_name) != null)) {
-                            self.push(val);
-                        } else if (self.hasMethod(obj.class_name, "__get")) {
-                            const result = try self.callMagicGet(obj, prop_name);
-                            self.push(result);
-                        } else {
-                            self.push(.null);
-                        }
-                    } else {
-                        self.push(.null);
-                    }
-                },
-
-                .set_prop_dynamic => {
-                    const prop_name_val = self.pop();
-                    const new_val = try self.copyValue(self.pop());
-                    const obj_val = self.pop();
-                    if (obj_val == .object and prop_name_val == .string) {
-                        const obj = obj_val.object;
-                        const prop_name = prop_name_val.string.bytes();
-                        const has_prop = obj.properties.contains(prop_name) or (obj.slots != null and obj.getSlotIndex(prop_name) != null);
-                        if (!has_prop and self.hasMethod(obj.class_name, "__set") and !obj.magic_set_active.contains(prop_name)) {
-                            try obj.magic_set_active.put(self.allocator, prop_name, {});
-                            _ = self.callMethod(obj, "__set", &.{ .{ .string = Value.String.borrowed(prop_name) }, new_val }) catch {};
-                            _ = obj.magic_set_active.remove(prop_name);
-                        } else {
-                            try self.objectSetOwned(obj, prop_name, new_val);
-                            self.syncObjPropRefs(obj, prop_name, new_val);
-                        }
-                    }
-                    self.push(new_val);
-                },
-
-                .set_prop => {
+                .set_prop, .set_prop_dynamic => {
                     const sp_ip = self.currentFrame().ip;
-                    const name_idx = self.readU16();
-                    const prop_name = self.currentChunk().constants.items[name_idx].string.bytes();
+                    const prop_name = if (op == .set_prop_dynamic) try self.valueToString(self.pop()) else blk: {
+                        const name_idx = self.readU16();
+                        break :blk self.currentChunk().constants.items[name_idx].string.bytes();
+                    };
                     // transferArg: clone an array, leave an object raw - the
                     // property store retains the object exactly once (obj.set
                     // on the slow path, retainValue on the IC path)
@@ -7837,6 +8008,8 @@ pub const VM = struct {
                     const obj_val = self.pop();
                     if (obj_val == .object) {
                         const obj = obj_val.object;
+                        obj.refcount +%= 1;
+                        defer self.releaseValue(.{ .object = obj });
 
                         if (obj.lazy_initializer != .null) try self.triggerLazyInit(obj);
 
@@ -7879,7 +8052,7 @@ pub const VM = struct {
                             // fall through to the regular slot/property write
                         }
 
-                        if (self.ic) |ic| {
+                        if (if (op == .set_prop) self.ic else null) |ic| {
                             const sp_idx = InlineCache.propIndex(@intFromPtr(self.currentChunk()), sp_ip);
                             const sp_entry = &ic.prop[sp_idx];
                             if (sp_entry.key == sp_ip and sp_entry.chunk_key == @intFromPtr(self.currentChunk()) and sp_entry.slot_index != 0xFFFF and sp_entry.class_ptr == @intFromPtr(obj.class_name.ptr)) {
@@ -7975,7 +8148,7 @@ pub const VM = struct {
                             // populate IC for slot-indexed writes. typed
                             // properties are cached too - the fast path runs
                             // checkPropertyType when prop_type is set
-                            if (self.ic) |ic| {
+                            if (if (op == .set_prop) self.ic else null) |ic| {
                                 if (vr.visibility == .public and vr.set_visibility == .public) {
                                     const sp_idx = InlineCache.propIndex(@intFromPtr(self.currentChunk()), sp_ip);
                                     const si = if (obj.slot_layout != null) obj.getSlotIndex(prop_name) orelse @as(u16, 0xFFFF) else @as(u16, 0xFFFF);
@@ -10876,6 +11049,16 @@ pub const VM = struct {
         self.retainFrameObjects(self.frame_count - 1);
         if (self.frame_count > self.frame_high_water) self.frame_high_water = self.frame_count;
 
+        const hook_guard_count = self.prop_hook_guard.items.len;
+        if (std.mem.endsWith(u8, gen.func.name, "$hook_get")) {
+            const name_start = if (std.mem.lastIndexOf(u8, gen.func.name, "::")) |sep| sep + 2 else 0;
+            const prop_name = gen.func.name[name_start .. gen.func.name.len - "$hook_get".len];
+            const receiver = self.currentFrame().vars.get("$this") orelse .null;
+            if (receiver == .object) {
+                try self.prop_hook_guard.append(self.allocator, .{ .obj_ptr = @intFromPtr(receiver.object), .prop_name = prop_name });
+            }
+        }
+        defer self.prop_hook_guard.shrinkRetainingCapacity(hook_guard_count);
         self.restoreGeneratorHandlers(gen);
 
         if (gen.ip > 0) {
@@ -11200,6 +11383,17 @@ pub const VM = struct {
         }
     }
 
+    fn valueToString(self: *VM, v: Value) RuntimeError![]const u8 {
+        if (v == .string) return v.string.bytes();
+        if (v == .object) return self.objectToString(v.object);
+        if (v == .array) self.emitWarning("Array to string conversion");
+        var buf = std.ArrayListUnmanaged(u8){};
+        try v.format(&buf, self.allocator);
+        const str = try buf.toOwnedSlice(self.allocator);
+        try self.strings.append(self.allocator, str);
+        return str;
+    }
+
     pub fn objectToString(self: *VM, obj: *PhpObject) RuntimeError![]const u8 {
         const method_name = self.resolveMethod(obj.class_name, "__toString") catch {
             // PHP: 'Object of class X could not be converted to string'.
@@ -11303,6 +11497,8 @@ pub const VM = struct {
         const prop_set_vis = try self.allocator.alloc(ClassDef.Visibility, prop_count);
         const prop_has_set_vis = try self.allocator.alloc(bool, prop_count);
         const prop_readonly = try self.allocator.alloc(bool, prop_count);
+        const prop_virtual = try self.allocator.alloc(bool, prop_count);
+        defer self.allocator.free(prop_virtual);
         const prop_final = try self.allocator.alloc(bool, prop_count);
         const prop_promoted = try self.allocator.alloc(bool, prop_count);
         const prop_type = try self.allocator.alloc([]const u8, prop_count);
@@ -11322,7 +11518,9 @@ pub const VM = struct {
         for (0..prop_count) |pi| {
             const pname_idx = self.readU16();
             prop_names[pi] = self.currentChunk().constants.items[pname_idx].string.bytes();
-            prop_has_default[pi] = self.readByte();
+            const default_flags = self.readByte();
+            prop_has_default[pi] = default_flags & 1;
+            prop_virtual[pi] = (default_flags & 2) != 0;
 
             const vis_byte = self.readByte();
 
@@ -11424,6 +11622,7 @@ pub const VM = struct {
                 .is_readonly = effective_readonly,
                 .is_final = reflection_final,
                 .is_promoted = prop_promoted[pi],
+                .is_virtual = prop_virtual[pi],
                 .type_str = prop_type[pi],
                 .doc_comment = prop_doc[pi],
             });
@@ -11649,7 +11848,7 @@ pub const VM = struct {
             // doesn't `implements Bar` directly)
             var iface_walk_parent: ?[]const u8 = class_name;
             while (iface_walk_parent) |cn| {
-                if (self.classes.get(cn)) |cd| {
+                if (if (std.mem.eql(u8, cn, class_name)) @as(?ClassDef, def) else self.classes.get(cn)) |cd| {
                     for (cd.interfaces.items) |iname| {
                         var current_iface: ?[]const u8 = iname;
                         while (current_iface) |in| {
@@ -11667,24 +11866,44 @@ pub const VM = struct {
             }
             var sa_iter = seen_abstract.iterator();
             while (sa_iter.next()) |se| {
-                // walk parent chain looking for a non-abstract implementation
-                var found_concrete = false;
-                if (def.methods.get(se.key_ptr.*)) |m| {
-                    if (!m.is_abstract) found_concrete = true;
-                }
-                if (!found_concrete) {
-                    var pp: ?[]const u8 = def.parent;
-                    while (pp) |pn2| {
-                        if (self.classes.get(pn2)) |pc| {
-                            if (pc.methods.get(se.key_ptr.*)) |pm| {
-                                if (!pm.is_abstract) {
-                                    found_concrete = true;
-                                    break;
+                if (std.mem.indexOf(u8, se.key_ptr.*, "$hook_") != null) {
+                    if (self.resolvePropertyHook(&def, se.key_ptr.*)) |hook| {
+                        if (!hook.info.is_abstract) continue;
+                    } else {
+                        // Only a declared property can satisfy a hook contract.
+                        const split = std.mem.indexOf(u8, se.key_ptr.*, "$hook_").?;
+                        var current: ?*const ClassDef = &def;
+                        var has_property = false;
+                        while (current) |cls| {
+                            for (cls.properties.items) |prop| {
+                                if (std.mem.eql(u8, prop.name, se.key_ptr.*[0..split])) {
+                                    if (!prop.is_virtual and prop.visibility == .public and
+                                        !(std.mem.endsWith(u8, se.key_ptr.*, "$hook_set") and prop.is_readonly)) has_property = true;
                                 }
                             }
-                            pp = pc.parent;
-                        } else break;
+                            current = if (cls.parent) |parent| self.classes.getPtr(parent) else null;
+                        }
+                        if (has_property) continue;
                     }
+                }
+                // Start with the in-progress definition: it is not in classes yet.
+                // Native methods need not have entries in ClassDef.methods, so
+                // check their registry at each level, but never skip an abstract
+                // redeclaration to reach a concrete implementation further up.
+                var found_concrete = false;
+                var implementation_class: ?*const ClassDef = &def;
+                while (implementation_class) |cls| {
+                    if (cls.methods.get(se.key_ptr.*)) |method| {
+                        found_concrete = !method.is_abstract;
+                        break;
+                    }
+                    const full = try std.fmt.allocPrint(self.allocator, "{s}::{s}", .{ cls.name, se.key_ptr.* });
+                    defer self.allocator.free(full);
+                    if (self.native_fns.contains(full)) {
+                        found_concrete = true;
+                        break;
+                    }
+                    implementation_class = if (cls.parent) |parent| self.classes.getPtr(parent) else null;
                 }
                 if (!found_concrete) {
                     const msg = try std.fmt.allocPrint(self.allocator, "Class {s} contains abstract method {s}::{s} and must therefore be declared abstract or implement it", .{ class_name, se.value_ptr.*, se.key_ptr.* });
@@ -14479,6 +14698,37 @@ pub const VM = struct {
         return name;
     }
 
+    // Adopt the returned source binding, never manufacture storage on a virtual
+    // property. Keep it alive across nested execution and preserve its mirrors.
+    fn takeHookReturnCell(self: *VM) RuntimeError!?*Value {
+        const cell = self.last_return_ref orelse return null;
+        self.bindCell(cell);
+        if (self.last_return_ref_owner != 0) {
+            const ri = try self.refIndex();
+            try ri.transferCell(self.allocator, self.last_return_ref_owner, try self.persistentRefOwner(), cell);
+            ri.releaseOwner(self.allocator, self.last_return_ref_owner);
+            self.last_return_ref_owner = 0;
+        }
+        self.setReturnRef(null);
+        return cell;
+    }
+
+    fn prepareHookArray(self: *VM, cell: *Value) RuntimeError!Value {
+        if (cell.* == .array and cell.array.refcount - cell.array.byref_pins > self.referenceAliasCount(cell)) {
+            const clone = try self.shallowCloneCow(cell.array);
+            self.setCell(cell, .{ .array = clone });
+            try self.propagateCellWrite(cell, cell.*);
+        }
+        return cell.*;
+    }
+
+    fn propGetReturnsRef(self: *VM, obj: *PhpObject, prop_name: []const u8) RuntimeError!bool {
+        const name = self.propHookName(prop_name, .get) orelse return error.OutOfMemory;
+        const full_name = try self.resolveMethod(obj.class_name, name);
+        const func = self.functions.get(full_name) orelse return false;
+        return func.returns_ref;
+    }
+
     pub fn inPropHook(self: *VM, obj: *PhpObject, prop_name: []const u8) bool {
         const obj_id = @intFromPtr(obj);
         for (self.prop_hook_guard.items) |g| {
@@ -14495,7 +14745,7 @@ pub const VM = struct {
         };
         const hook_name = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ prop_name, suffix });
         try self.strings.append(self.allocator, hook_name);
-        if (!self.hasMethod(obj.class_name, hook_name)) return null;
+        if (!self.hasPropHook(obj.class_name, prop_name, if (kind == .get) .get else .set)) return null;
         const obj_id = @intFromPtr(obj);
         try self.prop_hook_guard.append(self.allocator, .{ .obj_ptr = obj_id, .prop_name = prop_name });
         defer {
@@ -14556,7 +14806,7 @@ pub const VM = struct {
         };
         var buf: [256]u8 = undefined;
         const hook_name = std.fmt.bufPrint(&buf, "{s}{s}", .{ prop_name, suffix }) catch return false;
-        const result = self.hasMethod(class_name, hook_name);
+        const result = if (self.classes.getPtr(class_name)) |cls| self.resolvePropertyHook(cls, hook_name) != null else false;
         self.has_hook_cache_class = class_name;
         self.has_hook_cache_prop = prop_name;
         self.has_hook_cache_kind = kind_bit;
@@ -14574,6 +14824,25 @@ pub const VM = struct {
             const parent = cls.parent orelse return;
             if (!self.classes.contains(parent)) self.tryAutoload(parent) catch return;
             current = parent;
+        }
+    }
+
+    // An ordinary redeclaration supplies storage implementations for abstract
+    // hooks, but retains concrete hooks inherited from its ancestors.
+    pub fn resolvePropertyHook(self: *VM, start: *const ClassDef, method: []const u8) ?struct { declaring: []const u8, info: ClassDef.MethodInfo } {
+        const split = std.mem.indexOf(u8, method, "$hook_") orelse return null;
+        const prop_name = method[0..split];
+        var backed_replacement = false;
+        var cls = start;
+        while (true) {
+            if (cls.methods.get(method)) |info| {
+                if (info.is_abstract and backed_replacement) return null;
+                return .{ .declaring = cls.name, .info = info };
+            }
+            for (cls.properties.items) |prop| {
+                if (std.mem.eql(u8, prop.name, prop_name) and !prop.is_virtual) backed_replacement = true;
+            }
+            cls = self.classes.getPtr(cls.parent orelse return null) orelse return null;
         }
     }
 

--- a/src/stdlib/reflection.zig
+++ b/src/stdlib/reflection.zig
@@ -13,6 +13,25 @@ const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
 pub fn register(vm: *VM, a: Allocator) !void {
+    // Unit enum cases are request-lifetime objects, just like RoundingMode.
+    var hook_type = ClassDef{ .name = "PropertyHookType", .is_enum = true, .is_final = true };
+    for ([_][]const u8{ "Get", "Set" }) |name| {
+        const obj = try a.create(PhpObject);
+        vm.next_object_id += 1;
+        obj.* = .{ .class_name = "PropertyHookType", .id = vm.next_object_id };
+        try vm.objects.append(a, obj);
+        try obj.set(a, "name", .{ .string = Value.String.borrowed(name) });
+        VM.objRetain(obj);
+        try hook_type.static_props.put(a, name, .{ .object = obj });
+        try hook_type.constant_names.put(a, name, {});
+        try hook_type.constant_order.append(a, name);
+        try hook_type.case_order.append(a, name);
+    }
+    try hook_type.interfaces.append(a, "UnitEnum");
+    try hook_type.addMethod(a, .{ .name = "cases", .arity = 0, .is_static = true });
+    try vm.classes.put(a, "PropertyHookType", hook_type);
+    try vm.native_fns.put(a, "PropertyHookType::cases", @import("enums.zig").enumCases);
+
     // Reflector marker interface - all Reflection* implement it
     var reflector_iface = @import("../runtime/vm.zig").InterfaceDef{ .name = "Reflector" };
     try reflector_iface.methods.append(a, "__toString");
@@ -561,10 +580,10 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionProperty::isProtectedSet", rpropIsProtectedSet);
     try vm.native_fns.put(a, "ReflectionProperty::isFinal", rpropIsFinal);
     try vm.native_fns.put(a, "ReflectionProperty::isAbstract", rpropIsAbstract);
-    try vm.native_fns.put(a, "ReflectionProperty::hasHooks", reflectionFalse);
-    try vm.native_fns.put(a, "ReflectionProperty::hasHook", reflectionFalse);
+    try vm.native_fns.put(a, "ReflectionProperty::hasHooks", rpropHasHooks);
+    try vm.native_fns.put(a, "ReflectionProperty::hasHook", rpropHasHook);
     try vm.native_fns.put(a, "ReflectionProperty::getHooks", rpropGetHooks);
-    try vm.native_fns.put(a, "ReflectionProperty::getHook", reflectionNoop);
+    try vm.native_fns.put(a, "ReflectionProperty::getHook", rpropGetHook);
     try vm.native_fns.put(a, "ReflectionProperty::isLazy", reflectionFalse);
     try vm.native_fns.put(a, "ReflectionProperty::skipLazyInitialization", reflectionNoop);
     try vm.native_fns.put(a, "ReflectionProperty::getDefaultValue", rpropGetDefaultValue);
@@ -910,6 +929,11 @@ fn findPropertyDef(vm: *VM, class_name: []const u8, prop_name: []const u8) ?Prop
             const synth: ClassDef.PropertyDef = .{ .name = prop_name, .default = v, .has_default = true };
             return .{ .prop = synth, .declaring_class = name, .is_static = true };
         }
+        if (vm.interfaces.get(name)) |iface| {
+            for (iface.parents.items) |parent| {
+                if (findPropertyDef(vm, parent, prop_name)) |result| return result;
+            }
+        }
         current = cls.parent;
     }
     return null;
@@ -1207,6 +1231,7 @@ fn rcGetMethods(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // interface methods (declaration order, abstract by definition)
     if (ctx.vm.interfaces.get(class_name)) |iface| {
         for (iface.methods.items) |method_name| {
+            if (std.mem.indexOf(u8, method_name, "$hook_") != null) continue;
             if (seen.contains(method_name)) continue;
             try seen.put(ctx.allocator, method_name, {});
             const info = ClassDef.MethodInfo{ .name = method_name, .arity = 0, .visibility = .public, .is_abstract = true };
@@ -1225,6 +1250,7 @@ fn rcGetMethods(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (cls.method_order.items.len > 0) {
             for (cls.method_order.items) |method_name| {
                 const info = cls.methods.get(method_name) orelse continue;
+                if (std.mem.indexOf(u8, method_name, "$hook_") != null) continue;
                 if (depth > 0 and info.visibility == .private) continue;
                 if (seen.contains(method_name)) continue;
                 try seen.put(ctx.allocator, method_name, {});
@@ -1238,6 +1264,7 @@ fn rcGetMethods(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             while (it.next()) |entry| {
                 const method_name = entry.key_ptr.*;
                 const info = entry.value_ptr.*;
+                if (std.mem.indexOf(u8, method_name, "$hook_") != null) continue;
                 if (depth > 0 and info.visibility == .private) continue;
                 if (seen.contains(method_name)) continue;
                 try seen.put(ctx.allocator, method_name, {});
@@ -1617,10 +1644,27 @@ fn rcGetProperties(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
                 try arr.append(ctx.allocator, .{ .object = obj });
             }
         }
+        if (ctx.vm.interfaces.contains(name)) {
+            try appendInterfaceProperties(ctx, class_name, name, filter, arr, &seen);
+        }
         current = cls.parent;
         is_own = false;
     }
     return .{ .array = arr };
+}
+
+fn appendInterfaceProperties(ctx: *NativeContext, reflected: []const u8, name: []const u8, filter: i64, arr: *PhpArray, seen: *std.StringHashMapUnmanaged(void)) RuntimeError!void {
+    const iface = ctx.vm.interfaces.get(name) orelse return;
+    for (iface.parents.items) |parent| {
+        const cls = ctx.vm.classes.get(parent) orelse continue;
+        for (cls.properties.items) |prop| {
+            if (seen.contains(prop.name) or !matchPropFilter(filter, prop.visibility, false)) continue;
+            try seen.put(ctx.allocator, prop.name, {});
+            const obj = try buildPropertyObj(ctx, reflected, prop, parent);
+            try arr.append(ctx.allocator, .{ .object = obj });
+        }
+        try appendInterfaceProperties(ctx, reflected, parent, filter, arr, seen);
+    }
 }
 
 fn matchPropFilter(filter: i64, vis: ClassDef.Visibility, is_static: bool) bool {
@@ -2289,7 +2333,7 @@ fn rmGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn rmLookupFunc(ctx: *NativeContext) ?@TypeOf(ctx.vm.functions.get("").?) {
     const this = getThis(ctx) orelse return null;
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return null;
+    const method_name = methodLookupName(this) orelse return null;
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return null;
     var buf: [256]u8 = undefined;
     const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return null;
@@ -2332,14 +2376,20 @@ fn reflectionEmptyString(_: *NativeContext, _: []const Value) RuntimeError!Value
 
 fn rmGetParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const method_name = methodLookupName(this) orelse return .null;
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
 
     var buf: [256]u8 = undefined;
     const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .null;
     const func = ctx.vm.functions.get(key) orelse return .{ .array = try ctx.createArray() };
 
-    return buildParamArray(ctx, func, key);
+    const result = try buildParamArray(ctx, func, key);
+    if (this.get("_hook_method") == .string and result == .array) {
+        for (result.array.entries.items) |entry| {
+            if (entry.value == .object) try entry.value.object.set(ctx.allocator, "_hook_declaring_function", .{ .object = this });
+        }
+    }
+    return result;
 }
 
 fn rmIsPublic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2378,7 +2428,12 @@ fn rmGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value
 
 fn rmGetReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const hook_type = this.get("_hook_return_type");
+    if (hook_type == .string) {
+        if (hook_type.string.bytes().len == 0) return .null;
+        return .{ .object = try createTypeObj(ctx, hook_type.string.bytes(), false, this.get("_declaring_class").string.bytes()) };
+    }
+    const method_name = methodLookupName(this) orelse return .null;
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
 
     var buf: [256]u8 = undefined;
@@ -2392,7 +2447,11 @@ fn rmGetReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn rmHasReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .{ .bool = false };
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+    const hook_type = this.get("_hook_return_type");
+    if (hook_type == .string) {
+        return .{ .bool = hook_type.string.bytes().len > 0 };
+    }
+    const method_name = methodLookupName(this) orelse return .{ .bool = false };
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = false };
 
     var buf: [256]u8 = undefined;
@@ -2571,6 +2630,8 @@ fn rpIsVariadic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn rpGetDeclaringFunction(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
+    const hook = this.get("_hook_declaring_function");
+    if (hook == .object) return hook;
     const func_name = if (this.get("_function") == .string) this.get("_function").string.bytes() else "";
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else "";
     if (declaring.len > 0) {
@@ -3240,8 +3301,80 @@ fn reflectionFalse(_: *NativeContext, _: []const Value) RuntimeError!Value {
     return .{ .bool = false };
 }
 
+fn methodLookupName(obj: *PhpObject) ?[]const u8 {
+    const internal = obj.get("_hook_method");
+    if (internal == .string) return internal.string.bytes();
+    const name = obj.get("name");
+    return if (name == .string) name.string.bytes() else null;
+}
+
+const ReflectedHook = struct {
+    declaring: []const u8,
+    info: ClassDef.MethodInfo,
+};
+
+fn lookupPropertyHook(ctx: *NativeContext, kind: []const u8) ?ReflectedHook {
+    const this = getThis(ctx) orelse return null;
+    const name = this.get("name");
+    const declaring = this.get("_declaring_class");
+    if (name != .string or declaring != .string) return null;
+    var buf: [512]u8 = undefined;
+    const method = std.fmt.bufPrint(&buf, "{s}$hook_{s}", .{ name.string.bytes(), kind }) catch return null;
+    const cls = ctx.vm.classes.getPtr(declaring.string.bytes()) orelse return null;
+    const hook = ctx.vm.resolvePropertyHook(cls, method) orelse return null;
+    return .{ .declaring = hook.declaring, .info = hook.info };
+}
+
+fn hookKind(ctx: *NativeContext, args: []const Value) RuntimeError![]const u8 {
+    if (args.len > 0 and args[0] == .object and std.mem.eql(u8, args[0].object.class_name, "PropertyHookType")) {
+        const name = args[0].object.get("name");
+        if (name == .string) {
+            if (std.mem.eql(u8, name.string.bytes(), "Get")) return "get";
+            if (std.mem.eql(u8, name.string.bytes(), "Set")) return "set";
+        }
+    }
+    _ = try ctx.vm.throwBuiltinException("TypeError", "Argument #1 ($type) must be of type PropertyHookType");
+    return error.RuntimeError;
+}
+
+fn buildHookObj(ctx: *NativeContext, hook: ReflectedHook, kind: []const u8) !*PhpObject {
+    const this = getThis(ctx).?;
+    var info = hook.info;
+    // PHP exposes hook ReflectionMethods as public, even on private properties.
+    info.visibility = .public;
+    const obj = try buildMethodObj(ctx, hook.declaring, hook.info.name, info, hook.declaring);
+    const display = try std.fmt.allocPrint(ctx.allocator, "${s}::{s}", .{ this.get("name").string.bytes(), kind });
+    try ctx.strings.append(ctx.allocator, display);
+    try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(display) });
+    try obj.set(ctx.allocator, "_hook_method", .{ .string = Value.String.borrowed(hook.info.name) });
+    try obj.set(ctx.allocator, "_hook_property", this.get("name"));
+    const prop = findPropertyDef(ctx.vm, hook.declaring, this.get("name").string.bytes());
+    const return_type = if (std.mem.eql(u8, kind, "set")) "void" else if (prop) |p| p.prop.type_str else "";
+    try obj.set(ctx.allocator, "_hook_return_type", .{ .string = Value.String.borrowed(return_type) });
+    return obj;
+}
+
+fn rpropHasHooks(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    return .{ .bool = lookupPropertyHook(ctx, "get") != null or lookupPropertyHook(ctx, "set") != null };
+}
+
+fn rpropHasHook(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    return .{ .bool = lookupPropertyHook(ctx, try hookKind(ctx, args)) != null };
+}
+
+fn rpropGetHook(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const kind = try hookKind(ctx, args);
+    const hook = lookupPropertyHook(ctx, kind) orelse return .null;
+    return .{ .object = try buildHookObj(ctx, hook, kind) };
+}
+
 fn rpropGetHooks(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const arr = try ctx.createArray();
+    for ([_][]const u8{ "get", "set" }) |kind| {
+        if (lookupPropertyHook(ctx, kind)) |hook| {
+            try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(kind) }, .{ .object = try buildHookObj(ctx, hook, kind) });
+        }
+    }
     return .{ .array = arr };
 }
 
@@ -3543,7 +3676,12 @@ fn rpropIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     return .{ .bool = implicit_private_set_final };
 }
 
-fn rpropIsAbstract(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rpropIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    for ([_][]const u8{ "get", "set" }) |kind| {
+        if (lookupPropertyHook(ctx, kind)) |hook| {
+            if (hook.info.is_abstract) return .{ .bool = true };
+        }
+    }
     return .{ .bool = false };
 }
 
@@ -3697,13 +3835,28 @@ fn rpropGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value 
     return .{ .bool = false };
 }
 
-fn rpropIsVirtual(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rpropIsVirtual(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    const this = getThis(ctx) orelse return .null;
+    const dc = this.get("_declaring_class");
+    const name = this.get("name");
+    if (dc == .string and name == .string) {
+        if (ctx.vm.classes.get(dc.string.bytes())) |cls| {
+            for (cls.properties.items) |p| {
+                if (std.mem.eql(u8, p.name, name.string.bytes())) return .{ .bool = p.is_virtual };
+            }
+        }
+    }
     return .{ .bool = false };
 }
 
 fn rmInvoke(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const guard_count = ctx.vm.prop_hook_guard.items.len;
+    defer ctx.vm.prop_hook_guard.shrinkRetainingCapacity(guard_count);
+    if (this.get("_hook_property") == .string and args.len > 0 and args[0] == .object) {
+        try ctx.vm.prop_hook_guard.append(ctx.allocator, .{ .obj_ptr = @intFromPtr(args[0].object), .prop_name = this.get("_hook_property").string.bytes() });
+    }
+    const method_name = methodLookupName(this) orelse return .null;
     if (args.len > 0 and args[0] == .object) {
         return ctx.callMethod(args[0].object, method_name, args[1..]) catch .null;
     }
@@ -3717,7 +3870,12 @@ fn rmInvoke(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn rmInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const guard_count = ctx.vm.prop_hook_guard.items.len;
+    defer ctx.vm.prop_hook_guard.shrinkRetainingCapacity(guard_count);
+    if (this.get("_hook_property") == .string and args.len > 0 and args[0] == .object) {
+        try ctx.vm.prop_hook_guard.append(ctx.allocator, .{ .obj_ptr = @intFromPtr(args[0].object), .prop_name = this.get("_hook_property").string.bytes() });
+    }
+    const method_name = methodLookupName(this) orelse return .null;
     if (args.len < 1) return .null;
     const target = args[0];
 
@@ -3740,7 +3898,7 @@ fn rmInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn rmGetClosure(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const method_name = methodLookupName(this) orelse return .null;
     if (args.len < 1 or args[0] != .object) return .null;
 
     const arr = try ctx.createArray();
@@ -3751,7 +3909,7 @@ fn rmGetClosure(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn rmIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .{ .bool = false };
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+    const method_name = methodLookupName(this) orelse return .{ .bool = false };
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = false };
 
     if (ctx.vm.interfaces.contains(declaring)) return .{ .bool = true };
@@ -3770,7 +3928,7 @@ fn rmIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn rmIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .{ .bool = false };
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+    const method_name = methodLookupName(this) orelse return .{ .bool = false };
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = false };
     const cls = ctx.vm.classes.get(declaring) orelse return .{ .bool = false };
     const m = cls.methods.get(method_name) orelse return .{ .bool = false };
@@ -3779,7 +3937,7 @@ fn rmIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn rmFullName(ctx: *NativeContext) ?[]const u8 {
     const this = getThis(ctx) orelse return null;
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return null;
+    const method_name = methodLookupName(this) orelse return null;
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return null;
     var buf: [256]u8 = undefined;
     const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return null;
@@ -3802,11 +3960,11 @@ fn rmIsGenerator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn rmGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .{ .int = 0 };
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .int = 0 };
+    const method_name = methodLookupName(this) orelse return .{ .int = 0 };
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .int = 0 };
     const cls = ctx.vm.classes.get(declaring) orelse return .{ .int = 0 };
     const info = cls.methods.get(method_name) orelse return .{ .int = 0 };
-    return .{ .int = methodModifiers(info) };
+    return .{ .int = if (this.get("_hook_method") == .string) (methodModifiers(info) & ~@as(i64, 7)) | 1 else methodModifiers(info) };
 }
 
 fn reflectionGetModifierNames(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -3824,7 +3982,7 @@ fn reflectionGetModifierNames(ctx: *NativeContext, args: []const Value) RuntimeE
 
 fn rmGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const method_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .array = try ctx.createArray() };
+    const method_name = methodLookupName(this) orelse return .{ .array = try ctx.createArray() };
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .array = try ctx.createArray() };
     const cls = ctx.vm.classes.get(declaring) orelse return .{ .array = try ctx.createArray() };
     const attrs = cls.method_attributes.get(method_name) orelse return .{ .array = try ctx.createArray() };

--- a/src/stdlib/serialize.zig
+++ b/src/stdlib/serialize.zig
@@ -10,9 +10,11 @@ const RuntimeError = error{ RuntimeError, OutOfMemory };
 const SerCtx = struct {
     objects: std.AutoHashMapUnmanaged(*PhpObject, usize) = .{},
     arrays: std.AutoHashMapUnmanaged(*PhpArray, usize) = .{},
+    cells: std.AutoHashMapUnmanaged(*Value, usize) = .{},
     next_slot: usize = 1,
 
     fn deinit(self: *SerCtx, a: Allocator) void {
+        self.cells.deinit(a);
         self.objects.deinit(a);
         self.arrays.deinit(a);
     }
@@ -24,8 +26,11 @@ const AllowedClasses = union(enum) {
     list: []const []const u8,
 };
 
+const ArrayTarget = struct { array: *PhpArray, key: PhpArray.Key };
+
 const UnserCtx = struct {
     slots: std.ArrayListUnmanaged(Value) = .{},
+    array_targets: std.AutoHashMapUnmanaged(usize, ArrayTarget) = .{},
     allowed: AllowedClasses = .all,
     // set when we threw a user-visible exception (e.g. TypeError on a typed
     // property) so native_unserialize knows to propagate the error instead
@@ -43,6 +48,7 @@ const UnserCtx = struct {
     err_pos: usize = 0,
 
     fn deinit(self: *UnserCtx, a: Allocator) void {
+        self.array_targets.deinit(a);
         self.slots.deinit(a);
     }
 
@@ -287,6 +293,7 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
                 return;
             }
             try sctx.arrays.put(a, arr, sctx.next_slot - 1);
+            defer _ = sctx.arrays.remove(arr);
             try buf.appendSlice(a, "a:");
             var tmp: [20]u8 = undefined;
             const len_s = std.fmt.bufPrint(&tmp, "{d}", .{arr.entries.items.len}) catch return;
@@ -302,6 +309,15 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
                         try buf.append(a, ';');
                     },
                     .string => |s| try emitLenString(buf, a, s.bytes()),
+                }
+                if (if (entry.ref) |cell| (if (@import("../runtime/value.zig").cellOf(cell).binders > 1) cell else null) else null) |cell| {
+                    if (sctx.cells.get(cell)) |id| {
+                        const ref = try std.fmt.allocPrint(a, "R:{d};", .{id});
+                        defer a.free(ref);
+                        try buf.appendSlice(a, ref);
+                        continue;
+                    }
+                    try sctx.cells.put(a, cell, sctx.next_slot);
                 }
                 try serializeValue(ctx, buf, sctx, entry.value);
             }
@@ -368,10 +384,6 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
             // checks Serializable first only if __serialize is absent. handle
             // the Serializable path here so it precedes the regular property
             // serialization but does not override __serialize/__sleep below
-            // a class that declares Serializable but provides no serialize()
-            // method (e.g. ArrayObject in PHP 8.4 - the interface is listed for
-            // BC but actual serialization goes through the default property path)
-            // falls through to default object serialization
             if (!ctx.vm.hasMethod(obj.class_name, "__serialize") and ctx.vm.isInstanceOf(obj.class_name, "Serializable") and ctx.vm.hasMethod(obj.class_name, "serialize")) {
                 const ser_result = try ctx.vm.callMethod(obj, "serialize", &.{});
                 const payload: []const u8 = if (ser_result == .string) ser_result.string.bytes() else "";
@@ -552,6 +564,9 @@ fn unserializeValue(ctx: *NativeContext, uctx: *UnserCtx, s: []const u8, pos: us
         return error.RuntimeError;
     }
 
+    errdefer if (uctx.err_pos == 0) {
+        uctx.err_pos = pos;
+    };
     switch (s[pos]) {
         'N' => {
             if (pos + 1 < s.len and s[pos + 1] == ';') {
@@ -619,16 +634,30 @@ fn unserializeValue(ctx: *NativeContext, uctx: *UnserCtx, s: []const u8, pos: us
                 p = key_result.pos;
                 uctx.slots.items.len = key_slots_before;
 
+                const value_pos = p;
+                const value_slot = uctx.slots.items.len;
                 const val_result = try unserializeValue(ctx, uctx, s, p);
                 p = val_result.pos;
                 const key: PhpArray.Key = switch (key_result.value) {
                     .int => |i| .{ .int = i },
                     .string => |str| .{ .string = str },
-                    else => .{ .int = 0 },
+                    else => return error.RuntimeError,
                 };
                 try arr.set(ctx.allocator, key, val_result.value);
+                if (s[value_pos] == 'R') {
+                    const id = try std.fmt.parseInt(usize, s[value_pos + 2 .. p - 1], 10);
+                    if (uctx.array_targets.get(id - 1)) |target| {
+                        try bindDecodedArrayReference(ctx, target.array, target.key, arr, key);
+                    }
+                } else {
+                    try uctx.array_targets.put(ctx.allocator, value_slot, .{ .array = arr, .key = key });
+                }
             }
-            if (p < s.len and s[p] == '}') p += 1;
+            if (p >= s.len or s[p] != '}') {
+                uctx.err_pos = p;
+                return error.RuntimeError;
+            }
+            p += 1;
             return .{ .value = .{ .array = arr }, .pos = p };
         },
         'E' => {
@@ -750,7 +779,11 @@ fn unserializeValue(ctx: *NativeContext, uctx: *UnserCtx, s: []const u8, pos: us
                 try obj.set(ctx.allocator, "__size", .{ .int = @intCast(prop_count) });
                 try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
             }
-            if (p < s.len and s[p] == '}') p += 1;
+            if (p >= s.len or s[p] != '}') {
+                uctx.err_pos = p;
+                return error.RuntimeError;
+            }
+            p += 1;
 
             if (has_unserialize) {
                 if (collected) |arr| {
@@ -779,7 +812,11 @@ fn unserializeValue(ctx: *NativeContext, uctx: *UnserCtx, s: []const u8, pos: us
             if (data_start + data_len > s.len) return error.RuntimeError;
             const payload = s[data_start .. data_start + data_len];
             p = data_start + data_len;
-            if (p < s.len and s[p] == '}') p += 1;
+            if (p >= s.len or s[p] != '}') {
+                uctx.err_pos = p;
+                return error.RuntimeError;
+            }
+            p += 1;
 
             const obj = try ctx.createObject(class_name);
             const slot_idx = try uctx.reserve(ctx.allocator);
@@ -801,7 +838,8 @@ fn unserializeValue(ctx: *NativeContext, uctx: *UnserCtx, s: []const u8, pos: us
             const idx = std.fmt.parseInt(usize, s[start..end], 10) catch return error.RuntimeError;
             if (idx == 0 or idx > uctx.slots.items.len) return error.RuntimeError;
             const v = uctx.slots.items[idx - 1];
-            try uctx.slots.append(ctx.allocator, v);
+            if (s[pos] == 'r' and v != .object) return error.RuntimeError;
+            if (s[pos] == 'r') try uctx.slots.append(ctx.allocator, v);
             return .{ .value = v, .pos = end + 1 };
         },
         else => return error.RuntimeError,
@@ -823,4 +861,193 @@ fn parseString(s: []const u8, pos: usize) !StringResult {
     const end = str_start + str_len;
     if (end + 1 >= s.len or s[end] != '"' or s[end + 1] != ';') return error.RuntimeError;
     return .{ .str = str, .pos = end + 2 };
+}
+
+// SPL's legacy Serializable stream has one reference table spanning flags,
+// storage, and members (the separators themselves consume no reference IDs).
+pub fn serializeSplArray(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    errdefer buf.deinit(ctx.allocator);
+    var refs: SerCtx = .{};
+    defer refs.deinit(ctx.allocator);
+    try buf.appendSlice(ctx.allocator, "x:");
+    try serializeValue(ctx, &buf, &refs, obj.get("__flags"));
+    const flags = obj.get("__flags").toInt();
+    if ((flags & 16777216) == 0) {
+        try serializeValue(ctx, &buf, &refs, obj.get("__data"));
+        try buf.appendSlice(ctx.allocator, ";");
+    }
+    try buf.appendSlice(ctx.allocator, "m:");
+    const members = try splMembers(ctx, obj);
+    try serializeValue(ctx, &buf, &refs, .{ .array = members });
+    const result = try buf.toOwnedSlice(ctx.allocator);
+    try ctx.strings.append(ctx.allocator, result);
+    return .{ .string = Value.String.borrowed(result) };
+}
+
+fn splInternal(name: []const u8) bool {
+    return std.mem.eql(u8, name, "__data") or std.mem.eql(u8, name, "__flags") or
+        std.mem.eql(u8, name, "__cursor") or std.mem.eql(u8, name, "__iter_class");
+}
+
+fn splMember(ctx: *NativeContext, obj: *PhpObject, members: *PhpArray, name: []const u8, val: Value) !void {
+    if (splInternal(name) or obj.isUnset(name)) return;
+    const cls = ctx.vm.classes.get(obj.class_name);
+    const vis = if (cls) |c| findPropertyVisibility(c, name) else .public;
+    const key = switch (vis) {
+        .public => name,
+        .protected => try std.fmt.allocPrint(ctx.allocator, "\x00*\x00{s}", .{name}),
+        .private => try std.fmt.allocPrint(ctx.allocator, "\x00{s}\x00{s}", .{ obj.class_name, name }),
+    };
+    if (vis != .public) try ctx.strings.append(ctx.allocator, @constCast(key));
+    try members.set(ctx.allocator, .{ .string = Value.String.borrowed(key) }, val);
+}
+
+fn splMembers(ctx: *NativeContext, obj: *PhpObject) !*PhpArray {
+    const members = try ctx.createArray();
+    if (obj.slot_layout) |layout| {
+        if (obj.slots) |slots| {
+            for (layout.names, 0..) |name, i| try splMember(ctx, obj, members, name, slots[i]);
+        }
+    }
+    var it = obj.properties.iterator();
+    while (it.next()) |entry| try splMember(ctx, obj, members, entry.key_ptr.*, entry.value_ptr.*);
+    return members;
+}
+
+pub fn unserializeSplArray(ctx: *NativeContext, obj: *PhpObject, s: []const u8) RuntimeError!Value {
+    if (s.len == 0) return .null; // PHP treats an empty payload as a no-op.
+    var refs: UnserCtx = .{};
+    defer refs.deinit(ctx.allocator);
+    var pos: usize = 0;
+    parseSplArray(ctx, obj, &refs, s, &pos) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        if (refs.threw or ctx.vm.pending_exception != null) return error.RuntimeError;
+        const msg = try std.fmt.allocPrint(ctx.allocator, "Error at offset {d} of {d} bytes", .{ @max(pos, refs.err_pos), s.len });
+        try ctx.strings.append(ctx.allocator, msg);
+        try ctx.vm.setPendingException("UnexpectedValueException", msg);
+        return error.RuntimeError;
+    };
+    return .null;
+}
+
+fn parseSplArray(ctx: *NativeContext, obj: *PhpObject, refs: *UnserCtx, s: []const u8, pos: *usize) !void {
+    if (!std.mem.startsWith(u8, s, "x:")) return error.RuntimeError;
+    pos.* = 2;
+    const flags = try unserializeValue(ctx, refs, s, pos.*);
+    pos.* = flags.pos;
+    if (flags.value != .int) return error.RuntimeError;
+    var storage: Value = .{ .object = obj };
+    if ((flags.value.int & 16777216) == 0) {
+        if (pos.* >= s.len or (s[pos.*] != 'a' and s[pos.*] != 'O' and s[pos.*] != 'C' and s[pos.*] != 'r')) return error.RuntimeError;
+        const parsed = try unserializeValue(ctx, refs, s, pos.*);
+        pos.* = parsed.pos;
+        storage = parsed.value;
+        if (storage != .array and storage != .object) return error.RuntimeError;
+        if (pos.* >= s.len or s[pos.*] != ';') return error.RuntimeError;
+        pos.* += 1;
+    }
+    if (!std.mem.startsWith(u8, s[pos.*..], "m:")) return error.RuntimeError;
+    pos.* += 2;
+    const members = try unserializeValue(ctx, refs, s, pos.*);
+    pos.* = members.pos;
+    if (members.value != .array) return error.RuntimeError;
+    try obj.set(ctx.allocator, "__flags", flags.value);
+    try obj.set(ctx.allocator, "__data", storage);
+    try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
+    for (members.value.array.entries.items) |entry| {
+        if (entry.key == .string) {
+            const name = stripVisibilityPrefix(entry.key.string.bytes());
+            if (!splInternal(name)) try obj.set(ctx.allocator, name, entry.value);
+        }
+    }
+    // Trailing bytes are intentionally ignored, as in PHP 8.5.
+}
+
+pub fn splArrayState(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
+    const state = try ctx.createArray();
+    try state.append(ctx.allocator, obj.get("__flags"));
+    const data = obj.get("__data");
+    // __serialize exposes a value snapshot, not the mutable internal table.
+    try state.append(ctx.allocator, if (data == .array) .{ .array = try splStorageSnapshot(ctx, data.array) } else data);
+    try state.append(ctx.allocator, .{ .array = try splMembers(ctx, obj) });
+    try state.append(ctx.allocator, obj.get("__iter_class"));
+    return .{ .array = state };
+}
+
+pub fn restoreSplArrayState(ctx: *NativeContext, obj: *PhpObject, state: Value) RuntimeError!Value {
+    if (state != .array) return error.RuntimeError;
+    const flags = state.array.get(.{ .int = 0 });
+    const storage = state.array.get(.{ .int = 1 });
+    const members = state.array.get(.{ .int = 2 });
+    const iterator = state.array.get(.{ .int = 3 });
+    if (flags != .int or members != .array or (iterator != .null and iterator != .string)) {
+        try ctx.vm.setPendingException("UnexpectedValueException", "Incomplete or ill-typed serialization data");
+        return error.RuntimeError;
+    }
+    if (storage != .array and storage != .object) {
+        try ctx.vm.setPendingException("InvalidArgumentException", "Passed variable is not an array or object");
+        return error.RuntimeError;
+    }
+    if (iterator == .string and !ctx.vm.isInstanceOf(iterator.string.bytes(), "Iterator")) {
+        const msg = try std.fmt.allocPrint(ctx.allocator, "Cannot deserialize ArrayObject with iterator class '{s}'; this class does not implement the Iterator interface", .{iterator.string.bytes()});
+        try ctx.strings.append(ctx.allocator, msg);
+        try ctx.vm.setPendingException("UnexpectedValueException", msg);
+        return error.RuntimeError;
+    }
+    try obj.set(ctx.allocator, "__flags", flags);
+    try obj.set(ctx.allocator, "__data", storage);
+    try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
+    try obj.set(ctx.allocator, "__iter_class", iterator);
+    for (members.array.entries.items) |entry| {
+        if (entry.key == .string) {
+            const name = stripVisibilityPrefix(entry.key.string.bytes());
+            if (!splInternal(name)) try obj.set(ctx.allocator, name, entry.value);
+        }
+    }
+    return .null;
+}
+
+// Decode R: aliases into the same owning cells/registry used by VM array
+// references. The registry is request-local; no serializer state escapes.
+fn bindDecodedArrayReference(ctx: *NativeContext, source: *PhpArray, source_key: PhpArray.Key, dest: *PhpArray, dest_key: PhpArray.Key) !void {
+    const values = @import("../runtime/value.zig");
+    const first = source.getPtr(source_key) orelse return;
+    const cell = first.ref orelse blk: {
+        const owner = try ctx.allocator.create(values.RefCell);
+        owner.* = .{};
+        try ctx.vm.ref_cells.append(ctx.allocator, owner);
+        ctx.vm.setCell(&owner.value, first.value);
+        break :blk &owner.value;
+    };
+    if (ctx.vm.ref_index == null) {
+        const index = try ctx.allocator.create(values.RefIndex);
+        index.* = .{};
+        ctx.vm.ref_index = index;
+    }
+    const index = ctx.vm.ref_index.?;
+    if (ctx.vm.persistent_ref_owner == 0) ctx.vm.persistent_ref_owner = index.createOwner();
+    const arrays = [_]*PhpArray{ source, dest };
+    const keys = [_]PhpArray.Key{ source_key, dest_key };
+    for (arrays, keys) |array, key| {
+        const entry = array.getPtr(key) orelse continue;
+        if (entry.ref == cell) continue;
+        entry.ref = cell;
+        values.cellOf(cell).binders += 1;
+        try ctx.vm.array_ref_bindings.append(ctx.allocator, .{ .cell = cell, .array = array, .key = key });
+        try index.addOwned(ctx.allocator, ctx.vm.persistent_ref_owner, cell, .{ .array = .{ .array = array, .key = key } });
+    }
+    ctx.vm.array_ref_active = true;
+}
+
+fn splStorageSnapshot(ctx: *NativeContext, source: *PhpArray) !*PhpArray {
+    const copy = try ctx.createArray();
+    for (source.entries.items) |entry| {
+        try copy.set(ctx.allocator, entry.key, entry.value);
+        if (entry.ref) |cell| {
+            if (@import("../runtime/value.zig").cellOf(cell).binders > 1)
+                try bindDecodedArrayReference(ctx, source, entry.key, copy, entry.key);
+        }
+    }
+    return copy;
 }

--- a/src/stdlib/spl.zig
+++ b/src/stdlib/spl.zig
@@ -190,8 +190,16 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try ao_def.static_props.put(a, "ARRAY_AS_PROPS", .{ .int = 2 });
     try ao_def.constant_names.put(a, "STD_PROP_LIST", {});
     try ao_def.constant_names.put(a, "ARRAY_AS_PROPS", {});
+    try ao_def.methods.put(a, "__serialize", .{ .name = "__serialize", .arity = 0 });
+    try ao_def.methods.put(a, "__unserialize", .{ .name = "__unserialize", .arity = 1 });
+    try ao_def.methods.put(a, "serialize", .{ .name = "serialize", .arity = 0 });
+    try ao_def.methods.put(a, "unserialize", .{ .name = "unserialize", .arity = 1 });
     try vm.classes.put(a, "ArrayObject", ao_def);
 
+    try vm.native_fns.put(a, "ArrayObject::__serialize", aoSerializeState);
+    try vm.native_fns.put(a, "ArrayObject::__unserialize", aoUnserializeState);
+    try vm.native_fns.put(a, "ArrayObject::serialize", aoSerialize);
+    try vm.native_fns.put(a, "ArrayObject::unserialize", aoUnserialize);
     try vm.native_fns.put(a, "ArrayObject::__construct", aoConstruct);
     try vm.native_fns.put(a, "ArrayObject::offsetGet", aoOffsetGet);
     try vm.native_fns.put(a, "ArrayObject::offsetSet", aoOffsetSet);
@@ -219,6 +227,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
 
     // ArrayIterator
     var ai_def = ClassDef{ .name = "ArrayIterator" };
+    try ai_def.interfaces.append(a, "Serializable");
     try ai_def.interfaces.append(a, "Iterator");
     try ai_def.interfaces.append(a, "Countable");
     try ai_def.interfaces.append(a, "ArrayAccess");
@@ -244,8 +253,16 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try ai_def.methods.put(a, "natsort", .{ .name = "natsort", .arity = 0 });
     try ai_def.methods.put(a, "natcasesort", .{ .name = "natcasesort", .arity = 0 });
     try ai_def.methods.put(a, "seek", .{ .name = "seek", .arity = 1 });
+    try ai_def.methods.put(a, "__serialize", .{ .name = "__serialize", .arity = 0 });
+    try ai_def.methods.put(a, "__unserialize", .{ .name = "__unserialize", .arity = 1 });
+    try ai_def.methods.put(a, "serialize", .{ .name = "serialize", .arity = 0 });
+    try ai_def.methods.put(a, "unserialize", .{ .name = "unserialize", .arity = 1 });
     try vm.classes.put(a, "ArrayIterator", ai_def);
 
+    try vm.native_fns.put(a, "ArrayIterator::__serialize", aoSerializeState);
+    try vm.native_fns.put(a, "ArrayIterator::__unserialize", aoUnserializeState);
+    try vm.native_fns.put(a, "ArrayIterator::serialize", aoSerialize);
+    try vm.native_fns.put(a, "ArrayIterator::unserialize", aoUnserialize);
     try vm.native_fns.put(a, "ArrayIterator::__construct", aiConstruct);
     try vm.native_fns.put(a, "ArrayIterator::rewind", aiRewind);
     try vm.native_fns.put(a, "ArrayIterator::current", aiCurrent);
@@ -871,9 +888,39 @@ fn stackToArray(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 // --- ArrayObject ---
 
+fn aoSerializeState(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    const obj = getThis(ctx) orelse return .null;
+    if (obj.get("__data") == .null) _ = try ensureData(ctx, obj);
+    return @import("serialize.zig").splArrayState(ctx, obj);
+}
+
+fn aoUnserializeState(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const obj = getThis(ctx) orelse return .null;
+    if (args.len == 0 or args[0] != .array) {
+        try ctx.vm.setPendingException("TypeError", "__unserialize(): Argument #1 ($data) must be of type array");
+        return error.RuntimeError;
+    }
+    return @import("serialize.zig").restoreSplArrayState(ctx, obj, args[0]);
+}
+
+fn aoSerialize(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    const obj = getThis(ctx) orelse return .null;
+    if (obj.get("__data") == .null) _ = try ensureData(ctx, obj);
+    return @import("serialize.zig").serializeSplArray(ctx, obj);
+}
+
+fn aoUnserialize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const obj = getThis(ctx) orelse return .null;
+    if (args.len == 0 or args[0] != .string) {
+        try ctx.vm.setPendingException("TypeError", "unserialize(): Argument #1 ($data) must be of type string");
+        return error.RuntimeError;
+    }
+    return @import("serialize.zig").unserializeSplArray(ctx, obj, args[0].string.bytes());
+}
+
 fn aoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
-    if (args.len >= 1 and args[0] == .array) {
+    if (args.len >= 1 and (args[0] == .array or args[0] == .object)) {
         try obj.set(ctx.allocator, "__data", args[0]);
     } else {
         _ = try ensureData(ctx, obj);
@@ -941,6 +988,8 @@ fn aoMagicUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn aoOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
+    if (args.len > 0 and obj.get("__data") == .object and args[0] == .string)
+        return obj.get("__data").object.get(args[0].string.bytes());
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
     return arr.get(args[0].toArrayKey());
@@ -953,6 +1002,7 @@ fn aoOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args[0] == .null) {
         try arr.append(ctx.allocator, args[1]);
     } else {
+        detachSplReference(ctx, arr, args[0].toArrayKey());
         try arr.set(ctx.allocator, args[0].toArrayKey(), args[1]);
     }
     return .null;
@@ -999,6 +1049,18 @@ fn aoAppend(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn aoGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
+    if (obj.get("__data") == .object) {
+        const storage = obj.get("__data").object;
+        const copy = try ctx.createArray();
+        if (storage.slot_layout) |layout| {
+            if (storage.slots) |slots| {
+                for (layout.names, 0..) |name, i| try copy.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, slots[i]);
+            }
+        }
+        var it = storage.properties.iterator();
+        while (it.next()) |entry| try copy.set(ctx.allocator, .{ .string = Value.String.borrowed(entry.key_ptr.*) }, entry.value_ptr.*);
+        return .{ .array = copy };
+    }
     const arr = getData(obj) orelse {
         const empty = try ctx.allocator.create(PhpArray);
         empty.* = .{};
@@ -1139,13 +1201,13 @@ fn aoGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn aiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
-    if (args.len >= 1 and args[0] == .array) {
+    if (args.len >= 1 and (args[0] == .array or args[0] == .object)) {
         try obj.set(ctx.allocator, "__data", args[0]);
     } else {
         _ = try ensureData(ctx, obj);
     }
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    try obj.set(ctx.allocator, "__flags", .{ .int = 0 });
+    try obj.set(ctx.allocator, "__flags", .{ .int = if (args.len >= 2) args[1].toInt() else 0 });
     return .null;
 }
 
@@ -1209,6 +1271,8 @@ fn aiCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn aiOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
+    if (args.len > 0 and obj.get("__data") == .object and args[0] == .string)
+        return obj.get("__data").object.get(args[0].string.bytes());
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
     return arr.get(args[0].toArrayKey());
@@ -1221,6 +1285,7 @@ fn aiOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args[0] == .null) {
         try arr.append(ctx.allocator, args[1]);
     } else {
+        detachSplReference(ctx, arr, args[0].toArrayKey());
         try arr.set(ctx.allocator, args[0].toArrayKey(), args[1]);
     }
     return .null;
@@ -1254,6 +1319,18 @@ fn aiOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn aiGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
+    if (obj.get("__data") == .object) {
+        const storage = obj.get("__data").object;
+        const copy = try ctx.createArray();
+        if (storage.slot_layout) |layout| {
+            if (storage.slots) |slots| {
+                for (layout.names, 0..) |name, i| try copy.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, slots[i]);
+            }
+        }
+        var it = storage.properties.iterator();
+        while (it.next()) |entry| try copy.set(ctx.allocator, .{ .string = Value.String.borrowed(entry.key_ptr.*) }, entry.value_ptr.*);
+        return .{ .array = copy };
+    }
     const arr = getData(obj) orelse {
         const empty = try ctx.allocator.create(PhpArray);
         empty.* = .{};
@@ -2643,4 +2720,21 @@ fn sosOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0) return .null;
     if (!try sosRequireObjectKey(ctx, "offsetUnset", args[0])) return error.RuntimeError;
     return sosDetach(ctx, args);
+}
+
+// SPL offsetSet replaces the bucket, rather than writing through a reference
+// in it (unlike a PHP array assignment).
+fn detachSplReference(ctx: *NativeContext, arr: *PhpArray, key: PhpArray.Key) void {
+    const entry = arr.getPtr(key) orelse return;
+    const cell = entry.ref orelse return;
+    entry.ref = null;
+    if (ctx.vm.ref_index) |index| index.removeTargetAllOwners(ctx.allocator, cell, .{ .array = .{ .array = arr, .key = key } });
+    var i: usize = 0;
+    while (i < ctx.vm.array_ref_bindings.items.len) {
+        const binding = ctx.vm.array_ref_bindings.items[i];
+        if (binding.array == arr and binding.key.eql(key)) {
+            _ = ctx.vm.array_ref_bindings.swapRemove(i);
+        } else i += 1;
+    }
+    if (@import("../runtime/value.zig").cell_unbind_hook) |hook| hook.call(hook.ctx, cell);
 }

--- a/src/stdlib/system.zig
+++ b/src/stdlib/system.zig
@@ -570,10 +570,14 @@ fn native_putenv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 }
 
+threadlocal var previous_uniqid_microsecond: i128 = -1;
+
 fn native_uniqid(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const prefix = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else "";
     const more_entropy = args.len >= 2 and args[1].isTruthy();
-    const ns = std.time.nanoTimestamp();
+    var ns = std.time.nanoTimestamp();
+    while (@divFloor(ns, 1_000) == previous_uniqid_microsecond) ns = std.time.nanoTimestamp();
+    previous_uniqid_microsecond = @divFloor(ns, 1_000);
     const abs_ns: u64 = @intCast(if (ns < 0) -ns else ns);
     const usec: u64 = @divTrunc(@mod(abs_ns, 1_000_000_000), 1_000);
     const sec: u64 = @divTrunc(abs_ns, 1_000_000_000);

--- a/src/stdlib/types.zig
+++ b/src/stdlib/types.zig
@@ -1227,6 +1227,7 @@ fn native_get_class_methods(ctx: *NativeContext, args: []const Value) RuntimeErr
         if (ctx.vm.classes.get(cn)) |cls| {
             const emit = struct {
                 fn run(c: *NativeContext, a: *@import("../runtime/value.zig").PhpArray, s: *std.StringHashMapUnmanaged(void), name: []const u8, info: anytype, d: usize, cnn: []const u8, clsn: []const u8, callr: ?[]const u8) !void {
+                    if (std.mem.indexOf(u8, name, "$hook_") != null) return;
                     if (d > 0 and info.visibility == .private) return;
                     const visible = switch (info.visibility) {
                         .public => true,

--- a/tests/class_qualified_inheritance.php
+++ b/tests/class_qualified_inheritance.php
@@ -1,0 +1,42 @@
+<?php
+// Reduced PHPUnit PhpParser shape: an aliased qualified parent supplies the
+// concrete implementation required by the child's interface. Autoload must
+// receive the resolved name, not the literal "Node\\Stmt".
+namespace QualifiedInheritance;
+use QualifiedInheritance\Tree as Node;
+interface Contract { public function getStartFilePos(): int; }
+spl_autoload_register(function ($name) {
+    echo "autoload $name\n";
+    if ($name === 'QualifiedInheritance\\Tree\\Stmt') {
+        eval('namespace QualifiedInheritance\\Tree; abstract class Stmt extends \\QualifiedInheritance\\Base {}');
+    }
+});
+abstract class Base {
+    public function getStartFilePos(): int { return 42; }
+}
+class ClassMethod extends Node\Stmt implements Contract {}
+echo (new ClassMethod)->getStartFilePos(), "\n";
+echo get_parent_class(ClassMethod::class), "\n";
+
+// All declaration paths share the same rules, including the hoist prepass.
+namespace QualifiedInheritance\Tree;
+interface Root { public function getStartFilePos(): int; }
+namespace QualifiedInheritance;
+use QualifiedInheritance\Tree as Alias;
+interface Derived extends Alias\Root {}
+class Relative extends Tree\Stmt implements Alias\Root {}
+class Absolute extends \QualifiedInheritance\Tree\Stmt implements \QualifiedInheritance\Tree\Root {}
+class Local extends namespace\Tree\Stmt implements namespace\Tree\Root {}
+foreach ([new Relative, new Absolute, new Local,
+          new class extends Alias\Stmt implements Alias\Root {}] as $node) {
+    echo $node->getStartFilePos(), "\n";
+}
+
+namespace QualifiedEarly;
+use QualifiedEarly as Prefix;
+class Base { public function value() { return 'early'; } }
+echo (new Child)->value(), "\n";
+class Child extends Prefix\Base {}
+interface Root {}
+interface Derived extends Prefix\Root {}
+var_dump(interface_exists(Derived::class, false));

--- a/tests/interface_parent_autoload.php
+++ b/tests/interface_parent_autoload.php
@@ -1,0 +1,27 @@
+<?php
+// Registering each parent grows the class/interface tables while the child
+// declaration is still in progress. Both direct and diamond contracts survive.
+spl_autoload_register(function ($name) {
+    if ($name === 'AutoloadLeaf') {
+        eval('interface AutoloadLeaf extends AutoloadLeft, AutoloadRight {}');
+    } elseif ($name === 'AutoloadLeft') {
+        eval('interface AutoloadLeft extends AutoloadRoot {}');
+    } elseif ($name === 'AutoloadRight') {
+        eval('interface AutoloadRight extends AutoloadRoot {}');
+    } elseif ($name === 'AutoloadRoot') {
+        for ($i = 0; $i < 80; $i++) {
+            eval('interface AutoloadPadding' . $i . ' {}');
+        }
+        eval('interface AutoloadRoot { public int $value { get; set; } }');
+    }
+});
+var_dump(interface_exists('AutoloadLeaf'));
+class AutoloadImplementation implements AutoloadLeaf {
+    public int $value = 7;
+}
+$object = new AutoloadImplementation;
+var_dump($object instanceof AutoloadLeaf, $object instanceof AutoloadLeft,
+    $object instanceof AutoloadRight, $object instanceof AutoloadRoot);
+echo $object->value, "\n";
+$object->value = 12;
+echo $object->value, "\n";

--- a/tests/property_hooks_abstract_backed.php
+++ b/tests/property_hooks_abstract_backed.php
@@ -1,0 +1,36 @@
+<?php
+abstract class HookContract {
+    abstract public int $value { get; set; }
+}
+class BackedContract extends HookContract { public int $value = 3; }
+class BackedGrandchild extends BackedContract {}
+foreach ([new BackedContract, new BackedGrandchild] as $object) {
+    echo $object->value, "\n";
+    $object->value = 9;
+    echo $object->value, "\n";
+    var_dump((new ReflectionProperty($object, 'value'))->hasHooks());
+}
+class ConcreteGetter { public int $value { get => 17; } }
+class RetainedGetter extends ConcreteGetter { public int $value = 2; }
+echo (new RetainedGetter)->value, "\n";
+echo (new ReflectionProperty(RetainedGetter::class, 'value'))->getHook(PropertyHookType::Get)->getDeclaringClass()->getName(), "\n";
+interface PropertyContract { public int $number { get; set; } }
+class PropertyImplementation implements PropertyContract { public int $number = 4; }
+$object = new PropertyImplementation;
+echo $object->number, "\n";
+$object->number = 7;
+echo $object->number, "\n";
+$property = new ReflectionProperty(PropertyContract::class, 'number');
+echo $property->getName(), ':', $property->getType(), "\n";
+var_dump($property->hasHooks(), $property->isAbstract());
+foreach ($property->getHooks() as $kind => $hook) {
+    echo $kind, ':', $hook->getName(), ':', $hook->getDeclaringClass()->getName(), "\n";
+    var_dump($hook->isAbstract());
+}
+interface OtherPropertyContract { public string $label { get; } }
+interface CombinedPropertyContract extends PropertyContract, OtherPropertyContract {}
+foreach ((new ReflectionClass(CombinedPropertyContract::class))->getProperties() as $property) {
+    echo $property->getName(), ':', $property->getDeclaringClass()->getName(), "\n";
+}
+$property = new ReflectionProperty(CombinedPropertyContract::class, 'number');
+echo $property->getDeclaringClass()->getName(), ':', $property->getHook(PropertyHookType::Get)->getDeclaringClass()->getName(), "\n";

--- a/tests/property_hooks_array_access.php
+++ b/tests/property_hooks_array_access.php
@@ -1,0 +1,49 @@
+<?php
+// Reduced from php-src Zend/tests/property_hooks/array_access.phpt.
+
+class Collection implements ArrayAccess {
+    public function offsetExists(mixed $offset): bool {
+        echo __METHOD__ . "\n";
+        return true;
+    }
+
+    public function offsetGet(mixed $offset): mixed {
+        echo __METHOD__ . "\n";
+        return true;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void {
+        echo __METHOD__ . "\n";
+    }
+
+    public function offsetUnset(mixed $offset): void {
+        echo __METHOD__ . "\n";
+    }
+}
+
+class C {
+    public function __construct(
+        public Collection $collection = new Collection(),
+    ) {}
+    public $prop {
+        get => $this->collection;
+    }
+}
+
+$c = new C();
+var_dump($c->prop['foo']);
+var_dump($c->prop[] = 'foo');
+var_dump(isset($c->prop['foo']));
+unset($c->prop['foo']);
+
+// Indexed assignment uses prop_set_chain instead of ensure_array_prop.
+var_dump($c->prop['key'] = 'bar');
+// Hook exceptions must reach the surrounding PHP handler.
+class FailingCollection {
+    public $prop { get { throw new Exception('getter failed'); } }
+}
+$f = new FailingCollection;
+try { $f->prop[] = 1; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { $f->prop['key'] = 1; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }

--- a/tests/property_hooks_backing_metadata.php
+++ b/tests/property_hooks_backing_metadata.php
@@ -1,0 +1,21 @@
+<?php
+interface MetadataContract { public int $x { get; set; } }
+abstract class MetadataBase { abstract public int $x { get; set; } }
+class MetadataBacked extends MetadataBase { public int $x = 3 { get => $this->x; } }
+class MetadataVirtual { public int $x { get => 7; } }
+class MetadataShortSet { public int $x { set => $value; } }
+class MetadataOther { public int $other = 1; public int $x { get => $this->other; } }
+trait MetadataTrait { public int $x { get => $this->x; } }
+class MetadataTraitUser { use MetadataTrait; }
+foreach ([MetadataContract::class, MetadataBase::class, MetadataBacked::class, MetadataVirtual::class, MetadataShortSet::class, MetadataOther::class, MetadataTraitUser::class] as $class) {
+    $p = new ReflectionProperty($class, 'x');
+    echo $class, ':', (int)$p->isVirtual(), ':', count((new ReflectionClass($class))->getMethods()), ':', count(get_class_methods($class)), "\n";
+}
+foreach ((new ReflectionProperty(MetadataContract::class, 'x'))->getHooks() as $kind => $hook) {
+    echo $kind, ':', $hook->getNumberOfParameters(), ':', $hook->getNumberOfRequiredParameters(), ':', $hook->getReturnType(), "\n";
+    foreach ($hook->getParameters() as $param) echo $param->getName(), ':', $param->getType(), ':', (int)$param->isOptional(), "\n";
+}
+$o = new MetadataBacked;
+echo $o->x, "\n";
+$o->x = 8;
+echo $o->x, "\n";

--- a/tests/property_hooks_dynamic_isset.php
+++ b/tests/property_hooks_dynamic_isset.php
@@ -1,0 +1,67 @@
+<?php
+// Dynamic names must share hook dispatch, write-context checks, and COW.
+class DynamicHooks {
+    public array $items = [] {
+        get { echo "get\n"; return $this->items; }
+        set { echo "set\n"; $this->items = $value; }
+    }
+}
+$o = new DynamicHooks;
+$p = 'items';
+$o->$p = ['key' => [1]];
+var_dump($o->$p);
+var_dump(isset($o->items['key']), isset($o->$p['key']));
+var_dump(isset($o->items['missing']), isset($o->$p['missing']));
+var_dump(isset($o->items['key'][0]), isset($o->$p['key'][0]));
+foreach ([0, 1, 2, 3] as $mode) {
+    try {
+        if ($mode === 0) $o->$p[] = 2;
+        if ($mode === 1) $o->$p['key'] = 2;
+        if ($mode === 2) $o->$p['key'][0] = 2;
+        if ($mode === 3) $o->$p['key'][0] += 2;
+    } catch (Error $e) { echo $e->getMessage(), "\n"; }
+}
+$o->{$p} = [];
+var_dump($o->{$p});
+class PlainDynamic { public array $a = [1]; public array $b = [2]; }
+$o = new PlainDynamic;
+$copy = $o->a;
+foreach (['a', 'b'] as $p) { $o->$p[] = 3; var_dump($o->$p); }
+var_dump($copy);
+class IssetMagic {
+    public bool $present = false;
+    public function __isset($p) { echo "isset:$p\n"; return $this->present; }
+    public function __get($p) { echo "magic:$p\n"; return [1]; }
+}
+$o = new IssetMagic; $p = 'a';
+var_dump(isset($o->a[0]), isset($o->$p[0]));
+$o->present = true;
+var_dump(isset($o->a[0]), isset($o->$p[0]));
+class ChangingGetter {
+    public int $calls = 0;
+    public array $a { get { ++$this->calls; return $this->calls === 1 ? [1] : []; } }
+}
+$o = new ChangingGetter;
+var_dump(isset($o->a[0]), $o->calls);
+class DynamicOffsets implements ArrayAccess {
+    public function offsetExists(mixed $k): bool { return true; }
+    public function offsetGet(mixed $k): mixed { return 1; }
+    public function offsetSet(mixed $k, mixed $v): void { echo "offset:", $k ?? 'append', ":$v\n"; }
+    public function offsetUnset(mixed $k): void {}
+}
+class ObjectGetter {
+    public DynamicOffsets $a { get { echo "object-get\n"; return new DynamicOffsets; } }
+}
+$o = new ObjectGetter; $p = 'a';
+$o->$p[] = 4;
+$o->$p['key'] = 5;
+class ThrowingDynamic {
+    public int $a {
+        get { throw new Exception('get failed'); }
+        set { throw new Exception('set failed'); }
+    }
+}
+$o = new ThrowingDynamic;
+try { $o->$p = 1; } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { var_dump(isset($o->$p[0])); } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+try { var_dump($o->$p); } catch (Exception $e) { echo $e->getMessage(), "\n"; }

--- a/tests/property_hooks_generator.php
+++ b/tests/property_hooks_generator.php
@@ -1,0 +1,39 @@
+<?php
+class HookSequence {
+    public $backed = 20 {
+        get {
+            yield 10;
+            yield $this->backed;
+            yield 30;
+            return 'finished';
+        }
+    }
+    public $virtual {
+        get { yield from [4, 5]; }
+    }
+    public $short {
+        get => yield 9;
+    }
+    public $factory {
+        get {
+            return function () { yield 6; };
+        }
+    }
+}
+$sequence = new HookSequence();
+$generator = $sequence->backed;
+var_dump($generator instanceof Generator);
+var_dump(iterator_to_array($generator));
+var_dump($generator->getReturn());
+var_dump(iterator_to_array($sequence->virtual));
+var_dump(iterator_to_array($sequence->short));
+$factory = $sequence->factory;
+var_dump(iterator_to_array($factory()));
+// Hook yields must not turn the containing function into a generator.
+function createHookSequence() {
+    class LocalHookSequence {
+        public $items { get { yield 8; } }
+    }
+    return new LocalHookSequence();
+}
+var_dump(iterator_to_array(createHookSequence()->items));

--- a/tests/property_hooks_get_by_ref.php
+++ b/tests/property_hooks_get_by_ref.php
@@ -1,0 +1,48 @@
+<?php
+// Reduced from php-src Zend/tests/property_hooks/get_by_ref.phpt.
+
+class Test {
+    public $byVal {
+        get { return $this->byVal; }
+        set { $this->byVal = $value; }
+    }
+}
+
+$test = new Test;
+
+try {
+    $test->byVal = [];
+    $test->byVal[] = 42;
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump($test->byVal);
+
+try {
+    $test->byVal =& $ref;
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// Indexed writes use a separate VM path from append.
+try { $test->byVal['key'] = 7; }
+catch (Error $e) { echo $e->getMessage(), "\n"; }
+var_dump($test->byVal);
+// Dynamic reference destinations must reject the binding too.
+$name = 'byVal';
+try { $test->$name =& $ref; }
+catch (Error $e) { echo $e->getMessage(), "\n"; }
+// Recursion guard still permits the hook to modify its backing array.
+class BackedArray {
+    public array $items = [] {
+        get { return $this->items; }
+        set { $this->items[] = $value[0]; }
+    }
+}
+$b = new BackedArray;
+$b->items = [9];
+var_dump($b->items);
+try { $alias =& $test->byVal; }
+catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { $alias =& $test->$name; }
+catch (Error $e) { echo $e->getMessage(), "\n"; }

--- a/tests/property_hooks_metadata.php
+++ b/tests/property_hooks_metadata.php
@@ -1,0 +1,28 @@
+<?php
+abstract class AbstractHookMetadata {
+    abstract public string $name { get; set; }
+}
+class FinalHookMetadata {
+    public int $number = 1 { final get => $this->number; set(string|int $input) { $this->number = (int)$input; } }
+    public ?string $text { set {} }
+}
+trait FinalHookMetadataTrait {
+    public int $value { final get => 42; }
+}
+class UsesHookMetadataTrait { use FinalHookMetadataTrait; }
+foreach ([AbstractHookMetadata::class => ['name'], FinalHookMetadata::class => ['number', 'text'], UsesHookMetadataTrait::class => ['value']] as $class => $names) {
+    foreach ($names as $name) {
+        $rp = new ReflectionProperty($class, $name);
+        echo $class, ':', $name, ':', (int)$rp->hasHooks(), ':', (int)$rp->isAbstract(), "\n";
+        foreach ($rp->getHooks() as $kind => $hook) {
+            echo $kind, ':', (int)$hook->isAbstract(), ':', (int)$hook->isFinal(), ':', $hook->getModifiers(), ':', (string)$hook->getReturnType(), "\n";
+            foreach ($hook->getParameters() as $p) echo $p->getName(), ':', (int)$p->hasType(), ':', (string)$p->getType(), ':', (int)$p->allowsNull(), "\n";
+        }
+    }
+}
+
+class ConcreteHookMetadata extends AbstractHookMetadata {
+    public string $name { get => 'implemented'; set {} }
+}
+$implemented = new ReflectionProperty(ConcreteHookMetadata::class, 'name');
+echo (int)$implemented->isAbstract(), ':', (new ConcreteHookMetadata)->name, "\n";

--- a/tests/property_hooks_reference_storage.php
+++ b/tests/property_hooks_reference_storage.php
@@ -1,0 +1,39 @@
+<?php
+// Reference getters must mutate their returned storage, not a virtual slot.
+class ReferenceStorage {
+    public array $data = [];
+    public array $items {
+        &get { echo "get\n"; return $this->data; }
+    }
+}
+$r = new ReferenceStorage;
+$p = 'items';
+$r->$p[] = 1;
+$r->items[] = 2;
+$r->$p['key'] = 3;
+$r->items['other'] = 4;
+var_dump($r->data, $r->$p);
+$copy = $r->data;
+$a =& $r->items;
+$b =& $r->$p;
+$a[] = 5;
+$b[] = 6;
+$r->$p[] = 7;
+var_dump($copy, $r->data, $a, $b);
+class NullableReferenceStorage {
+    public $data = null;
+    public $items { &get { return $this->data; } }
+}
+$n = new NullableReferenceStorage;
+$n->$p[] = 8;
+var_dump($n->data);
+class ShortReferenceStorage {
+    public array $data = [];
+    public array $items { &get => $this->data; }
+}
+$s = new ShortReferenceStorage;
+$s->$p[] = 9;
+$s->items['key'] = 10;
+$alias =& $s->$p;
+$alias[] = 11;
+var_dump($s->data, $s->items);

--- a/tests/property_hooks_reflection.php
+++ b/tests/property_hooks_reflection.php
@@ -1,0 +1,38 @@
+<?php
+class HookReflectionBase {
+    public int $plain = 1;
+    public int $number = 2 {
+        get => $this->number * 2;
+        set { $this->number = $value + 1; }
+    }
+    public string $virtual { get => 'virtual'; }
+    public string $write { set {} }
+}
+class HookReflectionChild extends HookReflectionBase {}
+foreach (PropertyHookType::cases() as $case) {
+    echo get_class($case), ':', $case->name, ':', (int)($case instanceof UnitEnum), "\n";
+}
+foreach (['plain', 'number', 'virtual', 'write'] as $name) {
+    $rp = new ReflectionProperty(HookReflectionChild::class, $name);
+    echo $name, ':', (int)$rp->hasHooks(), ':', (int)$rp->hasHook(PropertyHookType::Get), ':', (int)$rp->hasHook(PropertyHookType::Set), "\n";
+    foreach ($rp->getHooks() as $kind => $method) {
+        echo $kind, ':', get_class($method), ':', $method->getName(), ':', $method->name, ':', $method->class, ':', $method->getDeclaringClass()->getName(), ':', $method->getNumberOfParameters(), ':', $method->getNumberOfRequiredParameters(), ':', $method->getModifiers(), ':', (int)$method->isPublic(), ':', (int)$method->hasReturnType(), ':', (string)$method->getReturnType(), "\n";
+        foreach ($method->getParameters() as $p) echo $p->getName(), ':', $p->getDeclaringFunction()->getName(), "\n";
+    }
+    foreach ([PropertyHookType::Get, PropertyHookType::Set] as $kind) {
+        $hook = $rp->getHook($kind);
+        echo $hook === null ? 'none' : $hook->getName(), "\n";
+    }
+}
+$obj = new HookReflectionChild;
+$rp = new ReflectionProperty($obj, 'number');
+$get = $rp->getHook(PropertyHookType::Get);
+$set = $rp->getHook(PropertyHookType::Set);
+echo $get->invoke($obj), "\n";
+$set->invoke($obj, 5);
+echo $get->invokeArgs($obj, []), "\n";
+$set->invokeArgs($obj, [8]);
+echo $obj->number, "\n";
+foreach (['hasHook', 'getHook'] as $method) {
+    try { $rp->$method('get'); } catch (TypeError $e) { echo "TypeError\n"; }
+}

--- a/tests/property_hooks_trait_scope.php
+++ b/tests/property_hooks_trait_scope.php
@@ -1,0 +1,22 @@
+<?php
+trait HookStorage {
+    private string $stored = 'seed';
+    public string $label {
+        get => $this->stored;
+        set { $this->stored = strtoupper($value); }
+    }
+    public int $counter = 7 {
+        get => $this->counter;
+        set => $value + 1;
+    }
+    public function readStored() { return $this->stored; }
+}
+trait NestedHookStorage { use HookStorage; }
+class FirstHookOwner { use HookStorage; }
+class SecondHookOwner { use NestedHookStorage; }
+foreach ([new FirstHookOwner(), new SecondHookOwner()] as $owner) {
+    var_dump($owner->readStored(), $owner->label, $owner->counter);
+    $owner->label = 'changed';
+    $owner->counter = 10;
+    var_dump($owner->readStored(), $owner->label, $owner->counter);
+}

--- a/tests/spl_array_serializable.php
+++ b/tests/spl_array_serializable.php
@@ -1,0 +1,75 @@
+<?php
+// PHP 8.5 legacy Serializable and modern state contracts share storage/members,
+// but legacy streams deliberately omit the configured iterator class.
+class SerializableArrayObject extends ArrayObject {
+    public $label = 'member';
+    protected $hidden = 'protected';
+    private $secret = 'private';
+}
+class SerializableArrayIterator extends ArrayIterator {}
+foreach (['ArrayObject', 'ArrayIterator', 'SerializableArrayObject', 'SerializableArrayIterator'] as $class) {
+    $a = new $class(['name' => 'value', 7 => [false, null, 2.5]], 3);
+    $wire = $a->serialize();
+    echo $class, ':', bin2hex($wire), "\n";
+    $b = new $class();
+    var_dump($b->unserialize($wire));
+    var_dump($b->getFlags(), $b->getArrayCopy());
+    echo bin2hex($b->serialize()), "\n";
+    echo bin2hex(serialize($a)), "\n";
+    $c = unserialize(serialize($a));
+    var_dump($c->getFlags(), $c->getArrayCopy());
+}
+$o = (object)['value' => 12];
+$a = new ArrayObject([$o, $o]);
+$a->member = $o;
+$wire = $a->serialize();
+echo $wire, "\n";
+$b = new ArrayObject();
+$b->unserialize($wire);
+var_dump($b[0] === $b[1], $b[0] === $b->member);
+$b[0]->value = 20;
+var_dump($b[1]->value, $b->member->value);
+foreach (['ArrayObject', 'ArrayIterator'] as $class) {
+    $a = new $class((object)['key' => 'object storage'], 1);
+    echo $a->serialize(), "\n";
+    $b = new $class();
+    $b->unserialize($a->serialize());
+    echo $b->serialize(), "\n";
+    $b->unserialize('');
+    echo $b->serialize(), "\n";
+    $b->unserialize('x:i:99;a:0:{};m:a:0:{}ignored');
+    echo $b->serialize(), "\n";
+}
+foreach (['garbage', 'x:i:0;i:1;;m:a:0:{}', 'x:i:0;a:0:{}', 'x:i:0;a:0:{};m:i:1;', 'x:i:0;R:1;;m:a:0:{}'] as $wire) {
+    try { (new ArrayObject())->unserialize($wire); }
+    catch (UnexpectedValueException $e) { echo $e->getMessage(), "\n"; }
+}
+foreach ([[], ['0', [], [], null], [0, 1, [], null], [0, [], 1, null]] as $state) {
+    try { (new ArrayObject())->__unserialize($state); }
+    catch (Exception $e) { echo get_class($e), ': ', $e->getMessage(), "\n"; }
+}
+$x = 1;
+$a = new ArrayObject([&$x, &$x]);
+echo $a->serialize(), "\n";
+$b = new ArrayObject();
+$b->unserialize($a->serialize());
+echo $b->serialize(), "\n";
+$b[0] = 7; // SPL replaces this bucket, unlike assignment into a PHP array.
+echo $b->serialize(), "\n";
+foreach (['x:i:0;a:0:{};m:a:0:{', 'x:i:0;a:1:{i:0;i:1;;m:a:0:{}'] as $wire) {
+    try { (new ArrayObject())->unserialize($wire); }
+    catch (UnexpectedValueException $e) { echo $e->getMessage(), "\n"; }
+}
+$a = new ArrayObject();
+$a->unserialize('x:i:16777216;m:a:1:{s:1:"p";i:2;}');
+echo $a->serialize(), "\n";
+$a = new ArrayObject();
+$a[] = $a;
+echo $a->serialize(), "\n";
+$b = new ArrayObject();
+$b->unserialize($a->serialize());
+echo $b->serialize(), "\n";
+class SerializationCustomIterator extends ArrayIterator {}
+$a = new ArrayObject([1], 0, SerializationCustomIterator::class);
+echo serialize($a), "\n";
+echo serialize(unserialize(serialize($a))), "\n";

--- a/tests/uniqid_consecutive.php
+++ b/tests/uniqid_consecutive.php
@@ -1,0 +1,9 @@
+<?php
+$previous = uniqid();
+$duplicates = 0;
+for ($i = 0; $i < 20000; ++$i) {
+    $current = uniqid();
+    if ($current === $previous) ++$duplicates;
+    $previous = $current;
+}
+var_dump($duplicates);


### PR DESCRIPTION
Fix reproduced property-hook gaps in references, array writes, traits, generators, inheritance, interfaces, and reflection. Add PHP 8.5 regression tests.

Also implement missing ArrayObject serialization methods exposed by stricter interface checks, and invalidate incompatible cached bytecode.

Closes #12.