### PR TITLE
Fix Composer callback scope and reference aliases

### DIFF
--- a/src/bytecode_format.zig
+++ b/src/bytecode_format.zig
@@ -13,7 +13,8 @@ const MAGIC = "ZPHPC\x00";
 // v10 adds property-hook metadata and interface_decl property operands.
 // v15 renumbers opcodes and adds the argument guard operands.
 // Older chunks cannot be decoded by the current VM.
-pub const FORMAT_VERSION: u16 = 15;
+// v16 instantiates capture-free class-scoped static closures.
+pub const FORMAT_VERSION: u16 = 16;
 
 // tag bytes for serialized values
 const TAG_NULL: u8 = 0;

--- a/src/pipeline/compiler_class.zig
+++ b/src/pipeline/compiler_class.zig
@@ -1095,6 +1095,14 @@ pub fn compileClosure(self: *Compiler, node: Ast.Node) Error!void {
     const idx = try self.addConstant(.{ .string = Value.String.borrowed(owned_name) });
     try self.emitConstant(idx);
 
+    // Even a capture-free static closure has lexical/late-static scope.
+    // A harmless internal capture instantiates it without binding $this.
+    if (is_static_closure and self.current_class.len > 0) {
+        const scope_idx = try self.addConstant(.{ .string = Value.String.borrowed("$__closure_context") });
+        try self.emitOp(.closure_bind);
+        try self.emitU16(scope_idx);
+    }
+
     for (use_vars) |use_var_node| {
         const use_node = self.ast.nodes[use_var_node];
         const var_name = self.ast.tokenSlice(use_node.main_token);

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -5507,6 +5507,14 @@ pub const VM = struct {
                             .string => |s| .{ .string = s },
                             else => .{ .int = Value.toInt(key_val) },
                         };
+                        // An element already referenced by a closure/variable
+                        // denotes that same cell; rebinding must not sever it.
+                        if (arr_ptr.getPtr(key)) |entry| {
+                            if (entry.ref) |cell| {
+                                try self.bindRefSlot(&self.currentFrame().ref_slots, name, cell);
+                                continue;
+                            }
+                        }
                         const cell = try self.newRefCell();
                         var elem = arr_ptr.get(key);
                         // `$v = &$arr[$k]` makes $arr[$k] a reference, which can't
@@ -5684,6 +5692,12 @@ pub const VM = struct {
                             else => .{ .int = Value.toInt(key_val) },
                         };
                         if (append_ref) try self.arraySetOwned(arr_ptr, key, .null);
+                        if (arr_ptr.getPtr(key)) |entry| {
+                            if (entry.ref) |cell| {
+                                try self.bindRefSlot(&frame.ref_slots, dst_name, cell);
+                                continue;
+                            }
+                        }
                         const cell = try self.newRefCell();
                         var elem = arr_ptr.get(key);
                         // `$v = &$arr[$k]` makes $arr[$k] a reference - it can't
@@ -6799,52 +6813,10 @@ pub const VM = struct {
                         .value = val,
                     });
                     const gop = try self.capture_index.getOrPut(self.allocator, closure_name);
-                    const first_bind = !gop.found_existing or gop.value_ptr.len == 0;
                     if (gop.found_existing) {
                         gop.value_ptr.len += 1;
                     } else {
                         gop.value_ptr.* = .{ .start = cap_pos, .len = 1, .has_refs = false };
-                    }
-                    // closures defined inside class methods inherit class scope
-                    const lexical_class = self.currentDefiningClass();
-                    if (std.mem.eql(u8, var_name, "$this") and val == .object) {
-                        // instance method closure: LSB = $this's runtime class
-                        try self.captures.append(self.allocator, .{
-                            .closure_name = closure_name,
-                            .var_name = "$__closure_scope",
-                            .value = .{ .string = Value.String.borrowed(val.object.class_name) },
-                        });
-                        const gop2 = try self.capture_index.getOrPut(self.allocator, closure_name);
-                        gop2.value_ptr.len += 1;
-                        if (lexical_class) |class_name| {
-                            try self.captures.append(self.allocator, .{
-                                .closure_name = closure_name,
-                                .var_name = "$__closure_defclass",
-                                .value = .{ .string = Value.String.borrowed(class_name) },
-                            });
-                            const gop3 = try self.capture_index.getOrPut(self.allocator, closure_name);
-                            gop3.value_ptr.len += 1;
-                        }
-                    } else if (first_bind) {
-                        const scope = self.currentFrame().called_class orelse lexical_class;
-                        if (scope) |class_name| {
-                            try self.captures.append(self.allocator, .{
-                                .closure_name = closure_name,
-                                .var_name = "$__closure_scope",
-                                .value = .{ .string = Value.String.borrowed(class_name) },
-                            });
-                            const gop2 = try self.capture_index.getOrPut(self.allocator, closure_name);
-                            gop2.value_ptr.len += 1;
-                        }
-                        if (lexical_class) |class_name| {
-                            try self.captures.append(self.allocator, .{
-                                .closure_name = closure_name,
-                                .var_name = "$__closure_defclass",
-                                .value = .{ .string = Value.String.borrowed(class_name) },
-                            });
-                            const gop2 = try self.capture_index.getOrPut(self.allocator, closure_name);
-                            gop2.value_ptr.len += 1;
-                        }
                     }
                 },
 
