### PR TITLE
Make array mutations safe on allocation failure

### DIFF
--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -143,14 +143,15 @@ pub const PhpArray = struct {
     pub fn append(self: *PhpArray, allocator: std.mem.Allocator, value: Value) !void {
         // a store choke point: the new element takes a reference (callers
         // pass raw values, never copyValue'd ones); weak containers count nothing
-        if (!self.weak) retainStored(value);
         const k = if (self.has_int_keys) self.next_int_key else 0;
         if (self.has_int_keys and k == std.math.maxInt(i64)) {
             for (self.entries.items) |entry| {
                 if (entry.key == .int and entry.key.int == k) return;
             }
         }
-        try self.entries.append(allocator, .{ .key = .{ .int = k }, .value = value });
+        try self.entries.ensureUnusedCapacity(allocator, 1);
+        if (!self.weak) retainStored(value);
+        self.entries.appendAssumeCapacity(.{ .key = .{ .int = k }, .value = value });
         self.next_int_key = if (k == std.math.maxInt(i64)) k else k + 1;
         self.has_int_keys = true;
     }
@@ -160,7 +161,6 @@ pub const PhpArray = struct {
         // value (callers pass raw values, never copyValue'd ones) and the
         // element it replaces is released through the VM's release hook.
         // weak containers ($GLOBALS view, WeakMap keys) count nothing
-        if (!self.weak) retainStored(value);
         const key = normalizeKey(raw_key);
         if (key == .int) {
             const idx = key.int;
@@ -169,9 +169,11 @@ pub const PhpArray = struct {
                 if (uidx < self.entries.items.len) {
                     const entry = &self.entries.items[uidx];
                     if (entry.key == .int and entry.key.int == idx) {
+                        if (!self.weak) retainStored(value);
                         const old = entry.value;
                         entry.value = value;
-                        self.next_int_key = if (self.has_int_keys) @max(self.next_int_key, idx + 1) else idx + 1;
+                        const next = if (idx == std.math.maxInt(i64)) idx else idx + 1;
+                        self.next_int_key = if (self.has_int_keys) @max(self.next_int_key, next) else next;
                         self.has_int_keys = true;
                         if (!self.weak) releaseReplaced(old);
                         return;
@@ -181,6 +183,7 @@ pub const PhpArray = struct {
         }
         if (key == .string) {
             if (self.string_index.get(key.string.bytes())) |idx| {
+                if (!self.weak) retainStored(value);
                 const old = self.entries.items[idx].value;
                 self.entries.items[idx].value = value;
                 if (!self.weak) releaseReplaced(old);
@@ -189,6 +192,7 @@ pub const PhpArray = struct {
         } else {
             for (self.entries.items) |*entry| {
                 if (entry.key.eql(key)) {
+                    if (!self.weak) retainStored(value);
                     const old = entry.value;
                     entry.value = value;
                     if (!self.weak) releaseReplaced(old);
@@ -197,15 +201,19 @@ pub const PhpArray = struct {
             }
         }
         const new_idx = self.entries.items.len;
+        // Capacity may grow on failure, but entries, index contents, key
+        // progression and ownership remain unchanged until both reserves succeed.
+        try self.entries.ensureUnusedCapacity(allocator, 1);
+        if (key == .string) try self.string_index.ensureUnusedCapacity(allocator, 1);
+        if (!self.weak) retainStored(value);
         if (key == .string) key.string.retain();
-        errdefer if (key == .string) key.string.release();
-        try self.entries.append(allocator, .{ .key = key, .value = value });
+        self.entries.appendAssumeCapacity(.{ .key = key, .value = value });
         if (key == .int) {
             const next = if (key.int == std.math.maxInt(i64)) key.int else key.int + 1;
             self.next_int_key = if (self.has_int_keys) @max(self.next_int_key, next) else next;
             self.has_int_keys = true;
         } else if (key == .string) {
-            try self.string_index.put(allocator, key.string.bytes(), new_idx);
+            self.string_index.putAssumeCapacity(key.string.bytes(), new_idx);
         }
     }
 
@@ -279,12 +287,30 @@ pub const PhpArray = struct {
         return @intCast(self.entries.items.len);
     }
 
+    // Build off to the side: a failed rebuild leaves the old index intact.
+    // Callers that mutate entries first must instead preflight capacity before
+    // mutation and use rebuildStringIndexAssumeCapacity for their commit.
     pub fn rebuildStringIndex(self: *PhpArray, allocator: std.mem.Allocator) !void {
+        var index: std.StringHashMapUnmanaged(usize) = .{};
+        errdefer index.deinit(allocator);
+        for (self.entries.items, 0..) |entry, i| {
+            if (entry.key == .string) try index.put(allocator, entry.key.string.bytes(), i);
+        }
+        self.string_index.deinit(allocator);
+        self.string_index = index;
+    }
+
+    // Reserve an upper bound on the number of string-keyed entries AFTER the
+    // caller's mutation. No entries or index contents change if this fails.
+    pub fn reserveStringIndex(self: *PhpArray, allocator: std.mem.Allocator, string_count: usize) !void {
+        const count = std.math.cast(u32, string_count) orelse return error.OutOfMemory;
+        try self.string_index.ensureTotalCapacity(allocator, count);
+    }
+
+    pub fn rebuildStringIndexAssumeCapacity(self: *PhpArray) void {
         self.string_index.clearRetainingCapacity();
         for (self.entries.items, 0..) |entry, i| {
-            if (entry.key == .string) {
-                try self.string_index.put(allocator, entry.key.string.bytes(), i);
-            }
+            if (entry.key == .string) self.string_index.putAssumeCapacity(entry.key.string.bytes(), i);
         }
     }
 
@@ -1878,4 +1904,161 @@ test "identical" {
     try std.testing.expect(Value.identical(.{ .int = 2 }, .{ .int = 2 }));
     try std.testing.expect(!Value.identical(.{ .int = 1 }, .{ .int = 2 }));
     try std.testing.expect(!Value.identical(.{ .int = 2 }, .{ .string = Value.String.borrowed("2") }));
+}
+
+// These tests deliberately use an owned key/value allocated independently of
+// the failing allocator, so every failure in the operation can check ownership.
+fn testArrayStoreFailures(allocator: std.mem.Allocator, mode: enum { append, integer, string }, weak: bool) !void {
+    const key = try PhpString.create(std.testing.allocator, "owned-key");
+    defer key.release();
+    const value = try PhpString.create(std.testing.allocator, "owned-value");
+    defer value.release();
+    var arr: PhpArray = .{ .weak = weak, .cursor = 7 };
+    defer arr.deinit(allocator);
+    // Deinit releases keys, but the VM normally releases stored values.
+    defer if (!weak) {
+        for (arr.entries.items) |entry| if (entry.value == .string) {
+            entry.value.string.release();
+        };
+    };
+    const result = switch (mode) {
+        .append => arr.append(allocator, .{ .string = value }),
+        .integer => arr.set(allocator, .{ .int = std.math.maxInt(i64) }, .{ .string = value }),
+        .string => arr.set(allocator, .{ .string = key }, .{ .string = value }),
+    };
+    result catch |err| {
+        try std.testing.expectEqual(@as(usize, 0), arr.entries.items.len);
+        try std.testing.expectEqual(@as(u32, 0), arr.string_index.count());
+        try std.testing.expectEqual(@as(i64, 0), arr.next_int_key);
+        try std.testing.expect(!arr.has_int_keys);
+        try std.testing.expectEqual(@as(usize, 7), arr.cursor);
+        try std.testing.expectEqual(@as(u32, 1), key.owner.?.refcount);
+        try std.testing.expectEqual(@as(u32, 1), value.owner.?.refcount);
+        return err;
+    };
+    try std.testing.expectEqual(@as(usize, 1), arr.entries.items.len);
+    try std.testing.expectEqual(@as(u32, if (weak) 1 else 2), value.owner.?.refcount);
+    try std.testing.expectEqual(@as(u32, if (mode == .string) 2 else 1), key.owner.?.refcount);
+    try std.testing.expect(arr.entries.items[0].ref == null);
+    if (mode == .string) {
+        try std.testing.expectEqual(@as(usize, 0), arr.string_index.get(key.bytes()).?);
+    } else {
+        try std.testing.expect(arr.has_int_keys);
+        try std.testing.expectEqual(@as(i64, if (mode == .append) 1 else std.math.maxInt(i64)), arr.next_int_key);
+    }
+}
+
+test "array append and set fail atomically at every allocation" {
+    inline for (.{ .append, .integer, .string }) |mode| {
+        inline for (.{ false, true }) |weak| {
+            try std.testing.checkAllAllocationFailures(std.testing.allocator, testArrayStoreFailures, .{ mode, weak });
+        }
+    }
+}
+
+fn testArrayRebuildFailures(allocator: std.mem.Allocator) !void {
+    var arr: PhpArray = .{};
+    defer arr.deinit(allocator);
+    // Use the failing allocator for setup too; the exhaustive runner reaches
+    // every growth in both the initial index and the temporary replacement.
+    const keys = [_][]const u8{ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o" };
+    for (keys, 0..) |key, i| try arr.set(allocator, .{ .string = PhpString.borrowed(key) }, .{ .int = @intCast(i) });
+    var cell: Value = .{ .int = 42 };
+    arr.entries.items[0].ref = &cell;
+    arr.cursor = 4;
+    arr.rebuildStringIndex(allocator) catch |err| {
+        try std.testing.expectEqual(@as(u32, keys.len), arr.string_index.count());
+        for (keys, 0..) |key, i| try std.testing.expectEqual(i, arr.string_index.get(key).?);
+        try std.testing.expect(arr.entries.items[0].ref == &cell);
+        try std.testing.expectEqual(@as(usize, 4), arr.cursor);
+        return err;
+    };
+    for (keys, 0..) |key, i| try std.testing.expectEqual(i, arr.string_index.get(key).?);
+}
+
+test "array index rebuild preserves old complete index on every allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, testArrayRebuildFailures, .{});
+}
+
+const ArrayStoreTestRelease = struct {
+    calls: usize = 0,
+    fn call(ctx: *anyopaque, value: Value) void {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        if (value == .string) value.string.release();
+    }
+};
+
+test "array allocation-free stores preserve ownership metadata and overflow refusal" {
+    const allocator = std.testing.allocator;
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .fail_index = 0 });
+    const noalloc = failing.allocator();
+    const value = try PhpString.create(allocator, "same value");
+    defer value.release();
+    var releases: ArrayStoreTestRelease = .{};
+    const saved = release_hook;
+    release_hook = .{ .ctx = &releases, .call = ArrayStoreTestRelease.call };
+    defer release_hook = saved;
+    var arr: PhpArray = .{};
+    defer arr.deinit(allocator);
+    defer for (arr.entries.items) |entry| {
+        if (entry.value == .string) entry.value.string.release();
+    };
+    try arr.entries.ensureUnusedCapacity(allocator, 4);
+    try arr.reserveStringIndex(allocator, 2);
+    try arr.append(noalloc, .{ .string = value });
+    try arr.set(noalloc, .{ .string = PhpString.borrowed("0") }, .{ .string = value });
+    try arr.set(noalloc, .{ .int = -5 }, .{ .string = value });
+    try arr.set(noalloc, .{ .int = -5 }, .{ .string = value });
+    try arr.set(noalloc, .{ .string = PhpString.borrowed("name") }, .{ .string = value });
+    var cell: Value = .null;
+    arr.entries.items[2].ref = &cell;
+    try arr.set(noalloc, .{ .string = PhpString.borrowed("name") }, .{ .string = value });
+    try std.testing.expect(arr.entries.items[2].ref == &cell);
+    try arr.set(noalloc, .{ .string = PhpString.borrowed("9223372036854775807") }, .{ .string = value });
+    try arr.set(noalloc, .{ .int = std.math.maxInt(i64) }, .{ .string = value });
+    try arr.append(noalloc, .{ .string = value }); // refused, no retain
+    try std.testing.expectEqual(@as(usize, 4), arr.entries.items.len);
+    try std.testing.expectEqual(@as(u32, 5), value.owner.?.refcount);
+    try std.testing.expectEqual(@as(usize, 4), releases.calls);
+    try std.testing.expectEqual(std.math.maxInt(i64), arr.next_int_key);
+    std.mem.swap(PhpArray.Entry, &arr.entries.items[0], &arr.entries.items[2]);
+    arr.rebuildStringIndexAssumeCapacity();
+    try std.testing.expectEqual(@as(usize, 0), arr.string_index.get("name").?);
+    try std.testing.expect(arr.entries.items[0].ref == &cell);
+    try std.testing.expect(!failing.has_induced_failure);
+}
+
+test "array failed growth preserves populated entries and reference bindings" {
+    const allocator = std.testing.allocator;
+    var arr: PhpArray = .{ .cursor = 3 };
+    defer arr.deinit(allocator);
+    var held: PhpArray = .{};
+    var candidate: PhpArray = .{};
+    var cell: Value = .{ .int = 99 };
+    try arr.set(allocator, .{ .string = PhpString.borrowed("existing") }, .{ .array = &held });
+    arr.entries.items[0].ref = &cell;
+    // Force entry growth regardless of ArrayList's growth policy.
+    while (arr.entries.items.len < arr.entries.capacity) try arr.append(allocator, .null);
+    const len = arr.entries.items.len;
+    const next = arr.next_int_key;
+    var failing = std.testing.FailingAllocator.init(allocator, .{ .fail_index = 0, .resize_fail_index = 0 });
+    try std.testing.expectError(error.OutOfMemory, arr.append(failing.allocator(), .{ .array = &candidate }));
+    try std.testing.expectError(error.OutOfMemory, arr.set(failing.allocator(), .{ .int = -20 }, .{ .array = &candidate }));
+    try std.testing.expectError(error.OutOfMemory, arr.set(failing.allocator(), .{ .string = PhpString.borrowed("new") }, .{ .array = &candidate }));
+    try std.testing.expectError(error.OutOfMemory, arr.reserveStringIndex(failing.allocator(), 100));
+    try std.testing.expectEqual(len, arr.entries.items.len);
+    try std.testing.expectEqual(next, arr.next_int_key);
+    try std.testing.expectEqual(@as(usize, 3), arr.cursor);
+    try std.testing.expectEqual(@as(u32, 1), held.refcount);
+    try std.testing.expectEqual(@as(u32, 0), candidate.refcount);
+    try std.testing.expect(arr.entries.items[0].ref == &cell);
+    try std.testing.expectEqual(@as(usize, 0), arr.string_index.get("existing").?);
+    try std.testing.expect(!arr.contains(.{ .string = PhpString.borrowed("new") }));
+    // A weak replacement neither retains the candidate nor releases the old.
+    arr.weak = true;
+    try arr.set(failing.allocator(), .{ .string = PhpString.borrowed("existing") }, .{ .array = &candidate });
+    try std.testing.expectEqual(@as(u32, 0), candidate.refcount);
+    try std.testing.expectEqual(@as(u32, 1), held.refcount);
+    try std.testing.expect(arr.entries.items[0].ref == &cell);
 }

--- a/src/stdlib/arrays.zig
+++ b/src/stdlib/arrays.zig
@@ -127,7 +127,8 @@ fn array_shift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0 or args[0] != .array) return .null;
     const arr = args[0].array;
     if (arr.entries.items.len == 0) return .null;
-    const first = arr.entries.orderedRemove(0);
+    const first = arr.entries.items[0];
+    ctx.vm.arrayRemoveOwned(arr, first.key);
     // re-index numeric keys starting from 0
     var next_int: i64 = 0;
     for (arr.entries.items) |*entry| {
@@ -139,9 +140,8 @@ fn array_shift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             .string => {},
         }
     }
-    try arr.rebuildStringIndex(ctx.allocator);
-    // drop the array's retain on the shifted element (Stage 2)
-    ctx.vm.releaseValue(first.value);
+    arr.rebuildStringIndexAssumeCapacity();
+
     return first.value;
 }
 
@@ -583,6 +583,14 @@ pub const SortField = enum { value, key };
 
 pub fn mergeSort(comptime T: type, items: []T, ctx: *NativeContext, callback: Value, comptime field: SortField) RuntimeError!void {
     if (items.len <= 1) return;
+    const staged = try ctx.allocator.dupe(T, items);
+    defer ctx.allocator.free(staged);
+    try mergeSortStaged(T, staged, ctx, callback, field);
+    @memcpy(items, staged);
+}
+
+fn mergeSortStaged(comptime T: type, items: []T, ctx: *NativeContext, callback: Value, comptime field: SortField) RuntimeError!void {
+    if (items.len <= 1) return;
     if (items.len <= 16) {
         // insertion sort for small slices
         for (1..items.len) |i| {
@@ -599,9 +607,9 @@ pub fn mergeSort(comptime T: type, items: []T, ctx: *NativeContext, callback: Va
         return;
     }
     const mid = items.len / 2;
-    try mergeSort(T, items[0..mid], ctx, callback, field);
-    try mergeSort(T, items[mid..], ctx, callback, field);
-    const buf = ctx.allocator.alloc(T, items.len) catch return;
+    try mergeSortStaged(T, items[0..mid], ctx, callback, field);
+    try mergeSortStaged(T, items[mid..], ctx, callback, field);
+    const buf = try ctx.allocator.alloc(T, items.len);
     defer ctx.allocator.free(buf);
     var l: usize = 0;
     var r: usize = mid;
@@ -890,13 +898,31 @@ fn array_splice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     } else @intCast(alen - offset);
     length = @min(length, arr.entries.items.len - uoffset);
 
-    var removed = try ctx.createArray();
+    const replacement_values: []Value = if (args.len >= 4 and args[3] == .array) blk: {
+        const source = args[3].array.entries.items;
+        const values = try ctx.allocator.alloc(Value, source.len);
+        for (source, values) |entry, *value| {
+            value.* = entry.value;
+            VM.retainValue(value.*);
+        }
+        break :blk values;
+    } else blk: {
+        const count: usize = if (args.len >= 4 and args[3] != .null) 1 else 0;
+        const values = try ctx.allocator.alloc(Value, count);
+        if (count != 0) {
+            values[0] = args[3];
+            VM.retainValue(values[0]);
+        }
+        break :blk values;
+    };
+    defer {
+        for (replacement_values) |value| ctx.vm.releaseValue(value);
+        ctx.allocator.free(replacement_values);
+    }
+    try arr.entries.ensureUnusedCapacity(ctx.allocator, replacement_values.len);
+    const removed = try ctx.createArray();
     var removed_int_idx: i64 = 0;
-    for (0..length) |_| {
-        const entry = arr.entries.orderedRemove(uoffset);
-        // arr loses its retain on the removed value; removed.set retains
-        // again - net 0 for objects/arrays (Stage 2 element-overwrite release)
-        ctx.vm.releaseValue(entry.value);
+    for (arr.entries.items[uoffset..][0..length]) |entry| {
         switch (entry.key) {
             .string => try removed.set(ctx.allocator, entry.key, entry.value),
             .int => {
@@ -905,20 +931,10 @@ fn array_splice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             },
         }
     }
-
-    if (args.len >= 4) {
-        if (args[3] == .array) {
-            const replacement = args[3].array;
-            var insert_idx = uoffset;
-            for (replacement.entries.items) |entry| {
-                VM.retainValue(entry.value);
-                try arr.entries.insert(ctx.allocator, insert_idx, .{ .key = .{ .int = 0 }, .value = entry.value });
-                insert_idx += 1;
-            }
-        } else if (args[3] != .null) {
-            // PHP: a non-array, non-null replacement is treated as a single element
-            try arr.entries.insert(ctx.allocator, uoffset, .{ .key = .{ .int = 0 }, .value = args[3] });
-        }
+    for (0..length) |_| ctx.vm.arrayRemoveOwned(arr, arr.entries.items[uoffset].key);
+    for (replacement_values, 0..) |value, i| {
+        VM.retainValue(value);
+        arr.entries.insertAssumeCapacity(uoffset + i, .{ .key = .{ .int = 0 }, .value = value });
     }
 
     // re-index numeric keys
@@ -931,7 +947,7 @@ fn array_splice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     arr.next_int_key = next_int;
     arr.has_int_keys = next_int > 0;
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
 
     return .{ .array = removed };
 }
@@ -1358,6 +1374,7 @@ fn array_unshift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len < 2 or args[0] != .array) return .{ .int = 0 };
     const arr = args[0].array;
 
+    try arr.entries.ensureUnusedCapacity(ctx.allocator, args.len - 1);
     var insert_idx: usize = 0;
     for (args[1..]) |val| {
         VM.retainValue(val);
@@ -1373,7 +1390,7 @@ fn array_unshift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
     arr.next_int_key = next_int;
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .int = arr.length() };
 }
 
@@ -1582,7 +1599,7 @@ fn native_ksort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortKeysWithFlags(arr, flags, false);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
     return .{ .bool = true };
 }
@@ -1593,7 +1610,7 @@ fn native_krsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortKeysWithFlags(arr, flags, true);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
     return .{ .bool = true };
 }
@@ -1604,7 +1621,7 @@ fn native_asort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortWithFlags(arr, flags, false);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
     return .{ .bool = true };
 }
@@ -1615,7 +1632,7 @@ fn native_arsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortWithFlags(arr, flags, true);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
     return .{ .bool = true };
 }
@@ -1672,7 +1689,7 @@ fn native_uasort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     const callback = args[1];
     try mergeSort(PhpArray.Entry, arr.entries.items, ctx, callback, .value);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
     return .{ .bool = true };
 }
