### PR TITLE
Fix native lazy objects for Doctrine

### DIFF
--- a/src/fast_loop.zig
+++ b/src/fast_loop.zig
@@ -747,7 +747,7 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                                 const gp_v = s[gp_entry.slot_index];
                                 // a null slot may be an uninitialized typed property
                                 // - bail so runLoop runs the type check
-                                if (gp_v != .null) {
+                                if (gp_v != .null and gp_obj.lazy == null) {
                                     // the receiver slot is replaced by the property
                                     // value: retain the new occupant, release the
                                     // receiver it overwrites (Stage 1)

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -751,7 +751,8 @@ pub const PhpObject = struct {
     // a dynamic property and stops re-entry
     magic_set_active: std.StringHashMapUnmanaged(void) = .{},
     magic_get_active: std.StringHashMapUnmanaged(void) = .{},
-    lazy_initializer: Value = .null,
+    lazy: ?*LazyState = null,
+
     id: u32 = 0,
     // object refcounting (Stage 1). counts live references to this object,
     // including operand-stack slots. born at 0: the `new` opcode pushes the
@@ -771,6 +772,24 @@ pub const PhpObject = struct {
     // release path must detach those weak mirrors before the address is reused
     ref_mirrored: bool = false,
 
+    pub const LazyState = struct {
+        initializer: Value,
+        pending: []bool,
+        skip_serialize: bool = false,
+        running: bool = false,
+    };
+
+    pub fn lazyInitializer(self: *const PhpObject) Value {
+        const state = self.lazy orelse return .null;
+        return state.initializer;
+    }
+
+    pub fn isLazySlot(self: *const PhpObject, name: []const u8, scope: ?[]const u8) bool {
+        const state = self.lazy orelse return false;
+        if (state.running or state.initializer == .null) return false;
+        const index = self.getSlotIndexForScope(name, scope) orelse return false;
+        return state.pending[index];
+    }
     pub const SlotLayout = struct {
         names: []const []const u8,
         // mutable: set_prop_default patches an instance-property default after
@@ -786,6 +805,10 @@ pub const PhpObject = struct {
     };
 
     pub fn deinit(self: *PhpObject, allocator: std.mem.Allocator) void {
+        if (self.lazy) |state| {
+            allocator.free(state.pending);
+            allocator.destroy(state);
+        }
         self.properties.deinit(allocator);
         self.unset_slots.deinit(allocator);
         self.magic_set_active.deinit(allocator);

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -529,6 +529,7 @@ pub const VM = struct {
     fiber_suspend_value: Value = .null,
     captures: std.ArrayListUnmanaged(CaptureEntry) = .{},
     capture_index: std.StringHashMapUnmanaged(CaptureRange) = .{},
+    cycle_closures: std.AutoArrayHashMapUnmanaged(*Value.String.Owner, i64) = .{},
     closure_instance_count: u32 = 0,
     captures_dead: usize = 0,
     // ZPHP_HEAP_STATS diagnostics: every live closure owner, so survivors of
@@ -2372,9 +2373,9 @@ pub const VM = struct {
         }
         for (self.objects.items[obj_start..]) |o| {
             if (!o.pooled) {
-                if (o.lazy_initializer == .string) {
-                    self.releaseValue(o.lazy_initializer);
-                    o.lazy_initializer = .null;
+                if (o.lazyInitializer() == .string) {
+                    self.releaseValue(o.lazyInitializer());
+                    o.lazy.?.initializer = .null;
                 }
                 if (o.slots) |slots| {
                     for (slots) |*slot| {
@@ -2876,7 +2877,7 @@ pub const VM = struct {
             if (obj.destructed) continue;
             if (self.pendingExceptionIs(obj)) continue;
             obj.destructed = true;
-            if (self.hasMethod(obj.class_name, "__destruct")) {
+            if (obj.lazyInitializer() == .null and self.hasMethod(obj.class_name, "__destruct")) {
                 _ = self.callMethod(obj, "__destruct", &.{}) catch {
                     self.pending_exception = null;
                 };
@@ -4464,6 +4465,10 @@ pub const VM = struct {
                     }
                     const obj = base.object;
                     const pname = prop_key.string.bytes();
+                    self.triggerLazyProperty(obj, pname, self.currentDefiningClass()) catch {
+                        if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                        return error.RuntimeError;
+                    };
                     const ik = Value.toArrayKey(inner_key);
                     // Hook reads must precede vivification/COW. A by-value hook
                     // may expose an object for offsetSet, but not writable array storage.
@@ -4603,6 +4608,10 @@ pub const VM = struct {
                         };
                         base_is_array_access_obj = true;
                     } else if (base == .object and outer_key == .string) {
+                        self.triggerLazyProperty(base.object, outer_key.string.bytes(), self.currentDefiningClass()) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
                         existing = base.object.get(outer_key.string.bytes());
                     } else {
                         self.push(v);
@@ -5082,6 +5091,10 @@ pub const VM = struct {
                     // may expose an object for offsetSet, but not writable array storage.
                     eap_obj.refcount +%= 1;
                     defer self.releaseValue(.{ .object = eap_obj });
+                    self.triggerLazyProperty(eap_obj, prop_name, self.currentDefiningClass()) catch {
+                        if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                        return error.RuntimeError;
+                    };
                     var cur = eap_obj.get(prop_name);
                     var hook_cell: ?*Value = null;
                     defer if (hook_cell) |cell| self.unbindCell(cell);
@@ -5329,6 +5342,10 @@ pub const VM = struct {
                             self.push(.{ .int = 0 });
                         } else if (iterable == .object) {
                             const obj = iterable.object;
+                            self.triggerLazyInit(obj) catch {
+                                if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                                return error.RuntimeError;
+                            };
                             const arr = try self.allocator.create(PhpArray);
                             arr.* = .{};
                             try self.arrays.append(self.allocator, arr);
@@ -5991,6 +6008,10 @@ pub const VM = struct {
                     const obj_val = self.pop();
                     if (obj_val == .object) {
                         const obj = obj_val.object;
+                        self.triggerLazyProperty(obj, prop_name, self.currentDefiningClass()) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
                         if (!obj.isUnset(prop_name)) {
                             if (try self.checkPropertyMutation(obj, prop_name, .unset)) continue;
                         }
@@ -6030,6 +6051,10 @@ pub const VM = struct {
                     const obj_val = self.pop();
                     if (obj_val == .object and name_val == .string) {
                         const obj = obj_val.object;
+                        self.triggerLazyProperty(obj, name_val.string.bytes(), self.currentDefiningClass()) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
                         const prop_name = name_val.string.bytes();
                         if (!obj.isUnset(prop_name)) {
                             if (try self.checkPropertyMutation(obj, prop_name, .unset)) continue;
@@ -6389,6 +6414,10 @@ pub const VM = struct {
                     const obj_val = self.pop();
                     if (obj_val == .object) {
                         const obj = obj_val.object;
+                        self.triggerLazyProperty(obj, prop_name, self.currentDefiningClass()) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
                         if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
                             obj.refcount +%= 1;
                             defer self.releaseValue(.{ .object = obj });
@@ -6416,6 +6445,10 @@ pub const VM = struct {
                     const obj_val = self.pop();
                     if (obj_val == .object and prop_name_val == .string) {
                         const obj = obj_val.object;
+                        self.triggerLazyProperty(obj, prop_name_val.string.bytes(), self.currentDefiningClass()) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
                         const prop_name = prop_name_val.string.bytes();
                         if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
                             obj.refcount +%= 1;
@@ -6489,6 +6522,10 @@ pub const VM = struct {
                     }
                     if (val == .object) {
                         const src = val.object;
+                        self.triggerLazyInit(src) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
                         const copy = try self.allocator.create(PhpObject);
                         self.next_object_id += 1;
                         copy.* = .{ .class_name = src.class_name, .id = self.next_object_id };
@@ -6616,6 +6653,7 @@ pub const VM = struct {
                             if (obj.slot_layout) |layout| {
                                 for (layout.names, 0..) |name, i| {
                                     if (i < slots.len) {
+                                        if (obj.isLazySlot(name, layout.declaring_classes[i])) continue;
                                         const vr = self.findPropertyVisibility(obj.class_name, name);
                                         // PHP omits uninitialized typed properties and
                                         // explicitly-unset properties from (array) casts
@@ -8020,7 +8058,10 @@ pub const VM = struct {
                         obj.refcount +%= 1;
                         defer self.releaseValue(.{ .object = obj });
 
-                        if (obj.lazy_initializer != .null) try self.triggerLazyInit(obj);
+                        if (obj.isLazySlot(prop_name, self.currentDefiningClass())) self.triggerLazyInit(obj) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
 
                         // property hooks: dispatch to get hook if present (and not recursing).
                         // route exceptions through the local try/catch handler
@@ -8149,7 +8190,10 @@ pub const VM = struct {
                         const obj = obj_val.object;
                         obj.refcount +%= 1;
                         defer self.releaseValue(.{ .object = obj });
-                        if (obj.lazy_initializer != .null) try self.triggerLazyInit(obj);
+                        if (obj.isLazySlot(prop_name, self.currentDefiningClass())) self.triggerLazyInit(obj) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
                         if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
                             const hook_result = self.callPropHook(obj, prop_name, .get, .null) catch {
                                 if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
@@ -8232,7 +8276,10 @@ pub const VM = struct {
                         obj.refcount +%= 1;
                         defer self.releaseValue(.{ .object = obj });
 
-                        if (obj.lazy_initializer != .null) try self.triggerLazyInit(obj);
+                        if (obj.isLazySlot(prop_name, self.currentDefiningClass())) self.triggerLazyInit(obj) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
 
                         // the set-scope gate runs before hooks and __set, but only
                         // an asymmetric or readonly declaration can ever deny a write
@@ -8378,10 +8425,6 @@ pub const VM = struct {
 
                     // object/generator is below args on the stack
                     const obj_val = self.stack[self.sp - ac - 1];
-
-                    if (obj_val == .object and obj_val.object.lazy_initializer != .null) {
-                        try self.triggerLazyInit(obj_val.object);
-                    }
 
                     if (obj_val == .generator) {
                         const gen = obj_val.generator;
@@ -14118,7 +14161,7 @@ pub const VM = struct {
 
     fn methodByValue(self: *VM, receiver: Value, method: []const u8, pos: u8) ?bool {
         if (receiver != .object) return null;
-        if (receiver.object.lazy_initializer != .null) return null;
+        if (receiver.object.lazyInitializer() != .null) return null;
         return self.classMethodByValue(receiver.object.class_name, method, pos, "__call");
     }
 
@@ -15174,16 +15217,57 @@ pub const VM = struct {
         return null;
     }
 
+    pub fn triggerLazyProperty(self: *VM, obj: *PhpObject, name: []const u8, scope: ?[]const u8) RuntimeError!void {
+        if (obj.isLazySlot(name, scope)) try self.triggerLazyInit(obj);
+    }
+
     pub fn triggerLazyInit(self: *VM, obj: *PhpObject) RuntimeError!void {
-        if (obj.lazy_initializer == .null) return;
-        const initializer = obj.lazy_initializer;
-        obj.lazy_initializer = .null;
+        const state = obj.lazy orelse return;
+        if (state.initializer == .null or state.running) return;
+        obj.refcount +%= 1;
+        defer self.releaseValue(.{ .object = obj });
+        // Retained snapshots force COW for arrays changed by the initializer.
+        const slots = obj.slots orelse return;
+        const saved = try self.allocator.dupe(Value, slots);
+        defer self.allocator.free(saved);
+        for (saved) |v| retainValue(v);
+        defer for (saved) |v| self.releaseValue(v);
+        var props = try obj.properties.clone(self.allocator);
+        defer props.deinit(self.allocator);
+        for (props.values()) |v| retainValue(v);
+        defer for (props.values()) |v| self.releaseValue(v);
+        var unset = try obj.unset_slots.clone(self.allocator);
+        defer unset.deinit(self.allocator);
+        state.running = true;
+        defer state.running = false;
         var ctx = self.makeContext(null);
-        _ = ctx.invokeCallable(initializer, &.{.{ .object = obj }}) catch |err| {
-            obj.lazy_initializer = initializer;
+        const result = ctx.invokeCallable(state.initializer, &.{.{ .object = obj }}) catch |err| {
+            for (slots, saved, 0..) |*slot, v, i| {
+                if (self.ref_index) |ri| {
+                    if (obj.slot_layout) |layout| {
+                        if (ri.prop_rev.contains(.{ .object = obj, .class_name = "", .prop_name = layout.names[i] })) continue;
+                    }
+                }
+                self.releaseValue(slot.*);
+                retainValue(v);
+                slot.* = v;
+            }
+            for (obj.properties.values()) |v| self.releaseValue(v);
+            obj.properties.clearRetainingCapacity();
+            for (props.keys(), props.values()) |k, v| {
+                retainValue(v);
+                try obj.properties.put(self.allocator, k, v);
+            }
+            obj.unset_slots.deinit(self.allocator);
+            obj.unset_slots = unset;
+            unset = .{};
             return err;
         };
+        _ = result;
+        const initializer = state.initializer;
+        state.initializer = .null;
         self.releaseValue(initializer);
+        if (self.hasPendingReleases()) self.drainPendingDestruct();
     }
 
     pub fn propHookName(self: *VM, prop_name: []const u8, kind: enum { get, set }) ?[]const u8 {
@@ -16552,7 +16636,7 @@ pub const VM = struct {
     // property write coercion rejects null for such a type, so a null slot
     // value can only mean the property is still uninitialized. union types are
     // treated conservatively (skipped) - they might admit null
-    fn typedPropForbidsNull(_: *VM, type_str: []const u8) bool {
+    pub fn typedPropForbidsNull(_: *VM, type_str: []const u8) bool {
         if (type_str.len == 0) return false; // untyped
         if (type_str[0] == '?') return false; // ?T
         if (std.mem.indexOfScalar(u8, type_str, '|') != null) return false; // union
@@ -17746,7 +17830,7 @@ pub const VM = struct {
                 if (self.valueInGlobalsCell(.{ .object = obj })) continue;
                 if (self.debug_gc_verify) self.gcVerifyDestructing(obj);
                 obj.destructed = true;
-                if (self.hasMethod(obj.class_name, "__destruct")) {
+                if (obj.lazyInitializer() == .null and self.hasMethod(obj.class_name, "__destruct")) {
                     _ = self.callMethod(obj, "__destruct", &.{}) catch {
                         // a throwing destructor must not corrupt the drop site
                         // it was called from - swallow (revisit for fidelity)
@@ -17881,7 +17965,7 @@ pub const VM = struct {
     //    + free
     pub fn collectCycles(self: *VM) usize {
         if (self.draining_destructors) return 0;
-        if (self.cycle_candidates.items.len == 0 and self.cycle_array_candidates.items.len == 0) return 0;
+        if (self.cycle_candidates.items.len == 0 and self.cycle_array_candidates.items.len == 0 and self.capture_index.count() == 0) return 0;
         self.gc_runs += 1;
         // drain any pending normal destructs first so the candidate set
         // doesn't include objects that are about to be released anyway
@@ -17892,7 +17976,16 @@ pub const VM = struct {
         var visited_arrs = std.AutoArrayHashMapUnmanaged(*PhpArray, void){};
         defer visited_arrs.deinit(self.allocator);
 
+        defer {
+            self.cycle_closures.deinit(self.allocator);
+            self.cycle_closures = .{};
+        }
         for (self.ref_cells.items) |cell| cell.visited = false;
+
+        var closure_ranges = self.capture_index.valueIterator();
+        while (closure_ranges.next()) |range| {
+            if (range.owner) |owner| self.cycleVisitChild(.{ .string = .{ .ptr = owner.bytes.ptr, .len = owner.bytes.len, .owner = owner } }, &visited_objs, &visited_arrs);
+        }
 
         // pass 1: BFS from candidates, init scratch_rc on first visit
         for (self.cycle_candidates.items) |c| {
@@ -17902,6 +17995,14 @@ pub const VM = struct {
         for (self.cycle_array_candidates.items) |c| {
             if (c.elements_released) continue;
             self.cycleVisitArr(c, &visited_objs, &visited_arrs);
+        }
+
+        for (self.cycle_closures.keys()) |owner| {
+            const range = self.capture_index.get(owner.bytes) orelse continue;
+            for (self.captures.items[range.start..][0..range.len]) |capture| {
+                self.cycleDecChild(capture.value, &visited_objs, &visited_arrs);
+                if (capture.ref_cell) |cell| cellOf(cell).scratch -= 1;
+            }
         }
 
         // pass 2: walk every visited node, decrement child scratch_rc for
@@ -17944,6 +18045,19 @@ pub const VM = struct {
             for (self.ref_cells.items) |cell| {
                 if (cell.visited and cell.scratch != 0) {
                     if (self.cycleMarkAliveChild(cell.value, &visited_objs, &visited_arrs)) changed = true;
+                }
+            }
+            for (self.cycle_closures.keys(), self.cycle_closures.values()) |owner, scratch| {
+                if (scratch == 0) continue;
+                const range = self.capture_index.get(owner.bytes) orelse continue;
+                for (self.captures.items[range.start..][0..range.len]) |capture| {
+                    if (self.cycleMarkAliveChild(capture.value, &visited_objs, &visited_arrs)) changed = true;
+                    if (capture.ref_cell) |cell| {
+                        if (cellOf(cell).scratch == 0) {
+                            cellOf(cell).scratch = 1;
+                            changed = true;
+                        }
+                    }
                 }
             }
             var it = visited_objs.iterator();
@@ -18079,7 +18193,7 @@ pub const VM = struct {
             };
             var pit = obj.properties.iterator();
             while (pit.next()) |e| if (gcTargetMatches(t, e.value_ptr.*)) gcNote(&c, in_graph, "object {s}#{d} rc {d} scratch {d} prop {s}", .{ obj.class_name, obj.id, obj.refcount, obj.scratch_rc, e.key_ptr.* });
-            if (gcTargetMatches(t, obj.lazy_initializer)) gcNote(&c, in_graph, "object {s}#{d} lazy_initializer", .{ obj.class_name, obj.id });
+            if (gcTargetMatches(t, obj.lazyInitializer())) gcNote(&c, in_graph, "object {s}#{d} lazy_initializer", .{ obj.class_name, obj.id });
         }
         const rc: u32 = switch (t) {
             .obj => |o| o.refcount,
@@ -18349,6 +18463,7 @@ pub const VM = struct {
         if (vo.contains(obj)) return;
         vo.put(self.allocator, obj, {}) catch return;
         obj.scratch_rc = @intCast(obj.refcount);
+        self.cycleVisitChild(obj.lazyInitializer(), vo, va);
         if (obj.slots) |s| {
             for (s) |v| self.cycleVisitChild(v, vo, va);
         }
@@ -18376,6 +18491,23 @@ pub const VM = struct {
 
     fn cycleVisitChild(self: *VM, v: Value, vo: anytype, va: anytype) void {
         switch (v) {
+            .string => |string| {
+                const owner = string.owner orelse return;
+                if (!owner.closure or self.cycle_closures.contains(owner)) return;
+                const range = self.capture_index.get(owner.bytes) orelse return;
+                self.cycle_closures.put(self.allocator, owner, @intCast(owner.refcount)) catch return;
+                for (self.captures.items[range.start..][0..range.len]) |capture| {
+                    self.cycleVisitChild(capture.value, vo, va);
+                    if (capture.ref_cell) |value| {
+                        const cell = cellOf(value);
+                        if (!cell.visited) {
+                            cell.visited = true;
+                            cell.scratch = @intCast(cell.binders);
+                            self.cycleVisitChild(cell.value, vo, va);
+                        }
+                    }
+                }
+            },
             .object => |o| self.cycleVisit(o, vo, va),
             .array => |a| self.cycleVisitArr(a, vo, va),
             else => {},
@@ -18383,6 +18515,7 @@ pub const VM = struct {
     }
 
     fn cycleDecrementChildren(self: *VM, obj: *PhpObject, vo: anytype, va: anytype) void {
+        self.cycleDecChild(obj.lazyInitializer(), vo, va);
         if (obj.slots) |s| {
             for (s) |v| self.cycleDecChild(v, vo, va);
         }
@@ -18406,8 +18539,11 @@ pub const VM = struct {
         }
     }
 
-    fn cycleDecChild(_: *VM, v: Value, vo: anytype, va: anytype) void {
+    fn cycleDecChild(self: *VM, v: Value, vo: anytype, va: anytype) void {
         switch (v) {
+            .string => |string| if (string.owner) |owner| {
+                if (self.cycle_closures.getPtr(owner)) |scratch| scratch.* -= 1;
+            },
             .object => |o| if (vo.contains(o)) {
                 o.scratch_rc -= 1;
             },
@@ -18419,7 +18555,7 @@ pub const VM = struct {
     }
 
     fn cycleMarkAlive(self: *VM, obj: *PhpObject, vo: anytype, va: anytype) bool {
-        var changed = false;
+        var changed = self.cycleMarkAliveChild(obj.lazyInitializer(), vo, va);
         if (obj.slots) |s| {
             for (s) |v| if (self.cycleMarkAliveChild(v, vo, va)) {
                 changed = true;
@@ -18448,8 +18584,16 @@ pub const VM = struct {
         return changed;
     }
 
-    fn cycleMarkAliveChild(_: *VM, v: Value, vo: anytype, va: anytype) bool {
+    fn cycleMarkAliveChild(self: *VM, v: Value, vo: anytype, va: anytype) bool {
         switch (v) {
+            .string => |string| if (string.owner) |owner| {
+                if (self.cycle_closures.getPtr(owner)) |scratch| {
+                    if (scratch.* == 0) {
+                        scratch.* = 1;
+                        return true;
+                    }
+                }
+            },
             .object => |o| {
                 if (vo.contains(o) and o.scratch_rc == 0) {
                     o.scratch_rc = 1;
@@ -18609,9 +18753,9 @@ pub const VM = struct {
                 ri.removeTargetAllOwners(self.allocator, binding.cell, binding.target);
             }
         };
-        if (obj.lazy_initializer != .null) {
-            self.releaseValue(obj.lazy_initializer);
-            obj.lazy_initializer = .null;
+        if (obj.lazyInitializer() != .null) {
+            self.releaseValue(obj.lazyInitializer());
+            obj.lazy.?.initializer = .null;
         }
         if (obj.slots) |s| {
             for (s) |*v| {

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -530,6 +530,7 @@ pub const VM = struct {
     captures: std.ArrayListUnmanaged(CaptureEntry) = .{},
     capture_index: std.StringHashMapUnmanaged(CaptureRange) = .{},
     cycle_closures: std.AutoArrayHashMapUnmanaged(*Value.String.Owner, i64) = .{},
+    collecting_cycles: bool = false,
     closure_instance_count: u32 = 0,
     captures_dead: usize = 0,
     // ZPHP_HEAP_STATS diagnostics: every live closure owner, so survivors of
@@ -17964,7 +17965,9 @@ pub const VM = struct {
     // 4. remaining nodes (scratch_rc == 0) are unreachable cycles - destruct
     //    + free
     pub fn collectCycles(self: *VM) usize {
-        if (self.draining_destructors) return 0;
+        if (self.draining_destructors or self.collecting_cycles) return 0;
+        self.collecting_cycles = true;
+        defer self.collecting_cycles = false;
         if (self.cycle_candidates.items.len == 0 and self.cycle_array_candidates.items.len == 0 and self.capture_index.count() == 0) return 0;
         self.gc_runs += 1;
         // drain any pending normal destructs first so the candidate set
@@ -18002,6 +18005,12 @@ pub const VM = struct {
             for (self.captures.items[range.start..][0..range.len]) |capture| {
                 self.cycleDecChild(capture.value, &visited_objs, &visited_arrs);
                 if (capture.ref_cell) |cell| cellOf(cell).scratch -= 1;
+            }
+            if (range.has_statics) {
+                var statics = self.statics_cells.iterator();
+                while (statics.next()) |entry| {
+                    if (closureOwnsStatic(owner.bytes, entry.key_ptr.*)) cellOf(entry.value_ptr.*).scratch -= 1;
+                }
             }
         }
 
@@ -18059,6 +18068,17 @@ pub const VM = struct {
                         }
                     }
                 }
+                if (range.has_statics) {
+                    var statics = self.statics_cells.iterator();
+                    while (statics.next()) |entry| {
+                        if (!closureOwnsStatic(owner.bytes, entry.key_ptr.*)) continue;
+                        const cell = cellOf(entry.value_ptr.*);
+                        if (cell.scratch == 0) {
+                            cell.scratch = 1;
+                            changed = true;
+                        }
+                    }
+                }
             }
             var it = visited_objs.iterator();
             while (it.next()) |kv| {
@@ -18101,8 +18121,36 @@ pub const VM = struct {
                 collected += 1;
             }
         }
+        // Pin dead closures while breaking their outgoing edges. Their names
+        // still occur in cells/containers being drained; forcing string RC to
+        // zero would make those ordinary releases underflow or use freed owners.
+        for (self.cycle_closures.keys(), self.cycle_closures.values()) |owner, scratch| {
+            if (scratch == 0) owner.refcount += 1;
+        }
+        for (self.cycle_closures.keys(), self.cycle_closures.values()) |owner, scratch| {
+            if (scratch != 0) continue;
+            const range = self.capture_index.get(owner.bytes) orelse continue;
+            for (self.captures.items[range.start..][0..range.len]) |*capture| {
+                const value = capture.value;
+                const cell = capture.ref_cell;
+                capture.value = .null;
+                capture.ref_cell = null;
+                self.releaseValue(value);
+                if (cell) |c| self.unbindCell(c);
+            }
+            if (range.ref_owner != 0) if (self.ref_index) |ri| ri.releaseOwner(self.allocator, range.ref_owner);
+            if (range.has_statics) self.purgeClosureStatics(owner.bytes);
+            if (self.capture_index.getPtr(owner.bytes)) |live_range| {
+                live_range.ref_owner = 0;
+                live_range.has_statics = false;
+            }
+        }
         self.cycle_candidates.clearRetainingCapacity();
         self.cycle_array_candidates.clearRetainingCapacity();
+        self.drainPendingDestruct();
+        for (self.cycle_closures.keys(), self.cycle_closures.values()) |owner, scratch| {
+            if (scratch == 0) self.releaseClosureByName(owner.bytes);
+        }
         self.drainPendingDestruct();
         self.gc_collected += collected;
         if (self.debug_gc_verify) {
@@ -18489,6 +18537,10 @@ pub const VM = struct {
         }
     }
 
+    fn closureOwnsStatic(name: []const u8, key: []const u8) bool {
+        return key.len > name.len + 2 and std.mem.startsWith(u8, key, name) and key[name.len] == ':' and key[name.len + 1] == ':';
+    }
+
     fn cycleVisitChild(self: *VM, v: Value, vo: anytype, va: anytype) void {
         switch (v) {
             .string => |string| {
@@ -18500,6 +18552,18 @@ pub const VM = struct {
                     self.cycleVisitChild(capture.value, vo, va);
                     if (capture.ref_cell) |value| {
                         const cell = cellOf(value);
+                        if (!cell.visited) {
+                            cell.visited = true;
+                            cell.scratch = @intCast(cell.binders);
+                            self.cycleVisitChild(cell.value, vo, va);
+                        }
+                    }
+                }
+                if (range.has_statics) {
+                    var statics = self.statics_cells.iterator();
+                    while (statics.next()) |entry| {
+                        if (!closureOwnsStatic(owner.bytes, entry.key_ptr.*)) continue;
+                        const cell = cellOf(entry.value_ptr.*);
                         if (!cell.visited) {
                             cell.visited = true;
                             cell.scratch = @intCast(cell.binders);

--- a/src/stdlib/json.zig
+++ b/src/stdlib/json.zig
@@ -321,6 +321,7 @@ fn encodeValue(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, val: Valu
             }
         },
         .object => |obj| {
+            if (vm) |runtime| try runtime.triggerLazyInit(obj);
             // PHP treats resources (fopen handles, curl handles, etc.) as
             // unsupported in json_encode: returns false + sets last_error to
             // 'Type is not supported' (and JsonException with THROW_ON_ERROR).

--- a/src/stdlib/reflection.zig
+++ b/src/stdlib/reflection.zig
@@ -124,6 +124,8 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try rc_def.methods.put(a, "getProperty", .{ .name = "getProperty", .arity = 1 });
     try rc_def.methods.put(a, "hasProperty", .{ .name = "hasProperty", .arity = 1 });
     try rc_def.methods.put(a, "newInstanceWithoutConstructor", .{ .name = "newInstanceWithoutConstructor", .arity = 0 });
+    try rc_def.static_props.put(a, "SKIP_INITIALIZATION_ON_SERIALIZE", .{ .int = 8 });
+    try rc_def.constant_names.put(a, "SKIP_INITIALIZATION_ON_SERIALIZE", {});
     try rc_def.methods.put(a, "newLazyGhost", .{ .name = "newLazyGhost", .arity = 1 });
     try rc_def.methods.put(a, "newLazyProxy", .{ .name = "newLazyProxy", .arity = 1 });
     try rc_def.methods.put(a, "initializeLazyObject", .{ .name = "initializeLazyObject", .arity = 1 });
@@ -570,7 +572,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionProperty::getRawValue", rpGetValue);
     try vm.native_fns.put(a, "ReflectionProperty::setValue", rpSetValue);
     try vm.native_fns.put(a, "ReflectionProperty::setRawValue", rpSetValue);
-    try vm.native_fns.put(a, "ReflectionProperty::setRawValueWithoutLazyInitialization", rpSetValue);
+    try vm.native_fns.put(a, "ReflectionProperty::setRawValueWithoutLazyInitialization", rpSetWithoutLazy);
     try vm.native_fns.put(a, "ReflectionProperty::getName", rpropGetName);
     try vm.native_fns.put(a, "ReflectionProperty::getType", rpropGetType);
     try vm.native_fns.put(a, "ReflectionProperty::isPublic", rpropIsPublic);
@@ -584,8 +586,8 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionProperty::hasHook", rpropHasHook);
     try vm.native_fns.put(a, "ReflectionProperty::getHooks", rpropGetHooks);
     try vm.native_fns.put(a, "ReflectionProperty::getHook", rpropGetHook);
-    try vm.native_fns.put(a, "ReflectionProperty::isLazy", reflectionFalse);
-    try vm.native_fns.put(a, "ReflectionProperty::skipLazyInitialization", reflectionNoop);
+    try vm.native_fns.put(a, "ReflectionProperty::isLazy", rpIsLazy);
+    try vm.native_fns.put(a, "ReflectionProperty::skipLazyInitialization", rpSkipLazy);
     try vm.native_fns.put(a, "ReflectionProperty::getDefaultValue", rpropGetDefaultValue);
     try vm.native_fns.put(a, "ReflectionProperty::hasDefaultValue", rpropHasDefaultValue);
     try vm.native_fns.put(a, "ReflectionProperty::isInitialized", rpropIsInitialized);
@@ -1717,9 +1719,20 @@ fn rcNewLazyGhost(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const obj = try ctx.vm.allocator.create(PhpObject);
     // the lazy object owns its initializer until it runs or is cleared
     VM.retainValue(args[0]);
-    obj.* = .{ .class_name = class_name, .lazy_initializer = args[0] };
+    obj.* = .{ .class_name = class_name };
     try ctx.vm.objects.append(ctx.vm.allocator, obj);
     try ctx.vm.initObjectProperties(obj, class_name);
+    const state = try ctx.allocator.create(PhpObject.LazyState);
+    const count = if (obj.slots) |slots| slots.len else 0;
+    state.* = .{ .initializer = args[0], .pending = try ctx.allocator.alloc(bool, count), .skip_serialize = args.len > 1 and args[1] == .int and (args[1].int & 8) != 0 };
+    @memset(state.pending, true);
+    obj.lazy = state;
+    ctx.vm.next_object_id += 1;
+    obj.id = ctx.vm.next_object_id;
+    if (count == 0) {
+        ctx.vm.releaseValue(state.initializer);
+        state.initializer = .null;
+    }
     return .{ .object = obj };
 }
 
@@ -1732,13 +1745,19 @@ fn rcInitializeLazyObject(ctx: *NativeContext, args: []const Value) RuntimeError
 
 fn rcIsUninitializedLazyObject(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    return .{ .bool = args[0].object.lazy_initializer != .null };
+    const state = args[0].object.lazy orelse return .{ .bool = false };
+    return .{ .bool = state.initializer != .null and !state.running };
 }
 
 fn rcMarkLazyObjectAsInitialized(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len < 1 or args[0] != .object) return .null;
-    ctx.vm.releaseValue(args[0].object.lazy_initializer);
-    args[0].object.lazy_initializer = .null;
+    if (args[0].object.lazy) |state| {
+        if (!state.running) {
+            const initializer = state.initializer;
+            state.initializer = .null;
+            ctx.vm.releaseValue(initializer);
+        }
+    }
     return .{ .object = args[0].object };
 }
 
@@ -3501,18 +3520,52 @@ fn rpGetValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const dc = this.get("_declaring_class");
         if (dc == .string and !ctx.vm.isInstanceOf(args[0].object.class_name, dc.string.bytes()))
             return throwReflection(ctx, "Given object is not an instance of the class this property was declared in");
+        try ctx.vm.triggerLazyProperty(args[0].object, prop_name, if (dc == .string) dc.string.bytes() else null);
         return args[0].object.getForScope(prop_name, if (dc == .string) dc.string.bytes() else null);
     }
     return .null;
 }
 
 fn rpSetValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    return rpWrite(ctx, args, false);
+}
+fn rpSetWithoutLazy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    return rpWrite(ctx, args, true);
+}
+fn rpSkipLazy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const this = getThis(ctx) orelse return .null;
+    if (args.len == 0 or args[0] != .object) return .null;
+    const name = this.get("name");
+    const dc = this.get("_declaring_class");
+    if (name != .string) return .null;
+    const obj = args[0].object;
+    if (obj.lazy) |state| {
+        if (state.running or state.initializer == .null) return .null;
+        if (obj.getSlotIndexForScope(name.string.bytes(), if (dc == .string) dc.string.bytes() else null)) |i| state.pending[i] = false;
+        for (state.pending) |pending| {
+            if (pending) return .null;
+        }
+        const initializer = state.initializer;
+        state.initializer = .null;
+        ctx.vm.releaseValue(initializer);
+    }
+    return .null;
+}
+fn rpIsLazy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const this = getThis(ctx) orelse return .{ .bool = false };
+    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+    const name = this.get("name");
+    const dc = this.get("_declaring_class");
+    return .{ .bool = name == .string and args[0].object.isLazySlot(name.string.bytes(), if (dc == .string) dc.string.bytes() else null) };
+}
+fn rpWrite(ctx: *NativeContext, args: []const Value, skip: bool) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
     const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
     if (args.len >= 2 and args[0] == .object) {
         const target = args[0].object;
         const dc = this.get("_declaring_class");
         const scope = if (dc == .string) dc.string.bytes() else target.class_name;
+        if (!skip) try ctx.vm.triggerLazyProperty(target, prop_name, scope);
         const vr = ctx.vm.findPropertyVisibility(scope, prop_name);
         if (vr.is_readonly and target.getForScope(prop_name, scope) != .null) {
             const msg = try std.fmt.allocPrint(ctx.allocator, "Cannot modify readonly property {s}::${s}", .{ vr.defining_class, prop_name });
@@ -3523,6 +3576,7 @@ fn rpSetValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         var value = args[1];
         if (try ctx.vm.checkPropertyType(&value, vr.type_str, scope, prop_name)) return error.RuntimeError;
         try target.setForScope(ctx.allocator, prop_name, value, scope);
+        if (skip) _ = try rpSkipLazy(ctx, args);
     }
     return .null;
 }
@@ -3702,7 +3756,11 @@ fn rpropIsInitialized(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     const this = getThis(ctx) orelse return .{ .bool = false };
     const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
     if (args.len > 0 and args[0] == .object) {
-        return .{ .bool = args[0].object.get(prop_name) != .null };
+        const dc = this.get("_declaring_class");
+        const scope = if (dc == .string) dc.string.bytes() else args[0].object.class_name;
+        try ctx.vm.triggerLazyProperty(args[0].object, prop_name, scope);
+        const vr = ctx.vm.findPropertyVisibility(scope, prop_name);
+        return .{ .bool = !args[0].object.isUnset(prop_name) and (args[0].object.getForScope(prop_name, scope) != .null or vr.type_str.len == 0 or (findPropertyDef(ctx.vm, scope, prop_name) orelse return .{ .bool = false }).prop.has_default) };
     }
     return .{ .bool = true };
 }

--- a/src/stdlib/serialize.zig
+++ b/src/stdlib/serialize.zig
@@ -324,6 +324,9 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
             try buf.append(a, '}');
         },
         .object => |obj| {
+            if (obj.lazy) |state| {
+                if (!state.skip_serialize) try ctx.vm.triggerLazyInit(obj);
+            }
             // emit a back-reference if we've already serialized this object
             if (sctx.objects.get(obj)) |existing_slot| {
                 // rewind the slot counter: this r: entry occupies the slot we already consumed
@@ -457,7 +460,13 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
             if (sleep_props) |sp| {
                 total_count = @intCast(sp.entries.items.len);
             } else {
-                const slot_count: u32 = if (obj.slot_layout) |layout| @intCast(layout.names.len) else 0;
+                var slot_count: u32 = 0;
+                if (obj.slot_layout) |layout| for (layout.names, 0..) |name, i| {
+                    if (obj.isLazySlot(name, layout.declaring_classes[i]) or obj.isUnset(name)) continue;
+                    const vr = ctx.vm.findPropertyVisibility(layout.declaring_classes[i], name);
+                    if (obj.slots.?[i] == .null and ctx.vm.typedPropForbidsNull(vr.type_str)) continue;
+                    slot_count += 1;
+                };
                 total_count = slot_count + @as(u32, @intCast(obj.properties.count()));
             }
             const cl = std.fmt.bufPrint(&tmp, "{d}", .{total_count}) catch return;
@@ -480,6 +489,9 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
             if (obj.slot_layout) |layout| {
                 if (obj.slots) |slots| {
                     for (layout.names, 0..) |name, i| {
+                        if (obj.isLazySlot(name, layout.declaring_classes[i]) or obj.isUnset(name)) continue;
+                        const vr = ctx.vm.findPropertyVisibility(layout.declaring_classes[i], name);
+                        if (slots[i] == .null and ctx.vm.typedPropForbidsNull(vr.type_str)) continue;
                         const vis: ClassDef.Visibility = if (class_def) |c| findPropertyVisibility(c, name) else .public;
                         try emitObjectPropertyKey(buf, a, obj.class_name, name, vis);
                         try serializeValue(ctx, buf, sctx, slots[i]);

--- a/src/stdlib/types.zig
+++ b/src/stdlib/types.zig
@@ -1090,6 +1090,7 @@ fn native_get_object_vars(ctx: *NativeContext, args: []const Value) RuntimeError
     }
     if (args.len == 0 or args[0] != .object) return Value{ .bool = false };
     const obj = args[0].object;
+    try ctx.vm.triggerLazyInit(obj);
     var arr = try ctx.createArray();
 
     // Determine caller's class scope via the calling frame's function name (which is

--- a/tests/closure_gc_capture_roots.php
+++ b/tests/closure_gc_capture_roots.php
@@ -1,0 +1,65 @@
+<?php
+// A dead recursive closure must release its captures before GC recycles them.
+function abandonedClosure() {
+    $snapshot = [1, 2];
+    $f = function () use (&$f, $snapshot) {};
+}
+for ($i = 0; $i < 100; ++$i) {
+    abandonedClosure();
+    gc_collect_cycles();
+    gc_collect_cycles();
+}
+echo "recursive captures collected\n";
+
+// Snapshot and reference-cell holders are distinct owning graph edges.
+function liveClosures() {
+    $value = [1];
+    $snapshot = function () use ($value) { return $value; };
+    $reference = function ($next) use (&$value) { $value = $next; return $value; };
+    return [$snapshot, $reference];
+}
+[$snapshot, $reference] = liveClosures();
+$reference([2, 3]);
+gc_collect_cycles();
+var_dump($snapshot(), $reference([4]));
+gc_collect_cycles();
+var_dump($snapshot());
+unset($snapshot, $reference);
+gc_collect_cycles();
+
+class ClosureGcPayload {
+    public static $destroyed = 0;
+    public $callback;
+    function __destruct() { ++self::$destroyed; gc_collect_cycles(); }
+}
+// Static cells belong to their closure, not to a permanent global GC root.
+function staticCycle() {
+    $f = function ($self = null) {
+        static $payload;
+        if ($self !== null) {
+            $payload = new ClosureGcPayload();
+            $payload->callback = $self;
+        }
+        return $payload !== null;
+    };
+    $f($f);
+    return $f;
+}
+$live = staticCycle();
+gc_collect_cycles();
+var_dump($live(), ClosureGcPayload::$destroyed);
+unset($live);
+gc_collect_cycles();
+gc_collect_cycles();
+var_dump(ClosureGcPayload::$destroyed);
+echo "done\n";
+
+// An external alias to a captured cell keeps the closure reachable.
+$f = function () use (&$f) { return 17; };
+$alias =& $f;
+unset($f);
+gc_collect_cycles();
+var_dump($alias());
+unset($alias);
+gc_collect_cycles();
+gc_collect_cycles();

--- a/tests/doctrine/harness/test-native-lazy-objects.php
+++ b/tests/doctrine/harness/test-native-lazy-objects.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\SchemaTool;
+
+require __DIR__ . '/../app/vendor/autoload.php';
+
+#[ORM\Entity]
+class LazyAccount
+{
+    #[ORM\Id, ORM\GeneratedValue, ORM\Column]
+    private ?int $id = null;
+
+    public function __construct(#[ORM\Column] private string $name) {}
+
+    public function id(): ?int { return $this->id; }
+    public function name(): string { return $this->name; }
+    public function rename(string $name): void { $this->name = $name; }
+}
+
+function check(bool $condition, string $label): void
+{
+    if (!$condition) {
+        throw new RuntimeException($label);
+    }
+    echo "$label\n";
+}
+
+$config = ORMSetup::createAttributeMetadataConfiguration([__DIR__], true);
+$config->enableNativeLazyObjects(true);
+$connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+$em = new EntityManager($connection, $config);
+(new SchemaTool($em))->createSchema([$em->getClassMetadata(LazyAccount::class)]);
+
+$account = new LazyAccount('Ada');
+$em->persist($account);
+$em->flush();
+$id = $account->id();
+$em->clear();
+
+$reflection = new ReflectionClass(LazyAccount::class);
+$reference = $em->getReference(LazyAccount::class, $id);
+check(get_class($reference) === LazyAccount::class, 'native class');
+check($reflection->isUninitializedLazyObject($reference), 'reference starts lazy');
+check($reference === $em->getReference(LazyAccount::class, $id), 'reference identity');
+check($reference->id() === $id, 'identifier available');
+check($reflection->isUninitializedLazyObject($reference), 'identifier leaves reference lazy');
+$serialized = serialize($reference);
+check($reflection->isUninitializedLazyObject($reference), 'serialization leaves reference lazy');
+$detached = unserialize($serialized);
+check($detached->id() === $id, 'serialized identifier preserved');
+
+$connection->executeStatement('UPDATE LazyAccount SET name = ? WHERE id = ?', ['Augusta', $id]);
+check($reference->name() === 'Augusta', 'first access loads current database value');
+check(!$reflection->isUninitializedLazyObject($reference), 'reference initialized');
+check($em->find(LazyAccount::class, $id) === $reference, 'loaded identity');
+$reference->rename('Grace');
+$em->flush();
+$em->clear();
+check($em->find(LazyAccount::class, $id)->name() === 'Grace', 'updated value persisted');
+
+$em->clear();
+$missing = $em->getReference(LazyAccount::class, 999);
+$caught = false;
+try {
+    $missing->name();
+} catch (Doctrine\ORM\EntityNotFoundException $error) {
+    $caught = true;
+}
+check($caught, 'missing entity throws');
+check($reflection->isUninitializedLazyObject($missing), 'failed load stays lazy');
+check($missing->id() === 999, 'failed load preserves identifier');
+$connection->executeStatement('INSERT INTO LazyAccount (id, name) VALUES (?, ?)', [999, 'Recovered']);
+check($missing->name() === 'Recovered', 'failed load can retry');
+check(!$reflection->isUninitializedLazyObject($missing), 'retry initializes reference');

--- a/tests/doctrine/run
+++ b/tests/doctrine/run
@@ -4,17 +4,27 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZPHP="${ZPHP:-$SCRIPT_DIR/../../zig-out/bin/zphp}"
 [ -f "$ZPHP" ] || { echo "zphp not found at $ZPHP"; exit 1; }
 [ -d "$SCRIPT_DIR/app/vendor" ] || { echo "run tests/doctrine/setup first"; exit 1; }
+bounded() {
+    python3 - "$@" <<'PY'
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(sys.argv[1:], timeout=60)
+except subprocess.TimeoutExpired:
+    print('Doctrine harness timed out', file=sys.stderr)
+    sys.exit(124)
+sys.exit(result.returncode if result.returncode >= 0 else 128 - result.returncode)
+PY
+}
 passed=0
 failed=0
 errors=""
 for f in "$SCRIPT_DIR"/harness/test-*.php; do
     name="$(basename "$f" .php)"
-    php_out="$(php -d 'error_reporting=E_ALL & ~E_DEPRECATED' "$f" 2>&1)" && php_exit=0 || php_exit=$?
-    TIMEOUT_CMD=""
-    command -v timeout >/dev/null && TIMEOUT_CMD="timeout 60"
-    command -v gtimeout >/dev/null && TIMEOUT_CMD="gtimeout 60"
-    zphp_out="$($TIMEOUT_CMD "$ZPHP" run "$f" 2>&1)" && zphp_exit=0 || zphp_exit=$?
-    if [ "$php_exit" -eq "$zphp_exit" ] && [ "$php_out" = "$zphp_out" ]; then
+    php_out="$(bounded php -d 'error_reporting=E_ALL & ~E_DEPRECATED' "$f" 2>&1)" && php_exit=0 || php_exit=$?
+    zphp_out="$(bounded "$ZPHP" run "$f" 2>&1)" && zphp_exit=0 || zphp_exit=$?
+    if [ "$php_exit" -eq 0 ] && [ "$zphp_exit" -eq 0 ] && [ "$php_out" = "$zphp_out" ]; then
         passed=$((passed + 1)); echo "  pass  $name"
     else
         failed=$((failed + 1)); echo "  FAIL  $name (php=$php_exit zphp=$zphp_exit)"

--- a/tests/lazy_failure_retry.php
+++ b/tests/lazy_failure_retry.php
@@ -1,0 +1,19 @@
+<?php
+class LazyRetry {
+    public int $id = 1;
+    public int $value = 3;
+    public array $items = [1];
+}
+$r = new ReflectionClass(LazyRetry::class);
+$attempt = 0;
+$o = $r->newLazyGhost(function ($o) use (&$attempt) {
+    echo 'attempt:', ++$attempt, ':', $o->id, ':', $o->value, ':', count($o->items), "\n";
+    $o->id = 99;
+    $o->items[] = 2;
+    $o->value = 12;
+    if ($attempt === 1) throw new RuntimeException('retry');
+});
+$r->getProperty('id')->setRawValueWithoutLazyInitialization($o, 7);
+try { echo $o->value; } catch (RuntimeException $e) { echo $e->getMessage(), "\n"; }
+var_dump($o->id, $r->isUninitializedLazyObject($o));
+var_dump($o->value, $r->isUninitializedLazyObject($o));

--- a/tests/lazy_identifier_access.php
+++ b/tests/lazy_identifier_access.php
@@ -1,0 +1,33 @@
+<?php
+
+class LazyRecord
+{
+    private ?int $id = null;
+    private string $name;
+
+    public function id(): ?int { return $this->id; }
+    public function name(): string { return $this->name; }
+    public function load(): void { $this->name = 'Ada'; }
+}
+
+$reflection = new ReflectionClass(LazyRecord::class);
+$record = $reflection->newLazyGhost(function (LazyRecord $record) {
+    echo "initialize\n";
+    $record->load();
+});
+$identifier = $reflection->getProperty('id');
+$identifier->setRawValueWithoutLazyInitialization($record, 7);
+var_dump($reflection->isUninitializedLazyObject($record));
+var_dump($record->id());
+var_dump($reflection->isUninitializedLazyObject($record));
+var_dump($record->name());
+var_dump($reflection->isUninitializedLazyObject($record));
+
+// Parent and child private slots with identical names stay independent.
+class LazyParent { private int $id = 1; public function parentId() { return $this->id; } }
+class LazyChild extends LazyParent { private int $id = 2; public function childId() { return $this->id; } }
+$reflection = new ReflectionClass(LazyChild::class);
+$record = $reflection->newLazyGhost(function ($record) { echo "private-init\n"; });
+(new ReflectionProperty(LazyParent::class, 'id'))->setRawValueWithoutLazyInitialization($record, 7);
+var_dump($record->parentId(), $reflection->isUninitializedLazyObject($record));
+var_dump($record->childId(), $reflection->isUninitializedLazyObject($record));

--- a/tests/lazy_initializer_cycles.php
+++ b/tests/lazy_initializer_cycles.php
@@ -1,0 +1,29 @@
+<?php
+class LazyCycleNode { public int $value = 1; }
+class LazyCycleHolder {
+    public $object;
+    public function __destruct() { echo "holder released\n"; }
+}
+function lazyCycle(bool $keepInitializer) {
+    $holder = new LazyCycleHolder;
+    $initializer = function ($object) use ($holder) { $object->value = 2; };
+    $object = (new ReflectionClass(LazyCycleNode::class))->newLazyGhost($initializer);
+    $holder->object = $object;
+    return $keepInitializer ? $initializer : null;
+}
+$initializer = lazyCycle(false);
+gc_collect_cycles();
+echo "collected\n";
+$initializer = lazyCycle(true);
+gc_collect_cycles();
+echo "retained\n";
+$initializer = null;
+gc_collect_cycles();
+echo "collected again\n";
+function lazyReferenceCycle(): void {
+    $holder = new LazyCycleHolder;
+    $holder->object = (new ReflectionClass(LazyCycleNode::class))->newLazyGhost(function ($object) use (&$holder) {});
+}
+lazyReferenceCycle();
+gc_collect_cycles();
+echo "reference cycle collected\n";

--- a/tests/lazy_initializer_lifetime.php
+++ b/tests/lazy_initializer_lifetime.php
@@ -1,0 +1,22 @@
+<?php
+class LazyLifetime {
+    public int $value = 1;
+    public function __destruct() { echo "object released\n"; }
+}
+class LazyCapture { public function __destruct() { echo "capture released\n"; } }
+$r = new ReflectionClass(LazyLifetime::class);
+$make = function () use ($r) {
+    $capture = new LazyCapture;
+    return $r->newLazyGhost(function ($o) use ($capture) { echo "initializer\n"; $o->value = 8; });
+};
+$o = $make();
+echo "created\n";
+var_dump($o->value);
+unset($o);
+echo "done\n";
+$o = $make();
+unset($o);
+echo "discarded\n";
+$o = $make();
+$r->markLazyObjectAsInitialized($o);
+echo "marked\n";

--- a/tests/lazy_property_paths.php
+++ b/tests/lazy_property_paths.php
@@ -1,0 +1,42 @@
+<?php
+class LazyPaths {
+    public ?int $id = null;
+    public int $value = 3;
+    public array $items = [1];
+    public function noop() { return 'noop'; }
+    public function value() { return $this->value; }
+}
+$r = new ReflectionClass(LazyPaths::class);
+foreach (['read', 'write', 'isset', 'unset', 'coalesce', 'append', 'reflect', 'raw'] as $path) {
+    $o = $r->newLazyGhost(function ($o) use ($path) { echo "init:$path\n"; $o->value = 9; });
+    echo $o->noop(), "\n";
+    $id = $r->getProperty('id');
+    var_dump($id->isLazy($o));
+    $id->skipLazyInitialization($o);
+    var_dump($id->isLazy($o), $id->isInitialized($o), $o->id);
+    $name = 'value';
+    if ($path === 'read') var_dump($o->$name);
+    if ($path === 'write') $o->$name = 4;
+    if ($path === 'isset') var_dump(isset($o->$name));
+    if ($path === 'unset') unset($o->$name);
+    if ($path === 'coalesce') var_dump($o->$name ?? 5);
+    if ($path === 'append') $o->items[] = 2;
+    if ($path === 'reflect') var_dump($r->getProperty('value')->getValue($o));
+    if ($path === 'raw') var_dump($r->getProperty('value')->getRawValue($o));
+    var_dump($r->isUninitializedLazyObject($o));
+}
+// Warm property ICs with ordinary instances before reading a ghost.
+function readValue($o) { return $o->value; }
+for ($i = 0; $i < 3; $i++) readValue(new LazyPaths);
+$o = $r->newLazyGhost(function ($o) { echo "warm-init\n"; $o->value = 17; });
+var_dump(readValue($o));
+foreach (['vars', 'json', 'clone', 'foreach', 'cast', 'initialized'] as $path) {
+    $o = $r->newLazyGhost(function ($o) use ($path) { echo "whole:$path\n"; });
+    if ($path === 'vars') get_object_vars($o);
+    if ($path === 'json') json_encode($o);
+    if ($path === 'clone') $copy = clone $o;
+    if ($path === 'foreach') foreach ($o as $value) {}
+    if ($path === 'cast') var_dump((array) $o);
+    if ($path === 'initialized') var_dump($r->getProperty('value')->isInitialized($o));
+    var_dump($r->isUninitializedLazyObject($o));
+}

--- a/tests/lazy_reentrant_state.php
+++ b/tests/lazy_reentrant_state.php
@@ -1,0 +1,14 @@
+<?php
+class ReentrantLazy { public int $value = 1; }
+$r = new ReflectionClass(ReentrantLazy::class);
+$attempt = 0;
+$o = $r->newLazyGhost(function ($o) use ($r, &$attempt) {
+    var_dump($r->isUninitializedLazyObject($o));
+    $r->markLazyObjectAsInitialized($o);
+    $r->getProperty('value')->skipLazyInitialization($o);
+    $o->value = 8;
+    if (++$attempt === 1) throw new Exception('retry');
+});
+try { var_dump($o->value); } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+var_dump($r->isUninitializedLazyObject($o));
+var_dump($o->value);

--- a/tests/lazy_reference_retry.php
+++ b/tests/lazy_reference_retry.php
@@ -1,0 +1,14 @@
+<?php
+class LazyReferencedItem {
+    public int $id = 1;
+    public int $value = 2;
+}
+$r = new ReflectionClass(LazyReferencedItem::class);
+$o = $r->newLazyGhost(function ($o) {
+    $o->id = 9;
+    throw new Exception;
+});
+$r->getProperty('id')->skipLazyInitialization($o);
+$id = &$o->id;
+try { $o->value; } catch (Exception $e) {}
+var_dump($id, $o->id);

--- a/tests/lazy_serialization_options.php
+++ b/tests/lazy_serialization_options.php
@@ -1,0 +1,19 @@
+<?php
+
+class LazySerializedRecord
+{
+    public ?int $id = null;
+    public string $name;
+    public int $untouched;
+}
+
+$reflection = new ReflectionClass(LazySerializedRecord::class);
+foreach ([0, ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE] as $options) {
+    $record = $reflection->newLazyGhost(function (LazySerializedRecord $record) {
+        echo "initialize\n";
+        $record->name = 'Ada';
+    }, $options);
+    $reflection->getProperty('id')->setRawValueWithoutLazyInitialization($record, 7);
+    var_dump(serialize($record));
+    var_dump($reflection->isUninitializedLazyObject($record));
+}


### PR DESCRIPTION
Fix property-level lazy initialization, serialization, failure recovery, and initializer lifetime handling.

Add a Doctrine workflow covering deferred loading, identity, persisted updates, and retry after initialization failure, plus focused PHP parity tests.