### PR TITLE
Skip duplicate CI for tested merges

### DIFF
--- a/.github/scripts/ci_reuse.py
+++ b/.github/scripts/ci_reuse.py
@@ -1,0 +1,59 @@
+import io
+import json
+import os
+import subprocess
+import zipfile
+
+
+def api(path):
+    return json.loads(subprocess.check_output(['gh', 'api', path]))
+
+
+def reusable(repo, sha):
+    commit = api(f'repos/{repo}/git/commits/{sha}')
+    pulls = api(f'repos/{repo}/commits/{sha}/pulls')
+    for pull in pulls:
+        if not pull['merged_at'] or pull['merge_commit_sha'] != sha:
+            continue
+        head = pull['head']['sha']
+        runs = api(f'repos/{repo}/actions/workflows/ci.yml/runs?event=pull_request&head_sha={head}&status=success&per_page=100')['workflow_runs']
+        for run in runs:
+            artifacts = api(f'repos/{repo}/actions/runs/{run["id"]}/artifacts')['artifacts']
+            for artifact in artifacts:
+                if artifact['name'] != 'tested-source' or artifact['expired']:
+                    continue
+                data = subprocess.check_output(['gh', 'api', f'repos/{repo}/actions/artifacts/{artifact["id"]}/zip'])
+                with zipfile.ZipFile(io.BytesIO(data)) as archive:
+                    proof = json.loads(archive.read('tested-source.json'))
+                if (proof['tree'] == commit['tree']['sha']
+                        and proof['head'] == head
+                        and proof['pull'] == pull['number']
+                        and proof['run'] == run['id']):
+                    return True
+    return False
+
+
+def main():
+    repo = os.environ['GITHUB_REPOSITORY']
+    sha = os.environ['GITHUB_SHA']
+    event = json.load(open(os.environ['GITHUB_EVENT_PATH']))
+    if os.environ['GITHUB_EVENT_NAME'] == 'pull_request':
+        tree = subprocess.check_output(['git', 'rev-parse', 'HEAD^{tree}'], text=True).strip()
+        proof = {'tree': tree, 'head': event['pull_request']['head']['sha'],
+                 'pull': event['number'], 'run': int(os.environ['GITHUB_RUN_ID'])}
+        with open('tested-source.json', 'w') as output:
+            json.dump(proof, output)
+        skip = False
+    else:
+        try:
+            skip = reusable(repo, sha)
+        except Exception as error:
+            print(f'Cannot verify prior CI; running full suite: {error}')
+            skip = False
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+        output.write(f'run-tests={str(not skip).lower()}\n')
+    print('Identical source already passed PR CI' if skip else 'Running full CI')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/test_ci_reuse.py
+++ b/.github/scripts/test_ci_reuse.py
@@ -1,0 +1,52 @@
+import importlib.util
+import io
+import json
+import unittest
+import zipfile
+from unittest.mock import patch
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location('ci_reuse', Path(__file__).with_name('ci_reuse.py'))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class ReuseTests(unittest.TestCase):
+    def check(self, tree='same', merged=True, expired=False, proof_head='head'):
+        responses = [
+            {'tree': {'sha': 'same'}},
+            [{'merged_at': 'today' if merged else None, 'merge_commit_sha': 'merge',
+              'number': 36, 'head': {'sha': 'head'}}],
+            {'workflow_runs': [{'id': 10}]},
+            {'artifacts': [{'id': 20, 'name': 'tested-source', 'expired': expired}]},
+        ]
+        data = io.BytesIO()
+        with zipfile.ZipFile(data, 'w') as archive:
+            archive.writestr('tested-source.json', json.dumps(
+                {'tree': tree, 'head': proof_head, 'pull': 36, 'run': 10}))
+        with patch.object(module, 'api', side_effect=responses), patch.object(
+                module.subprocess, 'check_output', return_value=data.getvalue()):
+            return module.reusable('owner/repo', 'merge')
+
+    def test_identical_successful_tree(self):
+        self.assertTrue(self.check())
+
+    def test_changed_merge_tree(self):
+        self.assertFalse(self.check(tree='different'))
+
+    def test_unmerged_pull(self):
+        self.assertFalse(self.check(merged=False))
+
+    def test_expired_proof(self):
+        self.assertFalse(self.check(expired=True))
+
+    def test_wrong_head(self):
+        self.assertFalse(self.check(proof_head='old'))
+
+    def test_direct_push(self):
+        with patch.object(module, 'api', side_effect=[{'tree': {'sha': 'same'}}, []]):
+            self.assertFalse(module.reusable('owner/repo', 'direct'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,32 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    outputs:
+      run-tests: ${{ steps.check.outputs.run-tests }}
+    steps:
+      - uses: actions/checkout@v6
+      - run: python3 .github/scripts/test_ci_reuse.py
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/ci_reuse.py
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
+        with:
+          name: tested-source
+          path: tested-source.json
+          retention-days: 30
+
   test:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     strategy:
       matrix:
         # macos pinned to 15: macos-latest resolved to macOS 26 in 2026-07 and
@@ -43,6 +68,8 @@ jobs:
       - run: zig build
 
   serve:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -62,6 +89,8 @@ jobs:
       - run: timeout 120 ./tests/serve_stress
 
   test-runner:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -81,6 +110,8 @@ jobs:
       - run: ./tests/dotenv_test
 
   packages:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -99,6 +130,8 @@ jobs:
       - run: ./tests/pkg_test
 
   fmt:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -117,6 +150,8 @@ jobs:
       - run: ./tests/fmt_test
 
   php-compat:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -141,6 +176,8 @@ jobs:
       - run: ./tests/run
 
   examples:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -162,6 +199,8 @@ jobs:
       - run: ./tests/examples_test
 
   laravel:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -185,6 +224,8 @@ jobs:
       - run: ./tests/laravel/run
 
   phpunit:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -209,6 +250,8 @@ jobs:
       - run: ./tests/phpunit/run
 
   composer:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -233,6 +276,8 @@ jobs:
       - run: ./tests/composer/run
 
   doctrine:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -257,6 +302,8 @@ jobs:
       - run: ./tests/doctrine/run
 
   symfony:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -281,6 +328,8 @@ jobs:
       - run: ./tests/symfony/serve_run
 
   wordpress:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -304,6 +353,8 @@ jobs:
       - run: ./tests/wordpress/run
 
   compile:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -328,6 +379,8 @@ jobs:
         run: ./tests/compile_test
 
   pdo:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     services:
       mysql:


### PR DESCRIPTION
Reuse successful PR validation when the merged source tree matches exactly. Keep full CI for direct pushes, changed source, and unverifiable results.