@@ -1683,7 +1700,7 @@ fn native_uksort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     const callback = args[1];
     try mergeSort(PhpArray.Entry, arr.entries.items, ctx, callback, .key);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
     return .{ .bool = true };
 }
@@ -2365,4 +2382,37 @@ fn array_change_key_case(ctx: *NativeContext, args: []const Value) RuntimeError!
         try result.set(ctx.allocator, new_key, entry.value);
     }
     return .{ .array = result };
+}
+
+test "unshift allocation failure preserves entries and ownership" {
+    const testing = std.testing;
+    var vm = try VM.init(testing.allocator);
+    defer vm.deinit();
+    const arr = try vm.allocArray();
+    const owned = try Value.String.create(testing.allocator, "owned");
+    defer owned.release();
+    var failing = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    var ctx: NativeContext = .{ .allocator = failing.allocator(), .arrays = &vm.arrays, .strings = &vm.strings, .vm = &vm };
+    const count = owned.owner.?.refcount;
+    try testing.expectError(error.OutOfMemory, array_unshift(&ctx, &.{ .{ .array = arr }, .{ .string = owned } }));
+    try testing.expectEqual(@as(usize, 0), arr.entries.items.len);
+    try testing.expectEqual(count, owned.owner.?.refcount);
+    ctx.allocator = testing.allocator;
+    _ = try array_unshift(&ctx, &.{ .{ .array = arr }, .{ .string = owned } });
+    try testing.expectEqualStrings("owned", arr.get(.{ .int = 0 }).string.bytes());
+}
+
+test "callback sort staging failure preserves input" {
+    const testing = std.testing;
+    var vm = try VM.init(testing.allocator);
+    defer vm.deinit();
+    var failing = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    var ctx: NativeContext = .{ .allocator = failing.allocator(), .arrays = &vm.arrays, .strings = &vm.strings, .vm = &vm };
+    var items = [_]PhpArray.Entry{
+        .{ .key = .{ .int = 0 }, .value = .{ .int = 2 } },
+        .{ .key = .{ .int = 1 }, .value = .{ .int = 1 } },
+    };
+    try testing.expectError(error.OutOfMemory, mergeSort(PhpArray.Entry, &items, &ctx, .null, .value));
+    try testing.expectEqual(@as(i64, 2), items[0].value.int);
+    try testing.expectEqual(@as(i64, 1), items[1].value.int);
 }