@@ -12808,6 +12780,32 @@ pub const VM = struct {
         {
             const func = self.functions.get(compile_name) orelse return error.RuntimeError;
             self.stack[self.sp - 1] = try self.newClosureInstance(compile_name, func);
+            // Scope belongs to the closure instance, not to a particular kind
+            // of use capture. Reference-only static closures need it too.
+            const name = self.peek().string.bytes();
+            const lexical_class = self.currentDefiningClass();
+            const this_val = self.getLocalByName("$this");
+            const scope = if (lexical_class != null)
+                self.currentFrame().called_class orelse
+                    (if (this_val == .object) this_val.object.class_name else lexical_class)
+            else
+                null;
+            if (scope) |class_name| {
+                try self.captures.append(self.allocator, .{
+                    .closure_name = name,
+                    .var_name = "$__closure_scope",
+                    .value = .{ .string = Value.String.borrowed(class_name) },
+                });
+                self.capture_index.getPtr(name).?.len += 1;
+            }
+            if (lexical_class) |class_name| {
+                try self.captures.append(self.allocator, .{
+                    .closure_name = name,
+                    .var_name = "$__closure_defclass",
+                    .value = .{ .string = Value.String.borrowed(class_name) },
+                });
+                self.capture_index.getPtr(name).?.len += 1;
+            }
         }
     }
 
@@ -15167,8 +15165,8 @@ pub const VM = struct {
             if (self.closureScopeForFrame(&self.frames[self.frame_count - 1])) |scope|
                 return scope;
         }
-        // walk the call stack from current frame upward to find enclosing class method
-        // closures inside methods need the enclosing method's class for visibility checks
+        // Includes/native bridge frames can inherit scope, but a PHP function
+        // is a lexical boundary: never grant its caller's private access.
         var fi: usize = self.frame_count;
         while (fi > 0) {
             fi -= 1;
@@ -15214,6 +15212,7 @@ pub const VM = struct {
                 }
             }
             if (best) |b| return b;
+            if (frame.func != null) return null;
         }
         return null;
     }
