### PR TITLE
Fix array literal references and object splice replacements

### DIFF
--- a/src/bytecode_format.zig
+++ b/src/bytecode_format.zig
@@ -13,8 +13,9 @@ const MAGIC = "ZPHPC\x00";
 // v10 adds property-hook metadata and interface_decl property operands.
 // v15 renumbers opcodes and adds the argument guard operands.
 // Older chunks cannot be decoded by the current VM.
+// v17 adds owning reference-source and array-literal reference opcodes.
 // v16 instantiates capture-free class-scoped static closures.
-pub const FORMAT_VERSION: u16 = 16;
+pub const FORMAT_VERSION: u16 = 17;
 
 // tag bytes for serialized values
 const TAG_NULL: u8 = 0;

--- a/src/pipeline/bytecode.zig
+++ b/src/pipeline/bytecode.zig
@@ -318,10 +318,16 @@ pub const OpCode = enum(u8) {
     arg_array_push,
     check_prop_dimension, // peek object + property name; guard indirect storage mutation
 
+    // Explicit reference sources use the same owning provenance as arguments.
+    reference_source, // u16 temporary binding name; move cell to a pushed value
+    array_set_elem_ref, // [array, key, source] -> [array], bind entry to source cell
+    array_push_ref, // [array, source] -> [array], append source cell
+
     pub fn width(self: OpCode) usize {
         return switch (self) {
             .arg_variable => 6,
             .arg_guard_prop, .arg_guard_prop_dynamic, .arg_guard_dim => 4,
+            .reference_source,
             .constant,
             .get_var,
             .set_var,
@@ -398,6 +404,7 @@ pub const OpCode = enum(u8) {
     pub fn stackEffect(self: OpCode) i8 {
         return switch (self) {
             // push a value
+            .reference_source,
             .constant,
             .op_null,
             .op_true,
@@ -463,9 +470,10 @@ pub const OpCode = enum(u8) {
             // scanCallerArgSources' backward arg-boundary walk whenever an
             // array literal appeared as a call argument
             .array_push,
+            .array_push_ref,
             .array_spread,
             => -1,
-            .array_set_elem => -2,
+            .array_set_elem, .array_set_elem_ref => -2,
             // unary ops: pop 1, push 1
             .negate,
             .bit_not,

--- a/src/pipeline/compiler.zig
+++ b/src/pipeline/compiler.zig
@@ -1384,45 +1384,11 @@ pub const Compiler = struct {
     // returns true if it handled the return (caller does not need to emit
     // return_val), false to fall back to the regular value-return path
     pub fn tryCompileRefReturn(self: *Compiler, expr_idx: u32) Error!bool {
-        const expr = self.ast.nodes[expr_idx];
-        const ret_name = "$__ret_ref";
-        const ret_name_idx = try self.addConstant(.{ .string = Value.String.borrowed(ret_name) });
-        if (expr.tag == .array_access) {
-            try @import("compiler_expr.zig").compileVivifyChain(self, expr.data.lhs); // writable dimension base
-            try self.compileNode(expr.data.rhs); // key
-            try self.emitOp(.make_var_array_elem_ref);
-            try self.emitU16(ret_name_idx);
-            try self.emitOp(.return_ref);
-            try self.emitU16(ret_name_idx);
-            return true;
-        }
-        if (expr.tag == .property_access) {
-            try self.compileNode(expr.data.lhs); // object
-            if (self.isDynamicProp(expr)) {
-                try self.compileNode(expr.data.rhs);
-                try self.emitOp(.make_var_prop_ref_dyn);
-                try self.emitU16(ret_name_idx);
-            } else {
-                const prop_idx = try self.addConstant(.{ .string = Value.String.borrowed(self.propName(expr)) });
-                try self.emitOp(.make_var_prop_ref);
-                try self.emitU16(ret_name_idx);
-                try self.emitU16(prop_idx);
-            }
-            try self.emitOp(.return_ref);
-            try self.emitU16(ret_name_idx);
-            return true;
-        }
-        if (expr.tag == .variable) {
-            const src_name = self.ast.tokenSlice(expr.main_token);
-            const src_idx = try self.addConstant(.{ .string = Value.String.borrowed(src_name) });
-            try self.emitOp(.make_var_ref);
-            try self.emitU16(ret_name_idx);
-            try self.emitU16(src_idx);
-            try self.emitOp(.return_ref);
-            try self.emitU16(ret_name_idx);
-            return true;
-        }
-        return false;
+        const name = try self.addConstant(.{ .string = Value.String.borrowed("$__ret_ref") });
+        if (!try compiler_expr.compileReferenceBinding(self, expr_idx, name)) return false;
+        try self.emitOp(.return_ref);
+        try self.emitU16(name);
+        return true;
     }
 
     // superinstruction: $local_dst op= $local_src as a statement (no stack effect)

--- a/src/pipeline/compiler_expr.zig
+++ b/src/pipeline/compiler_expr.zig
@@ -11,110 +11,16 @@ pub fn compileAssign(self: *Compiler, node: Ast.Node) Error!void {
     const target = self.ast.nodes[node.data.lhs];
     const op_tag = self.ast.tokens[node.main_token].tag;
 
-    // `$dst = &…` — emit break_var_ref so the subsequent value-write doesn't
-    // propagate through a stale prior ref binding on dst. true ref binding
-    // (make_var_ref, make_var_array_elem_ref) is defined in the runtime but
-    // not emitted from the compiler yet — enabling it makes correct PHP
-    // semantics for `$b = &$a` but exposes a downstream zphp bug where
-    // Laravel's Route registration loses the /api prefix on POST routes
-    // (the Arr::except → Arr::forget chain run during Route::__construct
-    // triggers the divergence). break_var_ref alone preserves today's
-    // baseline. see roadmap item #1 for the next push
-    // gated: enabling make_var_ref emission below correctly implements
-    // PHP's `$b = &$a` aliasing in isolation, but during Laravel's route
-    // registration the cumulative effect causes $this->groupStack[last] to
-    // lose its 'prefix' key between Router::mergeWithLastGroup invocations.
-    // bisected to: somewhere inside RouteGroup::merge → Arr::except → forget,
-    // $old (which should be a callLocalsOnly clone of array_last result) gets
-    // mutated AND the mutation propagates to $groupStack[last]. callLocalsOnly
-    // calls copyValue, which calls cloneArrayInner, which deep-clones nested
-    // arrays. yet the source array gets mutated. either there's a clone path
-    // that returns the original pointer, or there's a fast_loop path that
-    // skips the copy. tracking down requires deeper instrumentation of the
-    // call site that produces merge's $old
     if (op_tag == .equal and (target.tag == .variable or target.tag == .identifier)) {
-        const rhs_node = self.ast.nodes[node.data.rhs];
-        if (rhs_node.tag == .ref_target) {
-            const dst_name = self.ast.tokenSlice(target.main_token);
-            const dst_idx = try self.addConstant(.{ .string = Value.String.borrowed(dst_name) });
-            const inner = self.ast.nodes[rhs_node.data.lhs];
-            // when emitting make_var_ref / make_var_array_elem_ref, do NOT
-            // emit break_var_ref first - those opcodes replace dst's ref_slot
-            // atomically, and a prior break_var_ref would drop the slot before
-            // we push the rhs, causing the rhs's get_var to fall back to stale
-            // frame.vars
-            if (inner.tag == .variable or inner.tag == .identifier) {
-                const src_name = self.ast.tokenSlice(inner.main_token);
-                const src_idx = try self.addConstant(.{ .string = Value.String.borrowed(src_name) });
-                try self.emitOp(.make_var_ref);
-                try self.emitU16(dst_idx);
-                try self.emitU16(src_idx);
-                try self.compileNode(rhs_node.data.lhs);
+        const rhs = self.ast.nodes[node.data.rhs];
+        if (rhs.tag == .ref_target) {
+            const dst = try self.addConstant(.{ .string = Value.String.borrowed(self.ast.tokenSlice(target.main_token)) });
+            if (try compileReferenceBinding(self, rhs.data.lhs, dst)) {
+                try self.emitGetVar(self.ast.tokenSlice(target.main_token));
                 return;
             }
-            if (inner.tag == .array_access or inner.tag == .array_push_target) {
-                try compileVivifyChain(self, inner.data.lhs); // writable dimension base
-                if (inner.tag == .array_push_target) {
-                    try self.emitOp(.op_null);
-                } else {
-                    try self.compileNode(inner.data.rhs); // push key
-                }
-                try self.emitOp(.make_var_array_elem_ref);
-                try self.emitU16(dst_idx);
-                try self.emitOp(.op_null);
-                return;
-            }
-            if (inner.tag == .property_access and !self.isDynamicProp(inner)) {
-                try self.compileNode(inner.data.lhs); // push object
-                const prop_idx = try self.addConstant(.{ .string = Value.String.borrowed(self.propName(inner)) });
-                try self.emitOp(.make_var_prop_ref);
-                try self.emitU16(dst_idx);
-                try self.emitU16(prop_idx);
-                try self.emitOp(.op_null);
-                return;
-            }
-            if (inner.tag == .property_access and self.isDynamicProp(inner)) {
-                try self.compileNode(inner.data.lhs); // push object
-                try self.compileNode(inner.data.rhs); // push prop name (variable value)
-                try self.emitOp(.make_var_prop_ref_dyn);
-                try self.emitU16(dst_idx);
-                try self.emitOp(.op_null);
-                return;
-            }
-            if (inner.tag == .static_prop_access) {
-                const class_node = self.ast.nodes[inner.data.lhs];
-                const class_name = resolveNodeClassName(self, class_node) catch {
-                    try self.emitOp(.break_var_ref);
-                    try self.emitU16(dst_idx);
-                    try self.compileNode(rhs_node.data.lhs);
-                    return;
-                };
-                var prop_name = self.ast.tokenSlice(inner.main_token);
-                if (prop_name.len > 0 and prop_name[0] == '$') prop_name = prop_name[1..];
-                const class_idx = try self.addConstant(.{ .string = Value.String.borrowed(class_name) });
-                const prop_idx = try self.addConstant(.{ .string = Value.String.borrowed(prop_name) });
-                try self.emitOp(.make_var_static_prop_ref);
-                try self.emitU16(dst_idx);
-                try self.emitU16(class_idx);
-                try self.emitU16(prop_idx);
-                try self.emitOp(.op_null);
-                return;
-            }
-            if (inner.tag == .call or inner.tag == .method_call) {
-                // `$dst = &foo(...)` or `$dst = &$obj->method(...)` - the
-                // callee may be a ref-returning function. emit the call as a
-                // value (return_ref also pushes the value), then bind_ref_
-                // from_return picks up vm.last_return_ref if set. degrades
-                // to a value copy if the callee wasn't ref-returning
-                try self.compileNode(rhs_node.data.lhs);
-                try self.emitOp(.bind_ref_from_return);
-                try self.emitU16(dst_idx);
-                return;
-            }
-            // fallback for shapes we don't yet bind explicitly (dynamic property,
-            // chained ref-assign)
             try self.emitOp(.break_var_ref);
-            try self.emitU16(dst_idx);
+            try self.emitU16(dst);
         }
     }
 
@@ -1270,6 +1176,63 @@ fn emitEnsureArray(self: *Compiler, name: []const u8) Error!void {
     try self.emitByte(0);
 }
 
+// Bind a source lvalue without leaving an evaluated value on the stack.
+// Assignments, reference returns, and literal entries use the same machinery.
+pub fn compileReferenceBinding(self: *Compiler, source: u32, dst: u16) Error!bool {
+    const node = self.ast.nodes[source];
+    switch (node.tag) {
+        .variable, .identifier => {
+            try self.emitOp(.make_var_ref);
+            try self.emitU16(dst);
+            try self.emitU16(try self.addConstant(.{ .string = Value.String.borrowed(self.ast.tokenSlice(node.main_token)) }));
+        },
+        .array_access, .array_push_target => {
+            try compileVivifyChain(self, node.data.lhs);
+            if (node.tag == .array_push_target) try self.emitOp(.op_null) else try self.compileNode(node.data.rhs);
+            try self.emitOp(.make_var_array_elem_ref);
+            try self.emitU16(dst);
+        },
+        .property_access => {
+            try self.compileNode(node.data.lhs);
+            if (self.isDynamicProp(node)) {
+                try self.compileNode(node.data.rhs);
+                try self.emitOp(.make_var_prop_ref_dyn);
+                try self.emitU16(dst);
+            } else {
+                try self.emitOp(.make_var_prop_ref);
+                try self.emitU16(dst);
+                try self.emitU16(try self.addConstant(.{ .string = Value.String.borrowed(self.propName(node)) }));
+            }
+        },
+        .static_prop_access => {
+            const class_name = resolveNodeClassName(self, self.ast.nodes[node.data.lhs]) catch return false;
+            var prop_name = self.ast.tokenSlice(node.main_token);
+            if (prop_name.len > 0 and prop_name[0] == '$') prop_name = prop_name[1..];
+            try self.emitOp(.make_var_static_prop_ref);
+            try self.emitU16(dst);
+            try self.emitU16(try self.addConstant(.{ .string = Value.String.borrowed(class_name) }));
+            try self.emitU16(try self.addConstant(.{ .string = Value.String.borrowed(prop_name) }));
+        },
+        .call, .method_call, .static_call => {
+            try self.compileNode(source);
+            try self.emitOp(.bind_ref_from_return);
+            try self.emitU16(dst);
+            try self.emitOp(.pop);
+        },
+        else => return false,
+    }
+    return true;
+}
+
+// Move the temporary binding into the owning operand-stack provenance. No
+// synthetic variable survives the expression or holds a returned local alive.
+fn compileReferenceSource(self: *Compiler, source: u32) Error!void {
+    const dst = try self.addConstant(.{ .string = Value.String.borrowed("\x00reference-source") });
+    if (!try compileReferenceBinding(self, source, dst)) return error.CompileError;
+    try self.emitOp(.reference_source);
+    try self.emitU16(dst);
+}
+
 pub fn compileArrayLiteral(self: *Compiler, node: Ast.Node) Error!void {
     try self.emitOp(.array_new);
     for (self.ast.extraSlice(node.data.lhs)) |elem_idx| {
@@ -1277,24 +1240,16 @@ pub fn compileArrayLiteral(self: *Compiler, node: Ast.Node) Error!void {
         if (elem.tag == .array_spread) {
             try self.compileNode(elem.data.lhs);
             try self.emitOp(.array_spread);
-        } else if (elem.data.rhs != 0) {
-            try self.compileNode(elem.data.rhs);
-            try self.compileNode(elem.data.lhs);
-            try self.emitOp(.array_set_elem);
+            continue;
+        }
+        const value = self.ast.nodes[elem.data.lhs];
+        if (elem.data.rhs != 0) try self.compileNode(elem.data.rhs);
+        if (value.tag == .ref_target) {
+            try compileReferenceSource(self, value.data.lhs);
+            try self.emitOp(if (elem.data.rhs != 0) .array_set_elem_ref else .array_push_ref);
         } else {
-            const value_node = self.ast.nodes[elem.data.lhs];
-            if (value_node.tag == .ref_target) {
-                const ref_inner = self.ast.nodes[value_node.data.lhs];
-                if (ref_inner.tag == .variable) {
-                    try self.emitOp(.dup);
-                    try self.emitOp(.array_push_bind_ref);
-                    try self.emitU16(try self.addConstant(.{ .string = Value.String.borrowed(self.ast.tokenSlice(ref_inner.main_token)) }));
-                    try self.emitOp(.pop);
-                    continue;
-                }
-            }
             try self.compileNode(elem.data.lhs);
-            try self.emitOp(.array_push);
+            try self.emitOp(if (elem.data.rhs != 0) .array_set_elem else .array_push);
         }
     }
 }

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -4210,6 +4210,38 @@ pub const VM = struct {
                     }
                     self.push(val);
                 },
+                .reference_source => {
+                    const idx = self.readU16();
+                    const name = self.currentChunk().constants.items[idx].string.bytes();
+                    const frame = self.currentFrame();
+                    const cell = try self.getOrCreateVarCell(frame, name);
+                    self.push(cell.*);
+                    self.setArgSource(self.sp - 1, .{ .cell = .{ .value = cell } });
+                    self.unbindRefSlot(&frame.ref_slots, name);
+                },
+                .array_set_elem_ref, .array_push_ref => {
+                    var source = self.retainArgSource(self.ic.?.arg_stack[self.sp - 1]);
+                    defer self.releaseArgSource(&source);
+                    _ = self.pop();
+                    const key = if (op == .array_set_elem_ref) self.pop() else Value.null;
+                    const array = self.peek().array;
+                    if (key == .array or key == .object) {
+                        if (try self.throwOffsetKeyType(key, .access)) continue;
+                        return error.RuntimeError;
+                    }
+                    const ak = if (op == .array_push_ref)
+                        PhpArray.Key{ .int = if (array.has_int_keys) array.next_int_key else 0 }
+                    else
+                        Value.toArrayKey(key);
+                    if (source != .cell) return error.RuntimeError;
+                    try self.checkArgCell(source.cell.denial);
+                    const cell = source.cell.value;
+                    self.detachArrayEntryRef(array, ak);
+                    try self.arraySetOwned(array, ak, cell.*);
+                    self.setEntryRef(array.getPtr(ak).?, cell);
+                    try self.regRefArray(try self.persistentRefOwner(), cell, array, ak);
+                    self.array_ref_active = true;
+                },
                 .array_push, .arg_array_push => {
                     var source = if (op == .arg_array_push) self.retainArgSource(self.ic.?.arg_stack[self.sp - 1]) else RefSource.none;
                     defer self.releaseArgSource(&source);
@@ -4247,6 +4279,9 @@ pub const VM = struct {
                         }
                         const norm_key = Value.toArrayKey(key);
                         if (op == .arg_array_set) try self.recordArgArraySource(arr_val.array, norm_key, source);
+                        // A duplicate literal key replaces storage, not the value
+                        // of the reference previously installed at that key.
+                        if (op == .array_set_elem) self.detachArrayEntryRef(arr_val.array, norm_key);
                         if (!(self.array_ref_active and try self.writeArrayElemRef(arr_val.array, norm_key, val))) {
                             try self.arraySetOwned(arr_val.array, norm_key, val);
                         }
@@ -5644,6 +5679,7 @@ pub const VM = struct {
                     const src_name = self.currentChunk().constants.items[src_idx].string.bytes();
                     const frame = self.currentFrame();
                     const cell = try self.getOrCreateVarCell(frame, src_name);
+                    if (cell.* == .array) _ = try self.separateReferencedArray(frame, src_name, cell, cell.array);
                     if (isSuperglobal(dst_name)) {
                         try self.bindRefSlot(&self.globals_cells, dst_name, cell);
                         try self.putRequestVar(dst_name, cell.*);
@@ -5816,7 +5852,12 @@ pub const VM = struct {
                                 }
                             }
                             const fresh = try self.newRefCell();
-                            self.setCell(fresh, obj_ptr.get(prop_name));
+                            var value = obj_ptr.get(prop_name);
+                            if (value == .array and value.array.refcount > 1) {
+                                value = .{ .array = try self.shallowCloneCow(value.array) };
+                                try self.objectSetOwned(obj_ptr, prop_name, value);
+                            }
+                            self.setCell(fresh, value);
                             break :blk fresh;
                         };
 
@@ -5895,7 +5936,12 @@ pub const VM = struct {
                                 }
                             }
                             const fresh = try self.newRefCell();
-                            self.setCell(fresh, obj_ptr.get(prop_owned));
+                            var value = obj_ptr.get(prop_owned);
+                            if (value == .array and value.array.refcount > 1) {
+                                value = .{ .array = try self.shallowCloneCow(value.array) };
+                                try self.objectSetOwned(obj_ptr, prop_owned, value);
+                            }
+                            self.setCell(fresh, value);
                             break :blk fresh;
                         };
 
@@ -5918,7 +5964,7 @@ pub const VM = struct {
                             ri.releaseOwner(self.allocator, self.last_return_ref_owner);
                             self.last_return_ref_owner = 0;
                         }
-                        try frame.vars.put(self.allocator, dst_name, cell.*);
+                        if (dst_name.len == 0 or dst_name[0] != 0) try frame.vars.put(self.allocator, dst_name, cell.*);
                         if (frame.func) |func| {
                             for (func.slot_names, 0..) |sn, si| {
                                 if (std.mem.eql(u8, sn, dst_name)) {
@@ -5931,7 +5977,11 @@ pub const VM = struct {
                     } else {
                         // callee didn't return a ref - degrade to value copy
                         const val = self.peek();
-                        try frame.vars.put(self.allocator, dst_name, val);
+                        if (dst_name.len > 0 and dst_name[0] == 0) {
+                            const cell = try self.newRefCell();
+                            self.setCell(cell, val);
+                            try self.bindRefSlot(&frame.ref_slots, dst_name, cell);
+                        } else try frame.vars.put(self.allocator, dst_name, val);
                     }
                     // statement-level trailing .pop expects exactly one
                     // value on the stack from the assignment expression
@@ -5951,8 +6001,33 @@ pub const VM = struct {
                     const prop_name = self.currentChunk().constants.items[prop_idx].string.bytes();
                     const frame = self.currentFrame();
                     self.unbindRefSlot(&frame.ref_slots, dst_name);
-                    const cell = try self.newRefCell();
-                    self.setCell(cell, self.getStaticProp(class_name, prop_name) orelse .null);
+                    const cell = blk: {
+                        if (self.ref_index) |ri| {
+                            if (ri.prop_rev.get(.{ .object = null, .class_name = class_name, .prop_name = prop_name })) |cells| {
+                                if (cells.items.len > 0) {
+                                    const existing = cells.items[0];
+                                    if (existing.* == .array and existing.array.refcount > 1) {
+                                        const separated: Value = .{ .array = try self.shallowCloneCow(existing.array) };
+                                        self.setCell(existing, separated);
+                                        try self.propagateCellWrite(existing, separated);
+                                    }
+                                    break :blk existing;
+                                }
+                            }
+                        }
+                        var value = self.getStaticProp(class_name, prop_name) orelse .null;
+                        if (value == .array and value.array.refcount > 1) {
+                            value = .{ .array = try self.shallowCloneCow(value.array) };
+                            if (self.getStaticPropPtr(class_name, prop_name)) |slot| {
+                                VM.retainValue(value);
+                                self.releaseValue(slot.*);
+                                slot.* = value;
+                            }
+                        }
+                        const fresh = try self.newRefCell();
+                        self.setCell(fresh, value);
+                        break :blk fresh;
+                    };
 
                     try self.bindRefSlot(&frame.ref_slots, dst_name, cell);
                     try self.regRefStatic(try self.ensureRefOwner(frame), cell, class_name, prop_name);
@@ -18947,6 +19022,20 @@ pub const VM = struct {
     // both refcounted (arrays: refcounting Stage 2)
     // container stores release what they replace through the release hook;
     // these remain the named VM-aware store entry points
+    fn detachArrayEntryRef(self: *VM, array: *PhpArray, key: PhpArray.Key) void {
+        const entry = array.getPtr(key) orelse return;
+        const cell = entry.ref orelse return;
+        if (self.ref_index) |ri| ri.removeTargetAllOwners(self.allocator, cell, .{ .array = .{ .array = array, .key = entry.key } });
+        var i: usize = 0;
+        while (i < self.array_ref_bindings.items.len) {
+            const binding = self.array_ref_bindings.items[i];
+            if (binding.array == array and binding.key.eql(entry.key)) {
+                _ = self.array_ref_bindings.swapRemove(i);
+            } else i += 1;
+        }
+        self.setEntryRef(entry, null);
+    }
+
     pub fn arraySetOwned(self: *VM, array: *PhpArray, key: PhpArray.Key, value: Value) !void {
         try array.set(self.allocator, key, value);
         if (array == self.globals_array and key == .string) {

--- a/src/stdlib/arrays.zig
+++ b/src/stdlib/arrays.zig
@@ -906,6 +906,31 @@ fn array_splice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             VM.retainValue(value.*);
         }
         break :blk values;
+    } else if (args.len >= 4 and args[3] == .object) blk: {
+        const object = args[3].object.storage();
+        var values: std.ArrayListUnmanaged(Value) = .{};
+        errdefer {
+            for (values.items) |value| ctx.vm.releaseValue(value);
+            values.deinit(ctx.allocator);
+        }
+        try values.ensureTotalCapacity(ctx.allocator, (if (object.slots) |slots| slots.len else 0) + object.properties.count());
+        if (object.slots) |slots| {
+            if (object.slot_layout) |layout| {
+                for (slots, 0..) |value, i| {
+                    const name = layout.names[i];
+                    if (object.isLazySlot(name, layout.declaring_classes[i]) or object.isUnset(name)) continue;
+                    const property = ctx.vm.findPropertyVisibility(layout.declaring_classes[i], name);
+                    if (value == .null and ctx.vm.typedPropForbidsNull(property.type_str)) continue;
+                    VM.retainValue(value);
+                    values.appendAssumeCapacity(value);
+                }
+            }
+        }
+        for (object.properties.values()) |value| {
+            VM.retainValue(value);
+            values.appendAssumeCapacity(value);
+        }
+        break :blk try values.toOwnedSlice(ctx.allocator);
     } else blk: {
         const count: usize = if (args.len >= 4 and args[3] != .null) 1 else 0;
         const values = try ctx.allocator.alloc(Value, count);

--- a/tests/array_literal_references.php
+++ b/tests/array_literal_references.php
@@ -1,0 +1,124 @@
+<?php
+$v = 4;
+$a = ['z' => &$v, 'a' => 2];
+ksort($a);
+$a['z'] = 8;
+var_dump($v);
+
+// Keyed, unkeyed, mixed, numeric-string keys, and both write directions.
+$x = 10;
+$y = 20;
+$a = [&$x, 'z' => &$y, 5 => &$x, '6' => &$y, 99];
+$a[0] = 11;
+$y = 21;
+var_dump($x, $a[5], $a['z'], $a[6], $a[7]);
+
+// COW copies keep reference entries shared, ordinary entries independent.
+$b = $a;
+$b[5] = 12;
+$b[7] = 100;
+var_dump($x, $a[0], $a[7], $b[7]);
+unset($x, $y, $a);
+$b[0] = 13;
+var_dump($b[5]);
+
+// Duplicate keys replace a reference instead of assigning through it.
+$x = 1;
+$y = 2;
+$a = ['k' => &$x, 'k' => 3];
+$a['k'] = 4;
+var_dump($x, $a['k']);
+$a = ['k' => &$x, 'k' => &$y];
+$x = 5;
+$a['k'] = 6;
+var_dump($x, $y, $a['k']);
+
+// Sources use the same binding path as explicit reference assignments.
+class LiteralReferenceBox {
+    public $value = 30;
+    public static $shared = 40;
+    public function &getValue() { return $this->value; }
+}
+$box = new LiteralReferenceBox;
+$name = 'value';
+$source = ['nested' => ['value' => 50]];
+$a = ['p' => &$box->$name, &LiteralReferenceBox::$shared,
+      'n' => &$source['nested']['value'], &$box->value];
+$a['p'] = 31;
+$a[0] = 41;
+$a['n'] = 51;
+$a[1] = 32;
+var_dump($box->value, LiteralReferenceBox::$shared, $source['nested']['value'], $a['p']);
+
+function literalLocalReferences() {
+    $local = ['value' => 60];
+    return ['first' => &$local['value'], &$local['value']];
+}
+$a = literalLocalReferences();
+$b = $a;
+unset($a);
+$b[0] = 61;
+var_dump($b['first']);
+
+// Array-valued cells do not leak writes into pre-reference value copies.
+$value = ['n' => 1];
+$copy = $value;
+$a = [&$value];
+$a[0]['n'] = 2;
+var_dump($value['n'], $copy['n']);
+
+// Reference cells outlive their source object and source frame.
+function literalObjectReferences() {
+    $box = new LiteralReferenceBox;
+    return [&$box->value, 'same' => &$box->value];
+}
+$a = literalObjectReferences();
+$a[0] = 70;
+var_dump($a['same']);
+
+// Reading a referenced element by value must not capture the cell.
+$v = 80;
+$a = [&$v, 'value' => $v];
+$v = 81;
+var_dump($a[0], $a['value']);
+
+// Unset removes only the binding; reusing the name creates new storage.
+unset($v);
+$v = 82;
+$a[0] = 83;
+var_dump($v, $a[0]);
+
+// Two escaped aliases keep object values alive until the last array dies.
+class LiteralReferencePayload {
+    public $n = 90;
+    public function __destruct() { echo "payload destroyed\n"; }
+}
+function literalPayloadReferences() {
+    $value = new LiteralReferencePayload;
+    return [&$value, 'same' => &$value];
+}
+$a = literalPayloadReferences();
+$b = $a;
+unset($a);
+$b[0]->n = 91;
+var_dump($b['same']->n);
+unset($b);
+echo "done\n";
+
+// Reference acquisition in literals must separate dimension containers too.
+$source = ['n' => 1];
+$copy = $source;
+$a = [&$source['n']];
+$a[0] = 2;
+var_dump($source['n'], $copy['n']);
+$box = new LiteralReferenceBox;
+$box->value = ['n' => 3];
+$copy = $box->value;
+$a = [&$box->value];
+$a[0]['n'] = 4;
+var_dump($box->value['n'], $copy['n']);
+LiteralReferenceBox::$shared = ['n' => 5];
+$copy = LiteralReferenceBox::$shared;
+$a = [&LiteralReferenceBox::$shared];
+$a[0]['n'] = 6;
+var_dump(LiteralReferenceBox::$shared['n'], $copy['n']);

--- a/tests/array_splice_object_replacement.php
+++ b/tests/array_splice_object_replacement.php
@@ -1,0 +1,17 @@
+<?php
+class SpliceParent { private string $value = 'parent'; }
+class SpliceReplacement extends SpliceParent {
+    private string $value = 'child';
+    protected string $hidden = 'protected';
+    public string $visible = 'public';
+    public int $unset;
+    public function __destruct() { echo "replacement released\n"; }
+}
+$a = ['before', 'remove', 'after'];
+$r = array_splice($a, 1, 1, new SpliceReplacement());
+var_dump($a, $r);
+foreach ([new stdClass(), (object) ['a' => 3, 'b' => 4], null, false, 7, 'text'] as $replacement) {
+    $a = [1, 2];
+    array_splice($a, 1, 0, $replacement);
+    var_dump($a);
+}


### PR DESCRIPTION
Preserve reference bindings in keyed and unkeyed array literals, including copy-on-write isolation for array-valued sources. Convert object replacements to property values in `array_splice()`. Add PHP parity regressions for aliasing, lifetime, and replacement behavior.