--- a/src/stdlib/http.zig
+++ b/src/stdlib/http.zig
@@ -381,14 +381,14 @@ fn removeHeaderByName(ctx: *NativeContext, name: []const u8) void {
         if (entry.value == .string) {
             const hdr = entry.value.string.bytes();
             if (hdr.len > name.len and hdr[name.len] == ':' and std.ascii.eqlIgnoreCase(hdr[0..name.len], name)) {
-                _ = arr.entries.orderedRemove(i);
+                ctx.vm.arrayRemoveOwned(arr, entry.key);
                 removed = true;
                 continue;
             }
         }
         i += 1;
     }
-    if (removed) arr.rebuildStringIndex(ctx.allocator) catch {};
+    if (removed) arr.rebuildStringIndexAssumeCapacity();
 }
 
 fn startsWithIgnoreCase(s: []const u8, prefix: []const u8) bool {

--- a/src/stdlib/pcre.zig
+++ b/src/stdlib/pcre.zig
@@ -480,7 +480,7 @@ fn addNamedGroupsInterleaved(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.C
         const insert_pos = lowest;
         const named_entry = PhpArray.Entry{ .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) }, .value = val };
         try insertNamedMatch(ctx, arr, insert_pos, named_entry);
-        try arr.rebuildStringIndex(ctx.allocator);
+        arr.rebuildStringIndexAssumeCapacity();
         inserted_names[inserted_count] = ng.name;
         inserted_count += 1;
     }
