### PR TITLE
Fix native lazy proxies for Symfony services

### DIFF
--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -774,10 +774,26 @@ pub const PhpObject = struct {
 
     pub const LazyState = struct {
         initializer: Value,
+        proxy: bool = false,
+        backing: ?*PhpObject = null,
         pending: []bool,
         skip_serialize: bool = false,
         running: bool = false,
     };
+
+    pub fn backingValue(self: *const PhpObject) Value {
+        if (self.lazy) |state| if (state.backing) |obj| return .{ .object = obj };
+        return .null;
+    }
+
+    pub fn storage(self: *PhpObject) *PhpObject {
+        if (self.lazy) |state| if (state.backing) |obj| return obj;
+        return self;
+    }
+
+    pub fn ownsDestructor(self: *const PhpObject) bool {
+        return self.lazyInitializer() == .null and self.backingValue() == .null;
+    }
 
     pub fn lazyInitializer(self: *const PhpObject) Value {
         const state = self.lazy orelse return .null;
@@ -787,7 +803,7 @@ pub const PhpObject = struct {
     pub fn isLazySlot(self: *const PhpObject, name: []const u8, scope: ?[]const u8) bool {
         const state = self.lazy orelse return false;
         if (state.running or state.initializer == .null) return false;
-        const index = self.getSlotIndexForScope(name, scope) orelse return false;
+        const index = self.getSlotIndexForScope(name, scope) orelse return state.proxy;
         return state.pending[index];
     }
     pub const SlotLayout = struct {
@@ -824,6 +840,7 @@ pub const PhpObject = struct {
     }
 
     pub fn isUnset(self: *const PhpObject, name: []const u8) bool {
+        if (self.backingValue() == .object) return self.backingValue().object.isUnset(name);
         return self.unset_slots.contains(name);
     }
 
@@ -873,6 +890,7 @@ pub const PhpObject = struct {
     }
 
     pub fn getForScope(self: *const PhpObject, name: []const u8, scope: ?[]const u8) Value {
+        if (self.backingValue() == .object) return self.backingValue().object.getForScope(name, scope);
         if (self.slots) |s| {
             if (self.getSlotIndexForScope(name, scope)) |idx| return s[idx];
         }
@@ -880,6 +898,7 @@ pub const PhpObject = struct {
     }
 
     pub fn set(self: *PhpObject, allocator: std.mem.Allocator, name: []const u8, value: Value) !void {
+        if (self.storage() != self) return self.storage().set(allocator, name, value);
         // the universal property-store choke point: the property takes a
         // reference to the value (callers pass raw values, never copyValue'd
         // ones) and the value it replaces is released through the VM's hook
@@ -907,6 +926,7 @@ pub const PhpObject = struct {
     // scope-aware variant for the set_prop opcode path where we know the
     // declaring class (private slots are picked correctly)
     pub fn setForScope(self: *PhpObject, allocator: std.mem.Allocator, name: []const u8, value: Value, scope: ?[]const u8) !void {
+        if (self.storage() != self) return self.storage().setForScope(allocator, name, value, scope);
         retainStored(value);
         self.clearUnset(name);
         if (self.slots) |s| {

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -2878,7 +2878,7 @@ pub const VM = struct {
             if (obj.destructed) continue;
             if (self.pendingExceptionIs(obj)) continue;
             obj.destructed = true;
-            if (obj.lazyInitializer() == .null and self.hasMethod(obj.class_name, "__destruct")) {
+            if (obj.ownsDestructor() and self.hasMethod(obj.class_name, "__destruct")) {
                 _ = self.callMethod(obj, "__destruct", &.{}) catch {
                     self.pending_exception = null;
                 };
@@ -4464,12 +4464,13 @@ pub const VM = struct {
                         self.push(v);
                         continue;
                     }
-                    const obj = base.object;
+                    var obj = base.object;
                     const pname = prop_key.string.bytes();
                     self.triggerLazyProperty(obj, pname, self.currentDefiningClass()) catch {
                         if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                         return error.RuntimeError;
                     };
+                    obj = obj.storage();
                     const ik = Value.toArrayKey(inner_key);
                     // Hook reads must precede vivification/COW. A by-value hook
                     // may expose an object for offsetSet, but not writable array storage.
@@ -5087,15 +5088,16 @@ pub const VM = struct {
                         self.push(.null);
                         continue;
                     }
-                    const eap_obj = obj_val.object;
+                    var eap_obj = obj_val.object;
                     // Hook reads must precede vivification/COW. A by-value hook
                     // may expose an object for offsetSet, but not writable array storage.
                     eap_obj.refcount +%= 1;
-                    defer self.releaseValue(.{ .object = eap_obj });
+                    defer self.releaseValue(obj_val);
                     self.triggerLazyProperty(eap_obj, prop_name, self.currentDefiningClass()) catch {
                         if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                         return error.RuntimeError;
                     };
+                    eap_obj = eap_obj.storage();
                     var cur = eap_obj.get(prop_name);
                     var hook_cell: ?*Value = null;
                     defer if (hook_cell) |cell| self.unbindCell(cell);
@@ -5342,11 +5344,12 @@ pub const VM = struct {
                         } else if (iterable == .array) {
                             self.push(.{ .int = 0 });
                         } else if (iterable == .object) {
-                            const obj = iterable.object;
+                            var obj = iterable.object;
                             self.triggerLazyInit(obj) catch {
                                 if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                                 return error.RuntimeError;
                             };
+                            obj = obj.storage();
                             const arr = try self.allocator.create(PhpArray);
                             arr.* = .{};
                             try self.arrays.append(self.allocator, arr);
@@ -5760,7 +5763,12 @@ pub const VM = struct {
 
                         try self.bindRefSlot(&frame.ref_slots, dst_name, c);
                     } else {
-                        const obj_ptr = obj_val.object;
+                        var obj_ptr = obj_val.object;
+                        self.triggerLazyProperty(obj_ptr, prop_name, self.currentDefiningClass()) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
+                        obj_ptr = obj_ptr.storage();
                         if (try self.checkPropertyMutation(obj_ptr, prop_name, .indirect)) continue;
                         if (self.hasPropHook(obj_ptr.class_name, prop_name, .get) and !self.inPropHook(obj_ptr, prop_name) and !try self.propGetReturnsRef(obj_ptr, prop_name)) {
                             obj_ptr.refcount +%= 1;
@@ -5830,11 +5838,16 @@ pub const VM = struct {
 
                         try self.bindRefSlot(&frame.ref_slots, dst_name, c);
                     } else {
-                        const obj_ptr = obj_val.object;
+                        var obj_ptr = obj_val.object;
                         const prop_str = (try self.coerceToStringValue(name_val)).string.bytes();
                         // dupe so the binding's prop_name outlives the temporary
                         const prop_owned = try self.allocator.dupe(u8, prop_str);
                         try self.strings.append(self.allocator, prop_owned);
+                        self.triggerLazyProperty(obj_ptr, prop_owned, self.currentDefiningClass()) catch {
+                            if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
+                            return error.RuntimeError;
+                        };
+                        obj_ptr = obj_ptr.storage();
                         if (try self.checkPropertyMutation(obj_ptr, prop_owned, .indirect)) continue;
                         if (self.hasPropHook(obj_ptr.class_name, prop_owned, .get) and !self.inPropHook(obj_ptr, prop_owned) and !try self.propGetReturnsRef(obj_ptr, prop_owned)) {
                             obj_ptr.refcount +%= 1;
@@ -6022,11 +6035,12 @@ pub const VM = struct {
                     const prop_name = self.currentChunk().constants.items[name_idx].string.bytes();
                     const obj_val = self.pop();
                     if (obj_val == .object) {
-                        const obj = obj_val.object;
+                        var obj = obj_val.object;
                         self.triggerLazyProperty(obj, prop_name, self.currentDefiningClass()) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        obj = obj.storage();
                         if (!obj.isUnset(prop_name)) {
                             if (try self.checkPropertyMutation(obj, prop_name, .unset)) continue;
                         }
@@ -6065,11 +6079,12 @@ pub const VM = struct {
                     const name_val = self.pop();
                     const obj_val = self.pop();
                     if (obj_val == .object and name_val == .string) {
-                        const obj = obj_val.object;
+                        var obj = obj_val.object;
                         self.triggerLazyProperty(obj, name_val.string.bytes(), self.currentDefiningClass()) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        obj = obj.storage();
                         const prop_name = name_val.string.bytes();
                         if (!obj.isUnset(prop_name)) {
                             if (try self.checkPropertyMutation(obj, prop_name, .unset)) continue;
@@ -6428,11 +6443,12 @@ pub const VM = struct {
                     const prop_name = self.currentChunk().constants.items[name_idx].string.bytes();
                     const obj_val = self.pop();
                     if (obj_val == .object) {
-                        const obj = obj_val.object;
+                        var obj = obj_val.object;
                         self.triggerLazyProperty(obj, prop_name, self.currentDefiningClass()) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        obj = obj.storage();
                         if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
                             obj.refcount +%= 1;
                             defer self.releaseValue(.{ .object = obj });
@@ -6459,11 +6475,12 @@ pub const VM = struct {
                     const prop_name_val = self.pop();
                     const obj_val = self.pop();
                     if (obj_val == .object and prop_name_val == .string) {
-                        const obj = obj_val.object;
+                        var obj = obj_val.object;
                         self.triggerLazyProperty(obj, prop_name_val.string.bytes(), self.currentDefiningClass()) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        obj = obj.storage();
                         const prop_name = prop_name_val.string.bytes();
                         if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
                             obj.refcount +%= 1;
@@ -6536,11 +6553,12 @@ pub const VM = struct {
                         return error.RuntimeError;
                     }
                     if (val == .object) {
-                        const src = val.object;
+                        var src = val.object;
                         self.triggerLazyInit(src) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        src = src.storage();
                         const copy = try self.allocator.create(PhpObject);
                         self.next_object_id += 1;
                         copy.* = .{ .class_name = src.class_name, .id = self.next_object_id };
@@ -6557,13 +6575,37 @@ pub const VM = struct {
                             try copy.properties.put(self.allocator, entry.key_ptr.*, try self.copyObjectCloneValue(entry.value_ptr.*));
                         }
                         try self.objects.append(self.allocator, copy);
+                        if (src.ref_mirrored) {
+                            if (src.slot_layout) |layout| {
+                                for (layout.names) |name| {
+                                    if (self.ref_index) |ri| {
+                                        if (ri.prop_rev.get(.{ .object = src, .class_name = "", .prop_name = name })) |cells| {
+                                            if (cells.items.len > 0) {
+                                                const cell = cells.items[0];
+                                                try self.regRefObject(try self.persistentRefOwner(), cell, copy, name);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         if (self.hasMethod(src.class_name, "__clone")) {
                             _ = self.callMethod(copy, "__clone", &.{}) catch {
                                 if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                                 return error.RuntimeError;
                             };
                         }
-                        self.push(.{ .object = copy });
+                        if (val.object.backingValue() != .null) {
+                            const proxy = try self.allocator.create(PhpObject);
+                            self.next_object_id += 1;
+                            proxy.* = .{ .class_name = val.object.class_name, .id = self.next_object_id, .slot_layout = val.object.slot_layout };
+                            const state = try self.allocator.create(PhpObject.LazyState);
+                            state.* = .{ .initializer = .null, .proxy = true, .pending = try self.allocator.alloc(bool, 0), .backing = copy };
+                            proxy.lazy = state;
+                            copy.retain();
+                            try self.objects.append(self.allocator, proxy);
+                            self.push(.{ .object = proxy });
+                        } else self.push(.{ .object = copy });
                     } else {
                         self.push(val);
                     }
@@ -6660,7 +6702,7 @@ pub const VM = struct {
                     if (v == .array) {
                         self.push(v);
                     } else if (v == .object) {
-                        const obj = v.object;
+                        const obj = v.object.storage();
                         const arr = try self.allocator.create(PhpArray);
                         arr.* = .{};
                         try self.arrays.append(self.allocator, arr);
@@ -8024,17 +8066,18 @@ pub const VM = struct {
                     if (capturing) stackRetain(obj_val);
                     defer if (capturing) self.releaseValue(obj_val);
                     defer if (capturing and obj_val == .object and self.sp == arg_sp + 1 and self.pending_exception == null) {
-                        self.capturePropertyCell(arg_sp, obj_val.object, prop_name) catch unreachable;
+                        self.capturePropertyCell(arg_sp, obj_val.object.storage(), prop_name) catch unreachable;
                     };
                     if (obj_val == .object) {
-                        const obj = obj_val.object;
+                        var obj = obj_val.object;
                         obj.refcount +%= 1;
-                        defer self.releaseValue(.{ .object = obj });
+                        defer self.releaseValue(obj_val);
 
                         if (obj.isLazySlot(prop_name, self.currentDefiningClass())) self.triggerLazyInit(obj) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        obj = obj.storage();
 
                         // property hooks: dispatch to get hook if present (and not recursing).
                         // route exceptions through the local try/catch handler
@@ -8160,13 +8203,14 @@ pub const VM = struct {
                     };
                     const obj_val = self.pop();
                     if (obj_val == .object) {
-                        const obj = obj_val.object;
+                        var obj = obj_val.object;
                         obj.refcount +%= 1;
-                        defer self.releaseValue(.{ .object = obj });
+                        defer self.releaseValue(obj_val);
                         if (obj.isLazySlot(prop_name, self.currentDefiningClass())) self.triggerLazyInit(obj) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        obj = obj.storage();
                         if (self.hasPropHook(obj.class_name, prop_name, .get) and !self.inPropHook(obj, prop_name)) {
                             const hook_result = self.callPropHook(obj, prop_name, .get, .null) catch {
                                 if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
@@ -8245,14 +8289,15 @@ pub const VM = struct {
                     defer if (sp_val_pin) |p| self.objRelease(p);
                     const obj_val = self.pop();
                     if (obj_val == .object) {
-                        const obj = obj_val.object;
+                        var obj = obj_val.object;
                         obj.refcount +%= 1;
-                        defer self.releaseValue(.{ .object = obj });
+                        defer self.releaseValue(obj_val);
 
                         if (obj.isLazySlot(prop_name, self.currentDefiningClass())) self.triggerLazyInit(obj) catch {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
+                        obj = obj.storage();
 
                         // the set-scope gate runs before hooks and __set, but only
                         // an asymmetric or readonly declaration can ever deny a write
@@ -14160,7 +14205,7 @@ pub const VM = struct {
 
     fn methodByValue(self: *VM, receiver: Value, method: []const u8, pos: u8) ?bool {
         if (receiver != .object) return null;
-        if (receiver.object.lazyInitializer() != .null) return null;
+        if (receiver.object.lazy != null) return null;
         return self.classMethodByValue(receiver.object.class_name, method, pos, "__call");
     }
 
@@ -15241,7 +15286,7 @@ pub const VM = struct {
         state.running = true;
         defer state.running = false;
         var ctx = self.makeContext(null);
-        const result = ctx.invokeCallable(state.initializer, &.{.{ .object = obj }}) catch |err| {
+        errdefer {
             for (slots, saved, 0..) |*slot, v, i| {
                 if (self.ref_index) |ri| {
                     if (obj.slot_layout) |layout| {
@@ -15256,13 +15301,52 @@ pub const VM = struct {
             obj.properties.clearRetainingCapacity();
             for (props.keys(), props.values()) |k, v| {
                 retainValue(v);
-                try obj.properties.put(self.allocator, k, v);
+                obj.properties.put(self.allocator, k, v) catch unreachable;
             }
             obj.unset_slots.deinit(self.allocator);
             obj.unset_slots = unset;
             unset = .{};
-            return err;
-        };
+        }
+        if (state.proxy) {
+            const result = try ctx.invokeCallable(state.initializer, &.{.{ .object = obj }});
+            if (result != .object) {
+                const kind: []const u8 = switch (result) {
+                    .null => "null",
+                    .int => "int",
+                    .bool => "bool",
+                    .float => "float",
+                    .string => "string",
+                    .array => "array",
+                    else => "object",
+                };
+                const msg = try std.fmt.allocPrint(self.allocator, "Lazy proxy factory must return an instance of a class compatible with {s}, {s} returned", .{ obj.class_name, kind });
+                try self.strings.append(self.allocator, msg);
+                try self.setPendingException("TypeError", msg);
+                return error.RuntimeError;
+            }
+            const backing = result.object;
+            if (backing == obj or backing.lazyInitializer() != .null or backing.backingValue() != .null) {
+                try self.setPendingException("Error", "Lazy proxy factory must return a non-lazy object");
+                return error.RuntimeError;
+            }
+            if (!self.isInstanceOf(obj.class_name, backing.class_name) or
+                (if (obj.slots) |v| v.len else 0) != (if (backing.slots) |v| v.len else 0) or
+                (self.hasMethod(obj.class_name, "__clone") and (!self.hasMethod(backing.class_name, "__clone") or !std.mem.eql(u8, try self.resolveMethod(obj.class_name, "__clone"), try self.resolveMethod(backing.class_name, "__clone")))) or
+                (self.hasMethod(obj.class_name, "__destruct") and (!self.hasMethod(backing.class_name, "__destruct") or !std.mem.eql(u8, try self.resolveMethod(obj.class_name, "__destruct"), try self.resolveMethod(backing.class_name, "__destruct")))))
+            {
+                const msg = try std.fmt.allocPrint(self.allocator, "The real instance class {s} is not compatible with the proxy class {s}. The proxy must be a instance of the same class as the real instance, or a sub-class with no additional properties, and no overrides of the __destructor or __clone methods.", .{ backing.class_name, obj.class_name });
+                try self.strings.append(self.allocator, msg);
+                try self.setPendingException("TypeError", msg);
+                return error.RuntimeError;
+            }
+            retainValue(result);
+            state.backing = backing;
+            const initializer = state.initializer;
+            state.initializer = .null;
+            self.releaseValue(initializer);
+            return;
+        }
+        const result = try ctx.invokeCallable(state.initializer, &.{.{ .object = obj }});
         _ = result;
         const initializer = state.initializer;
         state.initializer = .null;
@@ -17833,7 +17917,7 @@ pub const VM = struct {
                 if (self.valueInGlobalsCell(.{ .object = obj })) continue;
                 if (self.debug_gc_verify) self.gcVerifyDestructing(obj);
                 obj.destructed = true;
-                if (obj.lazyInitializer() == .null and self.hasMethod(obj.class_name, "__destruct")) {
+                if (obj.ownsDestructor() and self.hasMethod(obj.class_name, "__destruct")) {
                     _ = self.callMethod(obj, "__destruct", &.{}) catch {
                         // a throwing destructor must not corrupt the drop site
                         // it was called from - swallow (revisit for fidelity)
@@ -18243,6 +18327,7 @@ pub const VM = struct {
             };
             var pit = obj.properties.iterator();
             while (pit.next()) |e| if (gcTargetMatches(t, e.value_ptr.*)) gcNote(&c, in_graph, "object {s}#{d} rc {d} scratch {d} prop {s}", .{ obj.class_name, obj.id, obj.refcount, obj.scratch_rc, e.key_ptr.* });
+            if (gcTargetMatches(t, obj.backingValue())) gcNote(&c, in_graph, "object {s}#{d} lazy_backing", .{ obj.class_name, obj.id });
             if (gcTargetMatches(t, obj.lazyInitializer())) gcNote(&c, in_graph, "object {s}#{d} lazy_initializer", .{ obj.class_name, obj.id });
         }
         const rc: u32 = switch (t) {
@@ -18514,6 +18599,7 @@ pub const VM = struct {
         vo.put(self.allocator, obj, {}) catch return;
         obj.scratch_rc = @intCast(obj.refcount);
         self.cycleVisitChild(obj.lazyInitializer(), vo, va);
+        self.cycleVisitChild(obj.backingValue(), vo, va);
         if (obj.slots) |s| {
             for (s) |v| self.cycleVisitChild(v, vo, va);
         }
@@ -18582,6 +18668,7 @@ pub const VM = struct {
 
     fn cycleDecrementChildren(self: *VM, obj: *PhpObject, vo: anytype, va: anytype) void {
         self.cycleDecChild(obj.lazyInitializer(), vo, va);
+        self.cycleDecChild(obj.backingValue(), vo, va);
         if (obj.slots) |s| {
             for (s) |v| self.cycleDecChild(v, vo, va);
         }
@@ -18622,6 +18709,7 @@ pub const VM = struct {
 
     fn cycleMarkAlive(self: *VM, obj: *PhpObject, vo: anytype, va: anytype) bool {
         var changed = self.cycleMarkAliveChild(obj.lazyInitializer(), vo, va);
+        changed = self.cycleMarkAliveChild(obj.backingValue(), vo, va) or changed;
         if (obj.slots) |s| {
             for (s) |v| if (self.cycleMarkAliveChild(v, vo, va)) {
                 changed = true;
@@ -18819,6 +18907,10 @@ pub const VM = struct {
                 ri.removeTargetAllOwners(self.allocator, binding.cell, binding.target);
             }
         };
+        if (obj.backingValue() != .null) {
+            self.releaseValue(obj.backingValue());
+            obj.lazy.?.backing = null;
+        }
         if (obj.lazyInitializer() != .null) {
             self.releaseValue(obj.lazyInitializer());
             obj.lazy.?.initializer = .null;

--- a/src/stdlib/json.zig
+++ b/src/stdlib/json.zig
@@ -320,8 +320,9 @@ fn encodeValue(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, val: Valu
                 try buf.append(a, '}');
             }
         },
-        .object => |obj| {
-            if (vm) |runtime| try runtime.triggerLazyInit(obj);
+        .object => |proxy| {
+            if (vm) |runtime| try runtime.triggerLazyInit(proxy);
+            const obj = proxy.storage();
             // PHP treats resources (fopen handles, curl handles, etc.) as
             // unsupported in json_encode: returns false + sets last_error to
             // 'Type is not supported' (and JsonException with THROW_ON_ERROR).

--- a/src/stdlib/reflection.zig
+++ b/src/stdlib/reflection.zig
@@ -180,7 +180,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionClass::hasProperty", rcHasProperty);
     try vm.native_fns.put(a, "ReflectionClass::newInstanceWithoutConstructor", rcNewInstanceWithoutConstructor);
     try vm.native_fns.put(a, "ReflectionClass::newLazyGhost", rcNewLazyGhost);
-    try vm.native_fns.put(a, "ReflectionClass::newLazyProxy", rcNewLazyGhost);
+    try vm.native_fns.put(a, "ReflectionClass::newLazyProxy", rcNewLazyProxy);
     try vm.native_fns.put(a, "ReflectionClass::initializeLazyObject", rcInitializeLazyObject);
     try vm.native_fns.put(a, "ReflectionClass::isUninitializedLazyObject", rcIsUninitializedLazyObject);
     try vm.native_fns.put(a, "ReflectionClass::markLazyObjectAsInitialized", rcMarkLazyObjectAsInitialized);
@@ -1712,6 +1712,12 @@ fn rcHasProperty(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return .{ .bool = findPropertyDef(ctx.vm, class_name, args[0].string.bytes()) != null };
 }
 
+fn rcNewLazyProxy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+    const result = try rcNewLazyGhost(ctx, args);
+    if (result == .object) result.object.lazy.?.proxy = true;
+    return result;
+}
+
 fn rcNewLazyGhost(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
     const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
@@ -1740,7 +1746,7 @@ fn rcInitializeLazyObject(ctx: *NativeContext, args: []const Value) RuntimeError
     if (args.len < 1 or args[0] != .object) return .null;
     const obj = args[0].object;
     try ctx.vm.triggerLazyInit(obj);
-    return .{ .object = obj };
+    return .{ .object = obj.storage() };
 }
 
 fn rcIsUninitializedLazyObject(_: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1758,7 +1764,7 @@ fn rcMarkLazyObjectAsInitialized(ctx: *NativeContext, args: []const Value) Runti
             ctx.vm.releaseValue(initializer);
         }
     }
-    return .{ .object = args[0].object };
+    return .{ .object = args[0].object.storage() };
 }
 
 fn rcNewInstanceWithoutConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!Value {

--- a/src/stdlib/serialize.zig
+++ b/src/stdlib/serialize.zig
@@ -323,10 +323,12 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
             }
             try buf.append(a, '}');
         },
-        .object => |obj| {
+        .object => |proxy| {
+            var obj = proxy;
             if (obj.lazy) |state| {
                 if (!state.skip_serialize) try ctx.vm.triggerLazyInit(obj);
             }
+            obj = obj.storage();
             // emit a back-reference if we've already serialized this object
             if (sctx.objects.get(obj)) |existing_slot| {
                 // rewind the slot counter: this r: entry occupies the slot we already consumed

--- a/src/stdlib/types.zig
+++ b/src/stdlib/types.zig
@@ -1089,8 +1089,8 @@ fn native_get_object_vars(ctx: *NativeContext, args: []const Value) RuntimeError
         return .{ .array = empty };
     }
     if (args.len == 0 or args[0] != .object) return Value{ .bool = false };
-    const obj = args[0].object;
-    try ctx.vm.triggerLazyInit(obj);
+    try ctx.vm.triggerLazyInit(args[0].object);
+    const obj = args[0].object.storage();
     var arr = try ctx.createArray();
 
     // Determine caller's class scope via the calling frame's function name (which is

--- a/tests/lazy_proxy_edges.php
+++ b/tests/lazy_proxy_edges.php
@@ -1,0 +1,60 @@
+<?php
+class ProxyEdge {
+    public int $value = 3;
+    public mixed $link = null;
+}
+$r = new ReflectionClass(ProxyEdge::class);
+$b = new ProxyEdge();
+$p = $r->newLazyProxy(fn () => $b);
+$rp = $r->getProperty('value');
+var_dump($rp->isLazy($p));
+$rp->setValue($p, 9);
+var_dump($rp->isLazy($p), $b->value);
+$ref =& $p->value;
+$ref = 21;
+echo $b->value, ':', $p->value, "\n";
+$b->value = 22;
+echo $ref, "\n";
+echo json_encode($p), "\n";
+echo json_encode(get_object_vars($p)), "\n";
+$c = clone $p;
+var_dump($r->initializeLazyObject($c) !== $c);
+$c->value = 80;
+echo $p->value, ':', $c->value, "\n";
+$skip = $r->newLazyProxy(fn () => $b, ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE);
+echo serialize($skip), "\n";
+var_dump($r->isUninitializedLazyObject($skip));
+foreach ([null, 123, new stdClass()] as $bad) {
+    $invalid = $r->newLazyProxy(fn () => $bad);
+    try { $r->initializeLazyObject($invalid); } catch (Throwable $e) { echo get_class($e), ':', $e->getMessage(), "\n"; }
+    var_dump($r->isUninitializedLazyObject($invalid));
+}
+$self = $r->newLazyProxy(fn ($proxy) => $proxy);
+try { $self->value; } catch (Throwable $e) { echo get_class($e), ':', $e->getMessage(), "\n"; }
+class ProxyCycle {
+    public mixed $link = null;
+    public function __destruct() { echo "cycle released\n"; }
+}
+function proxyCycle() {
+    $r = new ReflectionClass(ProxyCycle::class);
+    $b = new ProxyCycle();
+    $p = $r->newLazyProxy(fn () => $b);
+    $p->link = $p;
+}
+proxyCycle();
+gc_collect_cycles();
+echo "collected\n";
+class ProxyParent { public int $x = 1; }
+class ProxyChild extends ProxyParent {}
+class ProxyOverride extends ProxyParent { public function __clone() {} }
+class ProxyExtra extends ProxyParent { public int $extra = 2; }
+foreach ([ProxyChild::class, ProxyOverride::class, ProxyExtra::class] as $class) {
+    $rc = new ReflectionClass($class);
+    $proxy = $rc->newLazyProxy(fn () => new ProxyParent());
+    try { echo $proxy->x, "\n"; }
+    catch (Throwable $e) { echo get_class($e), "\n"; }
+}
+$rollback = $r->newLazyProxy(function ($proxy) { $proxy->value = 99; throw new RuntimeException('rollback'); });
+try { $rollback->value; } catch (Throwable $e) {}
+$r->markLazyObjectAsInitialized($rollback);
+echo $rollback->value, "\n";

--- a/tests/lazy_proxy_factory.php
+++ b/tests/lazy_proxy_factory.php
@@ -1,0 +1,31 @@
+<?php
+class ProxyService {
+    public int $value = 1;
+    private string $label = 'default';
+    public array $items = [];
+    public function configure(string $label): void { $this->label = $label; }
+    public function read(): string { return $this->label . ':' . $this->value; }
+    public function identity(): object { return $this; }
+}
+$r = new ReflectionClass(ProxyService::class);
+$backing = new ProxyService();
+$backing->value = 42;
+$backing->configure('factory');
+$calls = 0;
+$p = $r->newLazyProxy(function ($proxy) use (&$calls, $backing) { ++$calls; return $backing; });
+$alias = $p;
+var_dump($p->identity() === $p, $r->isUninitializedLazyObject($p), $calls);
+echo $p->read(), "\n";
+var_dump($p === $alias, $p !== $backing, $calls, $r->initializeLazyObject($p) === $backing);
+$p->value = 73;
+echo $backing->value, "\n";
+$backing->value = 91;
+echo $p->value, "\n";
+$p->items[] = 'shared';
+echo implode(',', $backing->items), "\n";
+var_dump(isset($p->value));
+unset($p->value);
+var_dump(isset($backing->value));
+$backing->value = 12;
+echo (new ReflectionProperty(ProxyService::class, 'value'))->getValue($p), "\n";
+var_dump($r->markLazyObjectAsInitialized($p) === $backing);

--- a/tests/lazy_proxy_lifecycle.php
+++ b/tests/lazy_proxy_lifecycle.php
@@ -1,0 +1,31 @@
+<?php
+class ProxyLife {
+    public int $value = 7;
+    public static int $destroyed = 0;
+    public function __destruct() { ++self::$destroyed; }
+    public function __clone() { ++$this->value; }
+}
+$r = new ReflectionClass(ProxyLife::class);
+$attempt = 0;
+$p = $r->newLazyProxy(function () use (&$attempt) {
+    ++$attempt;
+    if ($attempt === 1) throw new RuntimeException('retry');
+    if ($attempt === 2) return null;
+    return new ProxyLife();
+});
+for ($i = 0; $i < 3; ++$i) {
+    try { echo $p->value, "\n"; }
+    catch (Throwable $e) { echo get_class($e), "\n"; }
+    var_dump($r->isUninitializedLazyObject($p));
+}
+$c = clone $p;
+echo $c->value, ':', $p->value, "\n";
+var_dump($r->initializeLazyObject($c) !== $r->initializeLazyObject($p));
+echo serialize($p), "\n";
+unset($p);
+echo ProxyLife::$destroyed, "\n";
+unset($c);
+echo ProxyLife::$destroyed, "\n";
+$never = $r->newLazyProxy(fn () => new ProxyLife());
+unset($never);
+echo ProxyLife::$destroyed, "\n";

--- a/tests/symfony/harness/test-native-lazy-proxy.php
+++ b/tests/symfony/harness/test-native-lazy-proxy.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\LazyServiceInstantiator;
+
+require __DIR__ . '/../app/vendor/autoload.php';
+
+class LazyFactoryService
+{
+    public function __construct(public int $value) {}
+    public function value(): int { return $this->value; }
+    public function rename(int $value): void { $this->value = $value; }
+}
+
+class LazyServiceFactory
+{
+    public static int $calls = 0;
+    public static ?LazyFactoryService $instance = null;
+
+    public static function create(): LazyFactoryService
+    {
+        ++self::$calls;
+        return self::$instance = new LazyFactoryService(42);
+    }
+}
+
+function check(bool $condition, string $label): void
+{
+    if (!$condition) throw new RuntimeException($label);
+    echo "$label\n";
+}
+
+function definition(): ContainerBuilder
+{
+    $builder = new ContainerBuilder();
+    $builder->setProxyInstantiator(new LazyServiceInstantiator());
+    $builder->register('lazy.service', LazyFactoryService::class)
+        ->setFactory([LazyServiceFactory::class, 'create'])
+        ->setLazy(true)
+        ->setPublic(true);
+    return $builder;
+}
+
+function exercise($container): void
+{
+    LazyServiceFactory::$calls = 0;
+    LazyServiceFactory::$instance = null;
+    $service = $container->get('lazy.service');
+    $reflection = new ReflectionClass(LazyFactoryService::class);
+    check(LazyServiceFactory::$calls === 0, 'factory deferred');
+    check($reflection->isUninitializedLazyObject($service), 'proxy starts lazy');
+    check($container->get('lazy.service') === $service, 'container identity');
+    check($service->value() === 42, 'factory value loaded');
+    check(LazyServiceFactory::$calls === 1, 'factory called once');
+    check(!$reflection->isUninitializedLazyObject($service), 'proxy initialized');
+    check($service !== LazyServiceFactory::$instance, 'proxy identity preserved');
+    LazyServiceFactory::$instance->value = 73;
+    check($service->value() === 73, 'backing writes visible');
+    $service->rename(91);
+    check(LazyServiceFactory::$instance->value === 91, 'proxy writes forwarded');
+    check($container->get('lazy.service') === $service, 'initialized container identity');
+}
+
+exercise(definition());
+$builder = definition();
+$builder->compile();
+$code = (new PhpDumper($builder))->dump(['class' => 'NativeLazyFactoryContainer']);
+eval(substr($code, 5));
+exercise(new NativeLazyFactoryContainer());

--- a/tests/symfony/run
+++ b/tests/symfony/run
@@ -20,22 +20,29 @@ if [ ! -d "$APP_DIR/vendor" ]; then
     exit 1
 fi
 
+bounded() {
+    python3 - "$@" <<'PY'
+import subprocess
+import sys
+try:
+    result = subprocess.run(sys.argv[1:], timeout=60)
+except subprocess.TimeoutExpired:
+    print('Symfony harness timed out', file=sys.stderr)
+    sys.exit(124)
+sys.exit(result.returncode if result.returncode >= 0 else 128 - result.returncode)
+PY
+}
+
 passed=0
 failed=0
 errors=""
 
 for f in "$SCRIPT_DIR"/harness/test-*.php; do
     name="$(basename "$f" .php)"
-    php_out="$(php -d error_reporting=E_ALL\&~E_DEPRECATED\&~E_WARNING "$f" 2>&1)" || true
-    TIMEOUT_CMD=""
-    if command -v timeout &>/dev/null; then
-        TIMEOUT_CMD="timeout 60"
-    elif command -v gtimeout &>/dev/null; then
-        TIMEOUT_CMD="gtimeout 60"
-    fi
-    zphp_out="$($TIMEOUT_CMD "$ZPHP" run "$f" 2>&1)" && zphp_exit=0 || zphp_exit=$?
+    php_out="$(bounded php -d error_reporting=E_ALL\&~E_DEPRECATED\&~E_WARNING "$f" 2>&1)" && php_exit=0 || php_exit=$?
+    zphp_out="$(bounded "$ZPHP" run "$f" 2>&1)" && zphp_exit=0 || zphp_exit=$?
 
-    if [ "$php_out" = "$zphp_out" ]; then
+    if [ "$php_exit" -eq 0 ] && [ "$zphp_exit" -eq 0 ] && [ "$php_out" = "$zphp_out" ]; then
         passed=$((passed + 1))
         echo "  pass  $name"
     else


### PR DESCRIPTION
Implement native lazy proxies with backing-object forwarding, preserved proxy identity, factory validation, and initialization retry.

Add PHP parity tests and Symfony service-container coverage for deferred factory creation and shared backing state, including generated containers.