### PR TITLE
Reduce redundant cycle-collection work

### DIFF
--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -65,6 +65,7 @@ pub const PhpArray = struct {
     refcount: u32 = 0,
     elements_released: bool = false,
     pooled: bool = false,
+    cycle_queued: bool = false,
     release_queued: bool = false,
     // a weak container (WeakMap key list): its entries hold no reference to
     // the objects they name, so freeing it releases nothing and the cycle
@@ -768,6 +769,7 @@ pub const PhpObject = struct {
     // and the end-of-request safety sweep must not double-fire it)
     destructed: bool = false,
     pooled: bool = false,
+    cycle_queued: bool = false,
     // a reference cell has targeted one of this object's properties; the
     // release path must detach those weak mirrors before the address is reused
     ref_mirrored: bool = false,

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -17827,10 +17827,10 @@ pub const VM = struct {
         if (obj.refcount != 0) {
             // refcount went down but not to 0: object might be part of an
             // unreachable cycle (a -> b -> a where both still see each other).
-            // queue as a cycle-collector candidate. dedupe is handled inside
-            // collectCycles via the visited map - cheap to append duplicates
-            if (!obj.destructed) {
-                self.cycle_candidates.append(self.allocator, obj) catch {};
+            // each possible root occupies one candidate slot.
+            if (!obj.destructed and !obj.cycle_queued) {
+                self.cycle_candidates.append(self.allocator, obj) catch return;
+                obj.cycle_queued = true;
             }
             return;
         }
@@ -17861,13 +17861,14 @@ pub const VM = struct {
             self.pending_fiber_release.clearRetainingCapacity();
             self.fiber_release_cursor = 0;
             for (self.released_arrays.items) |arr| {
-                var i: usize = 0;
-                while (i < self.cycle_array_candidates.items.len) {
-                    if (self.cycle_array_candidates.items[i] == arr) {
-                        _ = self.cycle_array_candidates.swapRemove(i);
-                    } else {
-                        i += 1;
+                if (arr.cycle_queued) {
+                    for (self.cycle_array_candidates.items, 0..) |candidate, i| {
+                        if (candidate == arr) {
+                            _ = self.cycle_array_candidates.swapRemove(i);
+                            break;
+                        }
                     }
+                    arr.cycle_queued = false;
                 }
                 self.clearArgArraySources(arr);
                 arr.deinit(self.allocator);
@@ -17876,13 +17877,14 @@ pub const VM = struct {
             }
             self.released_arrays.clearRetainingCapacity();
             for (self.released_objects.items) |obj| {
-                var i: usize = 0;
-                while (i < self.cycle_candidates.items.len) {
-                    if (self.cycle_candidates.items[i] == obj) {
-                        _ = self.cycle_candidates.swapRemove(i);
-                    } else {
-                        i += 1;
+                if (obj.cycle_queued) {
+                    for (self.cycle_candidates.items, 0..) |candidate, i| {
+                        if (candidate == obj) {
+                            _ = self.cycle_candidates.swapRemove(i);
+                            break;
+                        }
                     }
+                    obj.cycle_queued = false;
                 }
                 obj.deinit(self.allocator);
                 obj.pooled = true;
@@ -18231,6 +18233,8 @@ pub const VM = struct {
                 live_range.has_statics = false;
             }
         }
+        for (self.cycle_candidates.items) |obj| obj.cycle_queued = false;
+        for (self.cycle_array_candidates.items) |arr| arr.cycle_queued = false;
         self.cycle_candidates.clearRetainingCapacity();
         self.cycle_array_candidates.clearRetainingCapacity();
         self.drainPendingDestruct();
@@ -18855,8 +18859,9 @@ pub const VM = struct {
         if (arr.refcount == 0) return;
         arr.refcount -= 1;
         if (arr.refcount != 0) {
-            if (!arr.elements_released) {
-                self.cycle_array_candidates.append(self.allocator, arr) catch {};
+            if (!arr.elements_released and !arr.cycle_queued) {
+                self.cycle_array_candidates.append(self.allocator, arr) catch return;
+                arr.cycle_queued = true;
             }
             return;
         }

--- a/tests/cycle_candidate_requeue.php
+++ b/tests/cycle_candidate_requeue.php
@@ -1,0 +1,22 @@
+<?php
+class CycleCandidate {
+    public $self;
+    public function __destruct() { echo "released\n"; }
+}
+for ($round = 0; $round < 3; ++$round) {
+    $object = new CycleCandidate;
+    $object->self = $object;
+    for ($i = 0; $i < 20000; ++$i) { $alias = $object; unset($alias); }
+    gc_collect_cycles();
+    echo "alive\n";
+    unset($object);
+    gc_collect_cycles();
+    $array = [];
+    $array['self'] = &$array;
+    $array['object'] = new CycleCandidate;
+    for ($i = 0; $i < 20000; ++$i) { $alias = $array; unset($alias); }
+    gc_collect_cycles();
+    echo "array alive\n";
+    unset($array);
+    gc_collect_cycles();
+}


### PR DESCRIPTION
Deduplicate object and array cycle candidates and avoid scanning candidate lists for unqueued values. Add regression coverage for repeated collection, live references, and candidate requeueing.