@@ -668,7 +668,7 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             inserted_names[inserted_count] = ng.name;
             inserted_count += 1;
         }
-        try out.rebuildStringIndex(ctx.allocator);
+        out.rebuildStringIndexAssumeCapacity();
     }
 
     if (args.len >= 3 and args[2] != .array) {
@@ -741,7 +741,7 @@ fn addNamedGroupsToMatch(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.Code,
         const named_entry = PhpArray.Entry{ .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) }, .value = val };
         try insertNamedMatch(ctx, arr, insert_pos, named_entry);
     }
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
 }
 
 fn clearMatches(ctx: *NativeContext, arr: *PhpArray) void {
@@ -761,7 +761,7 @@ fn insertNamedMatch(ctx: *NativeContext, arr: *PhpArray, position: usize, entry:
         const stored = arr.entries.items[last];
         std.mem.copyBackwards(PhpArray.Entry, arr.entries.items[position + 1 ..], arr.entries.items[position..last]);
         arr.entries.items[position] = stored;
-        try arr.rebuildStringIndex(ctx.allocator);
+        arr.rebuildStringIndexAssumeCapacity();
     }
 }
 

--- a/src/stdlib/spl.zig
+++ b/src/stdlib/spl.zig
@@ -976,13 +976,7 @@ fn aoMagicUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (!has_props) return .null;
     const arr = getData(obj) orelse return .null;
     const key = args[0].toArrayKey();