@@ -17197,6 +17196,7 @@ pub const VM = struct {
             if (args.len < func.required_params) return error.RuntimeError;
             if (self.ic) |ic| ic.pending_arg_count = @intCast(@min(args.len, 255));
             self.pending_call_name = name;
+            self.pending_called_class = self.closureScopeByName(name);
             const saved_pia_outer = self.pending_invoke_args;
             self.pending_invoke_args = args;
             defer self.pending_invoke_args = saved_pia_outer;
@@ -17373,6 +17373,8 @@ pub const VM = struct {
             }
             try self.fillDefaults(&new_vars, func, bind_count);
 
+            self.pending_call_name = name;
+            self.pending_called_class = self.closureScopeByName(name);
             const result = try self.executeFunctionWithRefs(func, new_vars, ref_slots);
 
             for (0..bind_count) |i| {

--- a/tests/closure_callback_ref_scope.php
+++ b/tests/closure_callback_ref_scope.php
@@ -1,0 +1,55 @@
+<?php
+namespace CallbackScope;
+
+class Promise {
+    private function settle($value) { echo "settled:$value\n"; }
+    public function resolver() {
+        $target = $this;
+        return static function ($value) use (&$target) {
+            $target->settle($value);
+        };
+    }
+}
+class Executor {
+    public function run($callback) { $callback('direct'); }
+    public function native($callback) { call_user_func($callback, 'native'); }
+}
+$callback = (new Promise())->resolver();
+(new Executor())->run($callback);
+(new Executor())->native($callback);
+
+class Base {
+    private static function secret() { return 'base'; }
+    public static function callbacks() {
+        $value = 'value';
+        return [
+            static function () { return self::secret() . ':' . static::class; },
+            static function () use (&$value) { return self::secret() . ':' . static::class . ':' . $value; },
+            static function () use ($value) { return self::secret() . ':' . static::class . ':' . $value; },
+            static fn () => self::secret() . ':' . static::class,
+            function () { return static function () { return self::secret() . ':' . static::class; }; },
+        ];
+    }
+}
+class Child extends Base {}
+foreach ([Base::callbacks(), Child::callbacks()] as $callbacks) {
+    foreach ($callbacks as $i => $cb) {
+        if ($i === 4) $cb = $cb();
+        echo $cb(), "\n";
+        echo call_user_func($cb), "\n";
+    }
+}
+
+// Global callbacks/functions must not borrow an invoking method's privilege.
+function outsider($object) { return $object->secret(); }
+class Vault {
+    private function secret() { return 'leaked'; }
+    public function invoke($cb) {
+        try { echo $cb($this), "\n"; }
+        catch (\Error $e) { echo "denied\n"; }
+    }
+}
+$vault = new Vault();
+$vault->invoke(static function ($object) { return $object->secret(); });
+$vault->invoke(function ($object) { return $object->secret(); });
+$vault->invoke(__NAMESPACE__ . '\\outsider');

--- a/tests/closure_job_reference_alias.php
+++ b/tests/closure_job_reference_alias.php
@@ -1,0 +1,26 @@
+<?php
+class Jobs {
+    private $jobs = [];
+    public function create() {
+        $job = ['id' => 0, 'status' => 1];
+        $resolver = static function ($resolve) use (&$job) { $job['resolve'] = $resolve; };
+        $resolver(function () {});
+        $callback = function () use (&$job) { echo json_encode(array_keys($job)), "\n"; };
+        $this->jobs[$job['id']] = &$job;
+        $this->start(0);
+        $callback();
+    }
+    private function start($id) {
+        $job = &$this->jobs[$id];
+        $job['status'] = 2;
+        $job['process'] = 'process';
+    }
+}
+(new Jobs())->create();
+$x = ['a' => 1];
+$a = [];
+$a[0] = &$x;
+$b = &$a[0];
+unset($a[0]);
+$b['b'] = 2;
+var_dump($x, $b);

--- a/tests/composer/run
+++ b/tests/composer/run
@@ -1,18 +1,45 @@
 #!/bin/sh
 set -eu
 D=$(CDPATH= cd -- "$(dirname "$0")" && pwd); Z=${ZPHP:-"$D/../../zig-out/bin/zphp"}; P="$D/composer.phar"; A="$D/fixture/app"
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT HUP INT TERM
 export COMPOSER_AUTH='{}'
-export COMPOSER_HOME="$D/.composer-home"
-rm -rf "$COMPOSER_HOME"
+export COMPOSER_HOME="$T/home"
+unset COMPOSER_ROOT_VERSION
 mkdir -p "$COMPOSER_HOME"
+cp -R "$D/fixture" "$T/fixture"
+A="$T/fixture/app"
+rm -rf "$A/vendor"
+git -C "$A" init -q -b main
+git -C "$A" add .
+git -C "$A" -c user.name=zphp -c user.email=fixture@example.invalid -c commit.gpgsign=false commit -qm fixture
+git -C "$A" switch -qc feature/version-discovery
 [ -x "$Z" ] || { echo "zphp not found at $Z"; exit 1; }; [ -f "$P" ] || { echo "run tests/composer/setup first"; exit 1; }; command -v php >/dev/null
-bounded() { if command -v timeout >/dev/null 2>&1; then timeout 120 "$@"; elif command -v gtimeout >/dev/null 2>&1; then gtimeout 120 "$@"; else "$@"; fi; }
+bounded() {
+    python3 - "$@" <<'PYTHON'
+import subprocess
+import sys
+try:
+    result = subprocess.run(sys.argv[1:], timeout=120)
+except subprocess.TimeoutExpired:
+    print('Composer command timed out', file=sys.stderr)
+    sys.exit(124)
+sys.exit(result.returncode if result.returncode >= 0 else 128 - result.returncode)
+PYTHON
+}
+locked_json() {
+    php -r '$v=json_decode(stream_get_contents(STDIN),true,512,JSON_THROW_ON_ERROR); if (!is_array($v) || !isset($v["locked"]) || count($v["locked"]) !== 1 || $v["locked"][0]["name"] !== "acme/greeter" || $v["locked"][0]["version"] !== "1.0.0") { throw new RuntimeException("Unexpected locked packages"); } echo json_encode($v, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);'
+}
 cd "$A"
-php_version=$(bounded php "$P" --version 2>/dev/null | sed 's/ PHP version.*//')
-zphp_version=$(bounded "$Z" run "$P" --version 2>/dev/null | sed 's/ PHP version.*//')
+php_version_raw=$(bounded php "$P" --version) || { echo 'php version failed'; exit 1; }
+zphp_version_raw=$(bounded "$Z" run "$P" --version) || { echo 'zphp version failed'; exit 1; }
+php_version=$(printf '%s' "$php_version_raw" | sed 's/ PHP version.*//')
+zphp_version=$(printf '%s' "$zphp_version_raw" | sed 's/ PHP version.*//')
 [ "$php_version" = "$zphp_version" ] || { printf 'version mismatch\nphp: %s\nzphp: %s\n' "$php_version" "$zphp_version"; exit 1; }
-php_locked=$(bounded php "$P" show --locked --format=json --no-interaction 2>/dev/null | php -r '$v=json_decode(stream_get_contents(STDIN),true); echo json_encode($v, JSON_UNESCAPED_SLASHES);')
-zphp_locked=$(bounded "$Z" run "$P" show --locked --format=json --no-interaction 2>/dev/null | php -r '$v=json_decode(stream_get_contents(STDIN),true); echo json_encode($v, JSON_UNESCAPED_SLASHES);')
+php_locked_raw=$(bounded php "$P" show --locked --format=json --no-interaction) || { echo 'php locked-package inspection failed'; exit 1; }
+zphp_locked_raw=$(bounded "$Z" run "$P" show --locked --format=json --no-interaction) || { echo 'zphp locked-package inspection failed'; exit 1; }
+php_locked=$(printf '%s' "$php_locked_raw" | locked_json)
+zphp_locked=$(printf '%s' "$zphp_locked_raw" | locked_json)
 [ "$php_locked" = "$zphp_locked" ] || { printf 'locked-package mismatch\nphp: %s\nzphp: %s\n' "$php_locked" "$zphp_locked"; exit 1; }
 php_validate=$(bounded php "$P" validate --no-check-publish --no-check-version --no-interaction 2>&1) || { printf 'php validate failed:\n%s\n' "$php_validate"; exit 1; }
 zphp_validate=$(bounded "$Z" run "$P" validate --no-check-publish --no-check-version --no-interaction 2>&1) || { printf 'zphp validate failed:\n%s\n' "$zphp_validate"; exit 1; }


### PR DESCRIPTION
Preserve closure class scope across callback invocation and retain existing reference aliases when rebinding array elements.

Add focused PHP parity tests and an isolated Composer Git fixture that exercises version discovery, installation, and the installed application without a root-version override.