-    for (arr.entries.items, 0..) |entry, i| {
-        if (entry.key.eql(key)) {
-            _ = arr.entries.orderedRemove(i);
-            arr.rebuildStringIndex(ctx.allocator) catch {};
-            return .null;
-        }
-    }
+    ctx.vm.arrayRemoveOwned(arr, key);
     return .null;
 }
 
@@ -1024,13 +1018,7 @@ fn aoOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
     const key = args[0].toArrayKey();
-    for (arr.entries.items, 0..) |entry, i| {
-        if (entry.key.eql(key)) {
-            _ = arr.entries.orderedRemove(i);
-            arr.rebuildStringIndex(ctx.allocator) catch {};
-            return .null;
-        }
-    }
+    ctx.vm.arrayRemoveOwned(arr, key);
     return .null;
 }
 
@@ -1079,7 +1067,7 @@ fn aoKsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortKeysWithFlags(arr, flags, false);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1088,7 +1076,7 @@ fn aoKrsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortKeysWithFlags(arr, flags, true);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1097,7 +1085,7 @@ fn aoAsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortWithFlags(arr, flags, false);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1106,7 +1094,7 @@ fn aoArsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortWithFlags(arr, flags, true);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1115,7 +1103,7 @@ fn aoUasort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     if (args.len < 1) return .{ .bool = false };
     try arrays_mod.mergeSort(PhpArray.Entry, arr.entries.items, ctx, args[0], .value);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1124,7 +1112,7 @@ fn aoUksort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     if (args.len < 1) return .{ .bool = false };
     try arrays_mod.mergeSort(PhpArray.Entry, arr.entries.items, ctx, args[0], .key);
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1132,7 +1120,7 @@ fn aoNatsort(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .{ .bool = false };
     const arr = getData(obj) orelse return .{ .bool = false };
     arrays_mod.sortWithFlags(arr, 6, false); // SORT_NATURAL
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1140,7 +1128,7 @@ fn aoNatcasesort(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .{ .bool = false };
     const arr = getData(obj) orelse return .{ .bool = false };
     arrays_mod.sortWithFlags(arr, 6 | 8, false); // SORT_NATURAL | SORT_FLAG_CASE
-    try arr.rebuildStringIndex(ctx.allocator);
+    arr.rebuildStringIndexAssumeCapacity();
     return .{ .bool = true };
 }
 
@@ -1307,13 +1295,7 @@ fn aiOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
     const key = args[0].toArrayKey();
-    for (arr.entries.items, 0..) |entry, i| {
-        if (entry.key.eql(key)) {
-            _ = arr.entries.orderedRemove(i);
-            arr.rebuildStringIndex(ctx.allocator) catch {};
-            return .null;
-        }
-    }
+    ctx.vm.arrayRemoveOwned(arr, key);
     return .null;
 }
 
@@ -2519,7 +2501,7 @@ fn sosDetach(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (real_key == .string) _ = objs.string_index.remove(real_key.string.bytes());
         info.remove(real_key);
         if (real_key == .string) {
-            objs.rebuildStringIndex(ctx.allocator) catch {};
+            objs.rebuildStringIndexAssumeCapacity();
         }
     }
     return .null;
@@ -2615,7 +2597,7 @@ fn sosRemoveAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             _ = objs.entries.orderedRemove(idx);
             if (key == .string) {
                 _ = objs.string_index.remove(key.string.bytes());
-                objs.rebuildStringIndex(ctx.allocator) catch {};
+                objs.rebuildStringIndexAssumeCapacity();
             }
             info.remove(key);
         }
@@ -2659,7 +2641,7 @@ fn sosRemoveAllExcept(ctx: *NativeContext, args: []const Value) RuntimeError!Val
             i += 1;
         }
     }
-    objs.rebuildStringIndex(ctx.allocator) catch {};
+    objs.rebuildStringIndexAssumeCapacity();
     return .null;
 }
 

--- a/tests/array_mutation_ownership.php
+++ b/tests/array_mutation_ownership.php
@@ -1,0 +1,27 @@
+<?php
+class ArrayOwned {
+    public function __construct(public string $name) {}
+    public function __destruct() { echo "released:$this->name\n"; }
+}
+$a = ['first' => new ArrayOwned('shift'), 'other' => 2];
+$item = array_shift($a);
+var_dump(array_keys($a));
+unset($item);
+$a = ['first' => new ArrayOwned('splice'), 'last' => 3];
+$removed = array_splice($a, 0, 1, [new ArrayOwned('replacement')]);
+var_dump(array_keys($a), array_keys($removed));
+unset($removed, $a);
+foreach ([new ArrayObject(), new ArrayIterator()] as $container) {
+    $container['key'] = new ArrayOwned('container');
+    unset($container['key']);
+    var_dump(isset($container['key']));
+}
+$value = 4;
+$a = ['a' => 2];
+$a['z'] = &$value;
+ksort($a);
+$a['z'] = 8;
+var_dump($value, array_keys($a));
+$b = [1, 2, 3];
+array_splice($b, 1, 1, $b);
+var_dump($b);


### PR DESCRIPTION
Reserve storage before changing array contents or ownership, make index rebuilding atomic, and preflight affected mutation callers. Add deterministic allocation-failure tests and PHP ownership regressions.