### PR TITLE
Fix temporary string ownership

### DIFF
--- a/src/fast_loop.zig
+++ b/src/fast_loop.zig
@@ -83,6 +83,13 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                         locals[slot] = val;
                     }
                     self.releaseValue(sl_old);
+                    if (frame.vars.count() > 0) {
+                        if (frame.func) |func| {
+                            if (slot < func.slot_names.len) {
+                                if (frame.vars.getPtr(func.slot_names[slot])) |mirror| mirror.* = locals[slot];
+                            }
+                        }
+                    }
                     if (code[ip] == @intFromEnum(OpCode.pop)) {
                         ip += 1;
                         sp -= 1;
@@ -1256,14 +1263,14 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                     if (a == .string and b == .string) {
                         const as = a.string.bytes();
                         const bs = b.string.bytes();
-                        const owned = try self.allocator.alloc(u8, as.len + bs.len);
+                        const owned = try self.stringAllocator().alloc(u8, as.len + bs.len);
                         @memcpy(owned[0..as.len], as);
                         @memcpy(owned[as.len..], bs);
-                        try self.strings.append(self.allocator, owned);
+                        const result = try Value.String.adopt(self.stringAllocator(), owned);
                         self.stackRelease(a);
                         self.stackRelease(b);
                         sp -= 1;
-                        self.stack[sp - 1] = .{ .string = Value.String.borrowed(owned) };
+                        self.stack[sp - 1] = .{ .string = result };
                         const _next = code[ip];
                         ip += 1;
                         continue :dispatch @as(OpCode, @enumFromInt(_next));
@@ -1274,14 +1281,14 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                             self.sp = sp;
                             return;
                         };
-                        const owned = try self.allocator.alloc(u8, a.string.len + bs.len);
+                        const owned = try self.stringAllocator().alloc(u8, a.string.len + bs.len);
                         @memcpy(owned[0..a.string.len], a.string.bytes());
                         @memcpy(owned[a.string.len..], bs);
-                        try self.strings.append(self.allocator, owned);
+                        const result = try Value.String.adopt(self.stringAllocator(), owned);
                         self.stackRelease(a);
                         self.stackRelease(b);
                         sp -= 1;
-                        self.stack[sp - 1] = .{ .string = Value.String.borrowed(owned) };
+                        self.stack[sp - 1] = .{ .string = result };
                         const _next = code[ip];
                         ip += 1;
                         continue :dispatch @as(OpCode, @enumFromInt(_next));
@@ -1292,14 +1299,14 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                             self.sp = sp;
                             return;
                         };
-                        const owned = try self.allocator.alloc(u8, as.len + b.string.len);
+                        const owned = try self.stringAllocator().alloc(u8, as.len + b.string.len);
                         @memcpy(owned[0..as.len], as);
                         @memcpy(owned[as.len..], b.string.bytes());
-                        try self.strings.append(self.allocator, owned);
+                        const result = try Value.String.adopt(self.stringAllocator(), owned);
                         self.stackRelease(a);
                         self.stackRelease(b);
                         sp -= 1;
-                        self.stack[sp - 1] = .{ .string = Value.String.borrowed(owned) };
+                        self.stack[sp - 1] = .{ .string = result };
                         const _next = code[ip];
                         ip += 1;
                         continue :dispatch @as(OpCode, @enumFromInt(_next));

--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -1804,3 +1804,54 @@ test "hash raw output length" {
         \\echo strlen(hash("sha256", "test", true));
     , "32");
 }
+
+test "discarded concatenations release allocations between batches" {
+    var gpa = std.heap.DebugAllocator(.{ .enable_memory_limit = true }){};
+    defer std.testing.expect(gpa.deinit() == .ok) catch @panic("string batch leak");
+    const alloc = gpa.allocator();
+    const source =
+        \\<?php
+        \\$held = ['retained-' . 1, strtoupper('retained-' . 2)];
+        \\function verifyHeld() {
+        \\    global $held;
+        \\    echo implode(',', $held);
+        \\}
+        \\function batch() {
+        \\    for ($i = 0; $i < 1000; ++$i) {
+        \\        $a = 'temporary-' . $i;
+        \\        $b = $a . '-suffix';
+        \\        $c = 'prefix';
+        \\        $c .= $b;
+        \\        $c .= $i;
+        \\        $upper = strtoupper($c);
+        \\        $trimmed = trim($upper);
+        \\        $repeated = str_repeat($trimmed, 2);
+        \\        $joined = implode(':', [$upper, $repeated]);
+        \\    }
+        \\}
+    ;
+    var ast = try parser.parse(alloc, source);
+    defer ast.deinit();
+    var result = try @import("pipeline/compiler.zig").compile(&ast, alloc);
+    defer result.deinit();
+    const vm = try VM.initOnHeap(alloc);
+    defer {
+        vm.deinit();
+        alloc.destroy(vm);
+    }
+    try vm.interpret(&result);
+    for (0..3) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+    }
+    const warm_bytes = gpa.total_requested_bytes;
+    const warm_strings = vm.strings.items.len;
+    for (0..20) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+        try std.testing.expectEqual(warm_strings, vm.strings.items.len);
+        try std.testing.expectEqual(warm_bytes, gpa.total_requested_bytes);
+    }
+    _ = try vm.callByName("verifyHeld", &.{});
+    try std.testing.expectEqualStrings("retained-1,RETAINED-2", vm.output.items);
+}

--- a/src/runtime/string_pool.zig
+++ b/src/runtime/string_pool.zig
@@ -68,13 +68,13 @@ fn free(ctx: *anyopaque, bytes: []u8, alignment: Alignment, ra: usize) void {
 test "string pool reuses bounded blocks and preserves realloc contents" {
     var pool: StringPool = .{ .backing = std.testing.allocator };
     defer pool.deinit();
-    const allocator = pool.allocator();
-    var bytes = try allocator.dupe(u8, "retained value");
-    bytes = try allocator.realloc(bytes, 100);
+    const alloc_api = pool.allocator();
+    var bytes = try alloc_api.dupe(u8, "retained value");
+    bytes = try alloc_api.realloc(bytes, 100);
     try std.testing.expectEqualStrings("retained value", bytes[0..14]);
-    allocator.free(bytes);
+    alloc_api.free(bytes);
     var blocks: [100][]u8 = undefined;
-    for (&blocks) |*block| block.* = try allocator.alloc(u8, 4096);
-    for (blocks) |block| allocator.free(block);
+    for (&blocks) |*block| block.* = try alloc_api.alloc(u8, 4096);
+    for (blocks) |block| alloc_api.free(block);
     try std.testing.expectEqual(@as(usize, 32), pool.counts[8]);
 }

--- a/src/runtime/string_pool.zig
+++ b/src/runtime/string_pool.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Alignment = std.mem.Alignment;
+const StringPool = @This();
+
+backing: Allocator,
+free_lists: [9][32]?[*]u8 = @splat(@splat(null)),
+counts: [9]usize = @splat(0),
+
+fn sizeClass(length: usize, alignment: Alignment) ?usize {
+    if (length > 4096 or alignment.toByteUnits() > 16) return null;
+    var index: usize = 0;
+    while ((@as(usize, 16) << @intCast(index)) < length) : (index += 1) {}
+    return index;
+}
+
+fn capacity(index: usize) usize {
+    return @as(usize, 16) << @intCast(index);
+}
+
+pub fn allocator(self: *StringPool) Allocator {
+    return .{ .ptr = self, .vtable = &.{ .alloc = alloc, .resize = resize, .remap = remap, .free = free } };
+}
+
+pub fn deinit(self: *StringPool) void {
+    for (&self.counts, 0..) |*count, index| {
+        for (self.free_lists[index][0..count.*]) |ptr| {
+            self.backing.rawFree(ptr.?[0..capacity(index)], .@"16", @returnAddress());
+        }
+        count.* = 0;
+    }
+}
+
+fn alloc(ctx: *anyopaque, length: usize, alignment: Alignment, ra: usize) ?[*]u8 {
+    const self: *StringPool = @ptrCast(@alignCast(ctx));
+    const index = sizeClass(length, alignment) orelse return self.backing.rawAlloc(length, alignment, ra);
+    if (self.counts[index] > 0) {
+        self.counts[index] -= 1;
+        return self.free_lists[index][self.counts[index]];
+    }
+    return self.backing.rawAlloc(capacity(index), .@"16", ra);
+}
+
+fn resize(ctx: *anyopaque, bytes: []u8, alignment: Alignment, length: usize, ra: usize) bool {
+    const self: *StringPool = @ptrCast(@alignCast(ctx));
+    const old = sizeClass(bytes.len, alignment);
+    const new = sizeClass(length, alignment);
+    if (old != null or new != null) return old == new;
+    return self.backing.rawResize(bytes, alignment, length, ra);
+}
+
+fn remap(ctx: *anyopaque, bytes: []u8, alignment: Alignment, length: usize, ra: usize) ?[*]u8 {
+    return if (resize(ctx, bytes, alignment, length, ra)) bytes.ptr else null;
+}
+
+fn free(ctx: *anyopaque, bytes: []u8, alignment: Alignment, ra: usize) void {
+    const self: *StringPool = @ptrCast(@alignCast(ctx));
+    const index = sizeClass(bytes.len, alignment) orelse {
+        self.backing.rawFree(bytes, alignment, ra);
+        return;
+    };
+    if (self.counts[index] < self.free_lists[index].len) {
+        self.free_lists[index][self.counts[index]] = bytes.ptr;
+        self.counts[index] += 1;
+    } else self.backing.rawFree(bytes.ptr[0..capacity(index)], .@"16", ra);
+}
+
+test "string pool reuses bounded blocks and preserves realloc contents" {
+    var pool: StringPool = .{ .backing = std.testing.allocator };
+    defer pool.deinit();
+    const allocator = pool.allocator();
+    var bytes = try allocator.dupe(u8, "retained value");
+    bytes = try allocator.realloc(bytes, 100);
+    try std.testing.expectEqualStrings("retained value", bytes[0..14]);
+    allocator.free(bytes);
+    var blocks: [100][]u8 = undefined;
+    for (&blocks) |*block| block.* = try allocator.alloc(u8, 4096);
+    for (blocks) |block| allocator.free(block);
+    try std.testing.expectEqual(@as(usize, 32), pool.counts[8]);
+}

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -1015,9 +1015,13 @@ pub const PhpString = struct {
         try writer.writeAll(self.bytes());
     }
 
+    pub fn borrowedSlice(self: PhpString, start: usize, end: usize) PhpString {
+        return .{ .ptr = self.ptr + start, .len = end - start, .owner = self.owner };
+    }
+
     pub fn retainedSlice(self: PhpString, start: usize, end: usize) PhpString {
         self.retain();
-        return .{ .ptr = self.ptr + start, .len = end - start, .owner = self.owner };
+        return self.borrowedSlice(start, end);
     }
 
     pub fn retain(self: PhpString) void {

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -14448,7 +14448,8 @@ pub const VM = struct {
         };
         self.clearArgStackFrom(floor);
         if (floor < self.sp) for (self.stack[floor..self.sp]) |v| {
-            self.stackRelease(v);
+            if (v == .string) self.stackRelease(v);
+            if (v == .array and v.array.refcount == 0) self.queueArrayRelease(v.array);
         };
     }
 

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -3047,7 +3047,7 @@ pub const VM = struct {
             }
         }
         for (caller_slot_names, 0..) |name, caller_slot| {
-            if (name.len == 0 or caller_slot >= caller.locals.len or inherited_vars.contains(name)) continue;
+            if (name.len == 0 or caller_slot >= caller.locals.len) continue;
             try inherited_vars.put(self.allocator, name, caller.locals[caller_slot]);
         }
         const saved_slot_names = self.global_slot_names;
@@ -4518,6 +4518,14 @@ pub const VM = struct {
                     const inner_key = self.pop();
                     const prop_key = self.pop();
                     const base = self.pop();
+                    VM.retainValue(v);
+                    VM.retainValue(inner_key);
+                    VM.retainValue(prop_key);
+                    VM.retainValue(base);
+                    defer self.releaseValue(v);
+                    defer self.releaseValue(inner_key);
+                    defer self.releaseValue(prop_key);
+                    defer self.releaseValue(base);
                     if (base != .object or prop_key != .string) {
                         self.push(v);
                         continue;

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -14448,7 +14448,7 @@ pub const VM = struct {
         };
         self.clearArgStackFrom(floor);
         if (floor < self.sp) for (self.stack[floor..self.sp]) |v| {
-            if (v == .array and v.array.refcount == 0) self.queueArrayRelease(v.array);
+            self.stackRelease(v);
         };
     }
 

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -687,6 +687,7 @@ pub const VM = struct {
     exception_dispatched: bool = false,
     run_base_frame: usize = 0,
     allocator: Allocator,
+    string_pool: @import("string_pool.zig") = .{ .backing = undefined },
     global_slot_names: []const []const u8 = &.{},
     script_strict_types: bool = false,
     // most recent ICU UErrorCode from any intl native call. reset to 0 on entry
@@ -1333,7 +1334,12 @@ pub const VM = struct {
         return vm;
     }
 
+    pub fn stringAllocator(self: *VM) Allocator {
+        return self.string_pool.allocator();
+    }
+
     fn initVm(vm: *VM, allocator: Allocator) RuntimeError!void {
+        vm.string_pool.backing = allocator;
         if (std.posix.getenv("ZPHP_HEAP_STATS") != null) vm.debug_closure_owners = .{};
         if (std.posix.getenv("ZPHP_NO_POOL") != null) vm.debug_no_pool = true;
         if (std.posix.getenv("ZPHP_GC_VERIFY") != null) vm.debug_gc_verify = true;
@@ -2289,8 +2295,21 @@ pub const VM = struct {
         defer self.heap_teardown = false;
         // static state (class static props, function statics, superglobals)
         // holds owned values that no frame releases
+        var constant_it = self.php_constants.valueIterator();
+        while (constant_it.next()) |value| {
+            if (value.* == .string) {
+                self.releaseValue(value.*);
+                value.* = .null;
+            }
+        }
         var class_it = self.classes.valueIterator();
         while (class_it.next()) |class| {
+            for (class.properties.items) |*property| {
+                if (property.default == .string) {
+                    self.releaseValue(property.default);
+                    property.default = .null;
+                }
+            }
             var sp_it = class.static_props.valueIterator();
             while (sp_it.next()) |value| {
                 self.releaseValue(value.*);
@@ -2569,6 +2588,7 @@ pub const VM = struct {
         self.pending_destruct.deinit(self.allocator);
         self.pending_array_release.deinit(self.allocator);
         self.pending_string_release.deinit(self.allocator);
+        self.string_pool.deinit();
         self.pending_gen_release.deinit(self.allocator);
         self.pending_fiber_release.deinit(self.allocator);
         self.weakmaps.deinit(self.allocator);
@@ -3437,35 +3457,38 @@ pub const VM = struct {
                 .concat => {
                     const b = self.pop();
                     const a = self.pop();
+                    VM.retainValue(a);
+                    VM.retainValue(b);
+                    defer self.releaseValue(a);
+                    defer self.releaseValue(b);
                     if (a == .string and b == .string) {
                         const as = a.string.bytes();
                         const bs = b.string.bytes();
-                        const owned = try self.allocator.alloc(u8, as.len + bs.len);
+                        const owned = try self.stringAllocator().alloc(u8, as.len + bs.len);
                         @memcpy(owned[0..as.len], as);
                         @memcpy(owned[as.len..], bs);
-                        try self.strings.append(self.allocator, owned);
-                        self.push(.{ .string = Value.String.borrowed(owned) });
+                        self.pushTransfer(.{ .string = try Value.String.adopt(self.stringAllocator(), owned) });
                     } else {
                         if (a == .array) self.emitWarning("Array to string conversion");
                         if (b == .array) self.emitWarning("Array to string conversion");
                         var buf = std.ArrayListUnmanaged(u8){};
+                        defer buf.deinit(self.stringAllocator());
                         if (a == .object) {
                             const s = self.objectToString(a.object) catch {
                                 if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                                 return error.RuntimeError;
                             };
-                            try buf.appendSlice(self.allocator, s);
-                        } else try a.format(&buf, self.allocator);
+                            try buf.appendSlice(self.stringAllocator(), s);
+                        } else try a.format(&buf, self.stringAllocator());
                         if (b == .object) {
                             const s = self.objectToString(b.object) catch {
                                 if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                                 return error.RuntimeError;
                             };
-                            try buf.appendSlice(self.allocator, s);
-                        } else try b.format(&buf, self.allocator);
-                        const owned = try buf.toOwnedSlice(self.allocator);
-                        try self.strings.append(self.allocator, owned);
-                        self.push(.{ .string = Value.String.borrowed(owned) });
+                            try buf.appendSlice(self.stringAllocator(), s);
+                        } else try b.format(&buf, self.stringAllocator());
+                        const owned = try buf.toOwnedSlice(self.stringAllocator());
+                        self.pushTransfer(.{ .string = try Value.String.adopt(self.stringAllocator(), owned) });
                     }
                 },
 
@@ -4354,7 +4377,7 @@ pub const VM = struct {
                         else
                             null;
                         if (resolved) |ri| {
-                            self.push(.{ .string = string.retainedSlice(ri, ri + 1) });
+                            self.pushTransfer(.{ .string = string.retainedSlice(ri, ri + 1) });
                         } else {
                             self.push(.{ .string = Value.String.borrowed("") });
                         }
@@ -4403,7 +4426,7 @@ pub const VM = struct {
                         else
                             null;
                         if (resolved) |ri| {
-                            self.push(.{ .string = string.retainedSlice(ri, ri + 1) });
+                            self.pushTransfer(.{ .string = string.retainedSlice(ri, ri + 1) });
                         } else {
                             self.push(.null);
                         }
@@ -4882,20 +4905,8 @@ pub const VM = struct {
                         @memcpy(buf[0..s.len], s);
                         if (new_len > s.len) @memset(buf[s.len..], ' ');
                         buf[target_idx] = write_byte;
-                        try self.strings.append(self.allocator, buf);
-                        const new_str = Value{ .string = Value.String.borrowed(buf) };
-
-                        if (ref_cell) |cell| self.setCell(cell, new_str);
-                        if (frame.func) |func| {
-                            if (slot < func.slot_names.len) {
-                                const name = func.slot_names[slot];
-                                if (name.len > 0) try frame.vars.put(self.allocator, name, new_str);
-                            }
-                            if (slot < frame.locals.len) frame.locals[slot] = new_str;
-                        } else {
-                            if (slot < frame.locals.len) frame.locals[slot] = new_str;
-                            try self.setLocalGlobal(slot, new_str, frame);
-                        }
+                        const new_str = Value{ .string = try Value.String.adopt(self.allocator, buf) };
+                        try self.setVariableByName(frame, self.slotName(frame, slot), new_str);
                         self.push(val);
                         continue;
                     }
@@ -5315,6 +5326,7 @@ pub const VM = struct {
                             // alias the original's shared cell (entry.value already
                             // mirrors the referenced value)
                             entry.ref = null;
+                            if (entry.key == .string) entry.key.string.retain();
                             retainValue(entry.value);
                         }
                         copy.next_int_key = src.next_int_key;
@@ -5631,11 +5643,7 @@ pub const VM = struct {
                     const cell = try self.getOrCreateVarCell(frame, var_name);
                     if (arr_val == .array) {
                         const arr_ptr = arr_val.array;
-                        const key: PhpArray.Key = switch (key_val) {
-                            .int => |i| .{ .int = i },
-                            .string => |s| .{ .string = s },
-                            else => .{ .int = Value.toInt(key_val) },
-                        };
+                        const key = PhpArray.normalizeKey(Value.toArrayKey(key_val));
                         // The element becomes a mirror of the cell.
                         try self.arraySetOwned(arr_ptr, key, cell.*);
                         if (arr_ptr.getPtr(key)) |ep| self.setEntryRef(ep, cell);
@@ -6231,119 +6239,42 @@ pub const VM = struct {
                     if (append_val == .array) self.emitWarning("Array to string conversion");
                     const is_ref = self.currentFrame().ref_slots.get(name);
 
-                    // find the local slot for this variable
-                    const ca_sn = if (self.currentFrame().func) |func| func.slot_names else self.currentFrame().slot_names;
-                    var ca_slot: u16 = 0xFFFF;
-                    for (ca_sn, 0..) |sn, si| {
-                        if (std.mem.eql(u8, sn, name)) {
-                            ca_slot = @intCast(si);
-                            break;
-                        }
-                    }
-
-                    // try growable buffer path for local variables (no refs)
-                    if (ca_slot != 0xFFFF and is_ref == null and self.ic != null and self.currentFrame().include_parent == null) {
-                        const ic = self.ic.?;
-                        const current = if (ca_slot < self.currentFrame().locals.len) self.currentFrame().locals[ca_slot] else Value.null;
-
-                        // check if we can reuse the existing buffer
-                        if (ic.concat_slot == ca_slot and ic.concat_frame == self.frame_count and ic.concat_buf.items.len > 0) {
-                            // verify the local still points into our buffer
-                            if (current == .string and current.string.len > 0 and
-                                ic.concat_buf.items.len >= current.string.len and
-                                current.string.ptr == ic.concat_buf.items.ptr)
-                            {
-                                if (append_val == .string) {
-                                    try ic.concat_buf.appendSlice(self.allocator, append_val.string.bytes());
-                                } else {
-                                    try append_val.format(&ic.concat_buf, self.allocator);
+                    const frame = self.currentFrame();
+                    const current = if (is_ref) |cell| cell.* else (frame.vars.get(name) orelse .null);
+                    var suffix_allocator = std.heap.stackFallback(128, self.allocator);
+                    const temporary_allocator = suffix_allocator.get();
+                    var suffix: std.ArrayListUnmanaged(u8) = .{};
+                    defer suffix.deinit(temporary_allocator);
+                    if (append_val == .string) {
+                        try suffix.appendSlice(temporary_allocator, append_val.string.bytes());
+                    } else try append_val.format(&suffix, temporary_allocator);
+                    if (is_ref == null and current == .string) {
+                        if (current.string.owner) |owner| {
+                            if (!owner.closure and owner.refcount == 1 and current.string.ptr == owner.bytes.ptr) {
+                                const length = std.math.add(usize, current.string.len, suffix.items.len) catch return error.OutOfMemory;
+                                if (length > owner.bytes.len) {
+                                    const growth = std.math.add(usize, owner.bytes.len / 2, 16) catch return error.OutOfMemory;
+                                    const capacity = @max(length, std.math.add(usize, owner.bytes.len, growth) catch length);
+                                    owner.bytes = try owner.allocator.realloc(owner.bytes, capacity);
                                 }
-                                const result_val = Value{ .string = Value.String.borrowed(ic.concat_buf.items) };
-                                self.currentFrame().locals[ca_slot] = result_val;
-                                try self.currentFrame().vars.put(self.allocator, name, result_val);
-                                self.push(result_val);
+                                @memcpy(owner.bytes[current.string.len..length], suffix.items);
+                                const result: Value = .{ .string = .{ .ptr = owner.bytes.ptr, .len = length, .owner = owner } };
+                                VM.retainValue(result);
+                                try self.setVariableByName(frame, name, result);
+                                self.push(result);
                                 continue;
                             }
                         }
-
-                        // finalize old buffer: transfer ownership to self.strings so
-                        // external references (array entries etc.) remain valid, then
-                        // start a fresh buffer
-                        if (ic.concat_buf.items.len > 0 and ic.concat_slot != 0xFFFF) {
-                            const old_str = try self.allocator.alloc(u8, ic.concat_buf.items.len);
-                            @memcpy(old_str, ic.concat_buf.items);
-                            try self.strings.append(self.allocator, old_str);
-                            if (ic.concat_frame == self.frame_count and ic.concat_slot < self.currentFrame().locals.len) {
-                                const old_val = self.currentFrame().locals[ic.concat_slot];
-                                if (old_val == .string and old_val.string.ptr == ic.concat_buf.items.ptr) {
-                                    self.currentFrame().locals[ic.concat_slot] = .{ .string = Value.String.borrowed(old_str) };
-                                }
-                            }
-                            // preserve old buffer memory for external references
-                            if (ic.concat_buf.capacity > 0) {
-                                try self.strings.append(self.allocator, ic.concat_buf.allocatedSlice());
-                                ic.concat_buf = .{};
-                            }
-                        } else {
-                            ic.concat_buf.clearRetainingCapacity();
-                        }
-                        if (current == .string) {
-                            try ic.concat_buf.appendSlice(self.allocator, current.string.bytes());
-                        } else if (current != .null) {
-                            try current.format(&ic.concat_buf, self.allocator);
-                        }
-                        if (append_val == .string) {
-                            try ic.concat_buf.appendSlice(self.allocator, append_val.string.bytes());
-                        } else {
-                            try append_val.format(&ic.concat_buf, self.allocator);
-                        }
-                        ic.concat_slot = ca_slot;
-                        ic.concat_frame = self.frame_count;
-                        const result_val = Value{ .string = Value.String.borrowed(ic.concat_buf.items) };
-                        self.currentFrame().locals[ca_slot] = result_val;
-                        try self.currentFrame().vars.put(self.allocator, name, result_val);
-                        self.push(result_val);
-                        continue;
                     }
-
-                    // fallback: allocate new string each time (ref variables, no IC, no slot)
-                    const current = if (is_ref) |cell| cell.* else (self.currentFrame().vars.get(name) orelse .null);
-                    var result_str: []const u8 = undefined;
-                    if (current == .string and append_val == .string) {
-                        const cs = current.string.bytes();
-                        const as = append_val.string.bytes();
-                        const new_str = try self.allocator.alloc(u8, cs.len + as.len);
-                        @memcpy(new_str[0..cs.len], cs);
-                        @memcpy(new_str[cs.len..], as);
-                        try self.strings.append(self.allocator, new_str);
-                        result_str = new_str;
-                    } else {
-                        var buf = std.ArrayListUnmanaged(u8){};
-                        if (current == .string) {
-                            try buf.appendSlice(self.allocator, current.string.bytes());
-                        } else {
-                            try current.format(&buf, self.allocator);
-                        }
-                        if (append_val == .string) {
-                            try buf.appendSlice(self.allocator, append_val.string.bytes());
-                        } else {
-                            try append_val.format(&buf, self.allocator);
-                        }
-                        const owned = try buf.toOwnedSlice(self.allocator);
-                        try self.strings.append(self.allocator, owned);
-                        result_str = owned;
-                    }
-                    const result_val = Value{ .string = Value.String.borrowed(result_str) };
-                    if (is_ref) |cell| {
-                        self.setCell(cell, result_val);
-                        try self.propagateCellWrite(cell, result_val);
-                    }
-                    try self.currentFrame().vars.put(self.allocator, name, result_val);
-                    if (ca_slot != 0xFFFF and ca_slot < self.currentFrame().locals.len) {
-                        self.currentFrame().locals[ca_slot] = result_val;
-                    }
-                    try self.syncIncludeVar(self.currentFrame(), name, result_val);
-                    self.push(result_val);
+                    var buffer: std.ArrayListUnmanaged(u8) = .{};
+                    errdefer buffer.deinit(self.stringAllocator());
+                    if (current == .string) {
+                        try buffer.appendSlice(self.stringAllocator(), current.string.bytes());
+                    } else if (current != .null) try current.format(&buffer, self.stringAllocator());
+                    try buffer.appendSlice(self.stringAllocator(), suffix.items);
+                    const result: Value = .{ .string = try Value.String.adopt(self.stringAllocator(), try buffer.toOwnedSlice(self.stringAllocator())) };
+                    try self.setVariableByName(frame, name, result);
+                    self.push(result);
                 },
                 .get_local => {
                     const slot = self.readU16();
@@ -6758,7 +6689,7 @@ pub const VM = struct {
                             if (self.pending_exception != null and self.dispatchPendingException(base_frame)) continue;
                             return error.RuntimeError;
                         };
-                        self.push(.{ .string = Value.String.borrowed(s) });
+                        self.pushTransfer(.{ .string = try Value.String.create(self.allocator, s) });
                     } else {
                         if (v == .array) self.emitWarning("Array to string conversion");
                         var buf = std.ArrayListUnmanaged(u8){};
@@ -7131,6 +7062,8 @@ pub const VM = struct {
                 .require => {
                     const variant = self.readByte();
                     const path_val = self.pop();
+                    VM.retainValue(path_val);
+                    defer self.releaseValue(path_val);
                     if (path_val != .string) {
                         self.push(.null);
                     } else {
@@ -7141,7 +7074,13 @@ pub const VM = struct {
                         if (is_once and self.loaded_files.contains(path)) {
                             self.push(.{ .bool = true });
                         } else {
-                            const from_cache = self.serve_mode and self.serve_compile_cache.contains(path);
+                            const stable_path = blk: {
+                                const owned = try self.allocator.dupe(u8, path);
+                                errdefer self.allocator.free(owned);
+                                try self.strings.append(self.allocator, owned);
+                                break :blk owned;
+                            };
+                            const from_cache = self.serve_mode and self.serve_compile_cache.contains(stable_path);
                             const result: ?*CompileResult = if (from_cache)
                                 self.serve_compile_cache.get(path).?
                             else if (self.file_loader) |loader|
@@ -7155,7 +7094,7 @@ pub const VM = struct {
                                     try self.serve_cache_keys.append(self.allocator, duped);
                                     try self.serve_compile_cache.put(self.allocator, duped, r);
                                 }
-                                try self.loaded_files.put(self.allocator, path, {});
+                                try self.loaded_files.put(self.allocator, stable_path, {});
                                 if (!from_cache) {
                                     try self.compile_results.append(self.allocator, r);
                                 }
@@ -9344,6 +9283,7 @@ pub const VM = struct {
                         return error.RuntimeError;
                     }
                     const obj = obj_val.object;
+                    defer self.stackRelease(method_name_val);
                     // shift args down by 1 to remove method_name from stack, leaving [object, arg1, ..., argN]
                     var i: usize = 0;
                     while (i < ac) : (i += 1) {
@@ -10171,6 +10111,7 @@ pub const VM = struct {
                     }
                     self.clearArgStackFrom(self.sp - 1);
                     self.sp -= 1;
+                    defer self.stackRelease(method_val);
                     try self.callStaticFunction(full_name, arg_count, effective_called);
                 },
 
@@ -11678,7 +11619,7 @@ pub const VM = struct {
     // set_local / set_var_var do: a slot and its vars mirror share the one
     // reference, a bound reference cell takes its own and propagates
     pub fn setVariableByName(self: *VM, frame: *CallFrame, name: []const u8, val: Value) RuntimeError!void {
-        const slot_names = if (frame.func) |func| func.slot_names else self.global_slot_names;
+        const slot_names = if (frame.func) |func| func.slot_names else frame.slot_names;
         for (slot_names, 0..) |slot_name, si| {
             if (!std.mem.eql(u8, slot_name, name)) continue;
             if (si < frame.locals.len) {
@@ -11686,11 +11627,20 @@ pub const VM = struct {
                 if (frame.func != null) {
                     if (frame.ref_slots.get(name)) |cell| try self.propagateCellWrite(cell, val);
                     try self.storeLocalSlot(frame, slot, val);
+                } else if (frame.include_parent != null) {
+                    if (frame.ref_slots.get(name)) |cell| {
+                        self.setCell(cell, val);
+                        try self.propagateCellWrite(cell, val);
+                    }
+                    if (try frame.vars.fetchPut(self.allocator, name, val)) |old| {
+                        self.releaseValue(old.value);
+                    } else self.releaseValue(frame.locals[slot]);
+                    frame.locals[slot] = val;
+                    try self.syncIncludeLocal(frame, slot, val);
                 } else {
                     self.releaseValue(frame.locals[slot]);
                     frame.locals[slot] = val;
                     try self.setLocalGlobal(slot, val, frame);
-                    try self.syncIncludeLocal(frame, slot, val);
                 }
                 return;
             }
@@ -13788,8 +13738,14 @@ pub const VM = struct {
                 try self.propagateCellWrite(cell, value);
             }
             retainValue(value);
-            if (try caller.vars.fetchPut(self.allocator, name, value)) |old| {
-                self.releaseValue(old.value);
+            const replaced = try caller.vars.fetchPut(self.allocator, name, value);
+            if (replaced) |old| self.releaseValue(old.value);
+            for (caller_sn, 0..) |slot_name, i| {
+                if (std.mem.eql(u8, slot_name, name) and i < caller.locals.len) {
+                    if (replaced == null) self.releaseValue(caller.locals[i]);
+                    caller.locals[i] = value;
+                    break;
+                }
             }
         }
     }
@@ -17794,20 +17750,14 @@ pub const VM = struct {
     }
 
     fn pushNativeResult(self: *VM, value: Value) void {
-        self.pushCallResult(value);
-    }
-
-    // a call result (callMethod / callByName / executeFunction*) is a borrowed
-    // reference: its last owning reference has been released into the deferred
-    // queues, so it stays valid until the next drain and whoever stores or
-    // pushes it retains it. a refcount-zero owned string is exactly that
-    // state; an owned string at refcount >= 1 is a native's own result and
-    // moves onto the stack as the transfer of that reference
-    fn pushCallResult(self: *VM, value: Value) void {
         if (value == .string and value.string.owner != null and value.string.owner.?.refcount > 0) {
             self.pushTransfer(value);
-            return;
-        }
+        } else self.push(value);
+    }
+
+    // call results borrow storage until the next release drain. Other holders
+    // may still own the same value, so its refcount does not identify ownership.
+    fn pushCallResult(self: *VM, value: Value) void {
         self.push(value);
     }
 
@@ -19068,11 +19018,21 @@ pub const VM = struct {
     }
 
     pub fn objectSetOwned(self: *VM, object: *PhpObject, name: []const u8, value: Value) !void {
-        try object.set(self.allocator, name, value);
+        var stable_name = name;
+        if (object.getSlotIndex(name) == null and !object.storage().properties.contains(name)) {
+            stable_name = try self.allocator.dupe(u8, name);
+            try self.strings.append(self.allocator, stable_name);
+        }
+        try object.set(self.allocator, stable_name, value);
     }
 
     pub fn objectSetForScopeOwned(self: *VM, object: *PhpObject, name: []const u8, value: Value, scope: ?[]const u8) !void {
-        try object.setForScope(self.allocator, name, value, scope);
+        var stable_name = name;
+        if (object.getSlotIndexForScope(name, scope) == null and !object.storage().properties.contains(name)) {
+            stable_name = try self.allocator.dupe(u8, name);
+            try self.strings.append(self.allocator, stable_name);
+        }
+        try object.setForScope(self.allocator, stable_name, value, scope);
     }
 
     pub inline fn retainValue(v: Value) void {

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -700,6 +700,8 @@ pub const VM = struct {
     // script's layout, not the most-recently-required file's
     top_slot_names: []const []const u8 = &.{},
     global_vars_dirty: bool = false,
+    method_cache_class_storage: [256]u8 = undefined,
+    method_cache_method_storage: [256]u8 = undefined,
     method_cache_class: []const u8 = "",
     method_cache_method: []const u8 = "",
     method_cache_result: []const u8 = "",
@@ -708,6 +710,8 @@ pub const VM = struct {
     // hasMethod single-entry cache. method dispatch repeatedly probes the
     // same (class, method) pair per call site (decide method-call vs __call
     // fallback) - this skips the bufPrint("{s}::{s}") cost on hits
+    has_method_cache_class_storage: [256]u8 = undefined,
+    has_method_cache_method_storage: [256]u8 = undefined,
     has_method_cache_class: []const u8 = "",
     has_method_cache_method: []const u8 = "",
     has_method_cache_result: bool = false,
@@ -1273,7 +1277,13 @@ pub const VM = struct {
             break :blk created;
         };
         self.next_object_id += 1;
-        obj.* = .{ .class_name = class_name, .id = self.next_object_id };
+        const stable_class_name = if (self.classes.getKey(class_name)) |registered| registered else blk: {
+            const owned = try self.allocator.dupe(u8, class_name);
+            errdefer self.allocator.free(owned);
+            try self.strings.append(self.allocator, owned);
+            break :blk owned;
+        };
+        obj.* = .{ .class_name = stable_class_name, .id = self.next_object_id };
         if (self.debug_trace_class) |trace_class| if (std.mem.eql(u8, trace_class, class_name)) {
             @import("value.zig").trace_obj = obj;
             @import("value.zig").trace_rc_verbose = true;
@@ -2783,6 +2793,7 @@ pub const VM = struct {
             while (ctfn_it.next()) |e| e.value_ptr.*.deinit(self.allocator);
             self.chunk_to_func_names.clearRetainingCapacity();
             self.php_constants.clearRetainingCapacity();
+            self.user_constants.clearRetainingCapacity();
             initConstants(&self.php_constants, self.allocator) catch {};
             // builtins persist across reset now (freeClassState kept them), so the
             // stdlib classes + their native methods + enum objects DON'T need
@@ -10988,7 +10999,13 @@ pub const VM = struct {
     pub fn setPendingException(self: *VM, class_name: []const u8, message: []const u8) !void {
         const obj = try self.allocator.create(PhpObject);
         self.next_object_id += 1;
-        obj.* = .{ .class_name = class_name, .id = self.next_object_id };
+        const stable_class_name = if (self.classes.getKey(class_name)) |registered| registered else blk: {
+            const owned = try self.allocator.dupe(u8, class_name);
+            errdefer self.allocator.free(owned);
+            try self.strings.append(self.allocator, owned);
+            break :blk owned;
+        };
+        obj.* = .{ .class_name = stable_class_name, .id = self.next_object_id };
         try self.initObjectProperties(obj, class_name);
         try obj.set(self.allocator, "message", .{ .string = Value.String.borrowed(message) });
         try obj.set(self.allocator, "code", .{ .int = 0 });
@@ -11280,7 +11297,13 @@ pub const VM = struct {
     pub fn throwBuiltinException(self: *VM, class_name: []const u8, message: []const u8) !bool {
         const obj = try self.allocator.create(PhpObject);
         self.next_object_id += 1;
-        obj.* = .{ .class_name = class_name, .id = self.next_object_id };
+        const stable_class_name = if (self.classes.getKey(class_name)) |registered| registered else blk: {
+            const owned = try self.allocator.dupe(u8, class_name);
+            errdefer self.allocator.free(owned);
+            try self.strings.append(self.allocator, owned);
+            break :blk owned;
+        };
+        obj.* = .{ .class_name = stable_class_name, .id = self.next_object_id };
         try self.initObjectProperties(obj, class_name);
         try obj.set(self.allocator, "message", .{ .string = Value.String.borrowed(message) });
         try obj.set(self.allocator, "code", .{ .int = 0 });
@@ -15585,8 +15608,14 @@ pub const VM = struct {
             }
             break false;
         };
-        self.has_method_cache_class = class_name;
-        self.has_method_cache_method = method_name;
+        if (class_name.len > self.has_method_cache_class_storage.len or method_name.len > self.has_method_cache_method_storage.len) {
+            self.has_method_cache_fn_count = std.math.maxInt(usize);
+            return result;
+        }
+        @memcpy(self.has_method_cache_class_storage[0..class_name.len], class_name);
+        @memcpy(self.has_method_cache_method_storage[0..method_name.len], method_name);
+        self.has_method_cache_class = self.has_method_cache_class_storage[0..class_name.len];
+        self.has_method_cache_method = self.has_method_cache_method_storage[0..method_name.len];
         self.has_method_cache_result = result;
         self.has_method_cache_fn_count = fn_count;
         self.has_method_cache_cls_count = cls_count;
@@ -15612,8 +15641,14 @@ pub const VM = struct {
             return self.method_cache_result;
         }
         const result = try self.resolveMethodSlow(class_name, method_name);
-        self.method_cache_class = class_name;
-        self.method_cache_method = method_name;
+        if (class_name.len > self.method_cache_class_storage.len or method_name.len > self.method_cache_method_storage.len) {
+            self.method_cache_fn_count = std.math.maxInt(usize);
+            return result;
+        }
+        @memcpy(self.method_cache_class_storage[0..class_name.len], class_name);
+        @memcpy(self.method_cache_method_storage[0..method_name.len], method_name);
+        self.method_cache_class = self.method_cache_class_storage[0..class_name.len];
+        self.method_cache_method = self.method_cache_method_storage[0..method_name.len];
         self.method_cache_result = result;
         self.method_cache_fn_count = fn_count;
         self.method_cache_cls_count = cls_count;
@@ -16274,7 +16309,13 @@ pub const VM = struct {
         }
         const obj = try self.allocator.create(PhpObject);
         self.next_object_id += 1;
-        obj.* = .{ .class_name = class_name, .id = self.next_object_id };
+        const stable_class_name = if (self.classes.getKey(class_name)) |registered| registered else blk: {
+            const owned = try self.allocator.dupe(u8, class_name);
+            errdefer self.allocator.free(owned);
+            try self.strings.append(self.allocator, owned);
+            break :blk owned;
+        };
+        obj.* = .{ .class_name = stable_class_name, .id = self.next_object_id };
         try self.objects.append(self.allocator, obj);
         try self.initObjectProperties(obj, class_name);
 

--- a/src/stdlib/arrays.zig
+++ b/src/stdlib/arrays.zig
@@ -115,11 +115,9 @@ fn array_pop(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (e.key == .int and e.key.int > max_int) max_int = e.key.int;
     }
     arr.next_int_key = max_int + 1;
-    // the array no longer references this value - drop the array's retain.
-    // the caller's stack push will retain again, rescuing the destruct if the
-    // result is kept; if the result is discarded the refcount returns to 0
-    // and __destruct fires at the next drain (Stage 2 element-overwrite release)
-    ctx.vm.releaseValue(entry.value);
+    // native strings transfer ownership; other heap results remain borrowed.
+    if (entry.key == .string) entry.key.string.release();
+    if (entry.value != .string) ctx.vm.releaseValue(entry.value);
     return entry.value;
 }
 
@@ -128,6 +126,7 @@ fn array_shift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     if (arr.entries.items.len == 0) return .null;
     const first = arr.entries.items[0];
+    if (first.value == .string) first.value.string.retain();
     ctx.vm.arrayRemoveOwned(arr, first.key);
     // re-index numeric keys starting from 0
     var next_int: i64 = 0;
@@ -229,7 +228,10 @@ fn array_search(_: *NativeContext, args: []const Value) RuntimeError!Value {
         if (match) {
             return switch (entry.key) {
                 .int => |i| .{ .int = i },
-                .string => |s| .{ .string = s },
+                .string => |s| blk: {
+                    s.retain();
+                    break :blk .{ .string = s };
+                },
             };
         }
     }
@@ -1672,13 +1674,18 @@ fn array_reduce(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return carry;
 }
 
+fn retainReturnedString(value: Value) Value {
+    if (value == .string) value.string.retain();
+    return value;
+}
+
 fn array_key_first(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0 or args[0] != .array) return .null;
     const arr = args[0].array;
     if (arr.entries.items.len == 0) return .null;
     return switch (arr.entries.items[0].key) {
         .int => |i| .{ .int = i },
-        .string => |s| .{ .string = s },
+        .string => |s| retainReturnedString(.{ .string = s }),
     };
 }
 
@@ -1688,7 +1695,7 @@ fn array_key_last(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (arr.entries.items.len == 0) return .null;
     return switch (arr.entries.items[arr.entries.items.len - 1].key) {
         .int => |i| .{ .int = i },
-        .string => |s| .{ .string = s },
+        .string => |s| retainReturnedString(.{ .string = s }),
     };
 }
 
@@ -1697,7 +1704,7 @@ fn array_first(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0 or args[0] != .array) return .null;
     const arr = args[0].array;
     if (arr.entries.items.len == 0) return .null;
-    return arr.entries.items[0].value;
+    return retainReturnedString(arr.entries.items[0].value);
 }
 
 fn array_last(_: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1705,7 +1712,7 @@ fn array_last(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0 or args[0] != .array) return .null;
     const arr = args[0].array;
     if (arr.entries.items.len == 0) return .null;
-    return arr.entries.items[arr.entries.items.len - 1].value;
+    return retainReturnedString(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
 fn native_uasort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1831,7 +1838,7 @@ fn native_current(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0 or args[0] != .array) return Value{ .bool = false };
     const arr = args[0].array;
     if (arr.cursor >= arr.entries.items.len) return Value{ .bool = false };
-    return arr.entries.items[arr.cursor].value;
+    return retainReturnedString(arr.entries.items[arr.cursor].value);
 }
 
 fn native_next(_: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1839,7 +1846,7 @@ fn native_next(_: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     if (arr.cursor < arr.entries.items.len) arr.cursor += 1;
     if (arr.cursor >= arr.entries.items.len) return Value{ .bool = false };
-    return arr.entries.items[arr.cursor].value;
+    return retainReturnedString(arr.entries.items[arr.cursor].value);
 }
 
 fn native_prev(_: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1850,7 +1857,7 @@ fn native_prev(_: *NativeContext, args: []const Value) RuntimeError!Value {
         return Value{ .bool = false };
     }
     arr.cursor -= 1;
-    return arr.entries.items[arr.cursor].value;
+    return retainReturnedString(arr.entries.items[arr.cursor].value);
 }
 
 fn native_reset(_: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1858,7 +1865,7 @@ fn native_reset(_: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     arr.cursor = 0;
     if (arr.entries.items.len == 0) return Value{ .bool = false };
-    return arr.entries.items[0].value;
+    return retainReturnedString(arr.entries.items[0].value);
 }
 
 fn native_end(_: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1866,7 +1873,7 @@ fn native_end(_: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = args[0].array;
     if (arr.entries.items.len == 0) return Value{ .bool = false };
     arr.cursor = arr.entries.items.len - 1;
-    return arr.entries.items[arr.cursor].value;
+    return retainReturnedString(arr.entries.items[arr.cursor].value);
 }
 
 fn native_key(_: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1875,7 +1882,7 @@ fn native_key(_: *NativeContext, args: []const Value) RuntimeError!Value {
     if (arr.cursor >= arr.entries.items.len) return .null;
     return switch (arr.entries.items[arr.cursor].key) {
         .int => |i| Value{ .int = i },
-        .string => |s| Value{ .string = s },
+        .string => |s| retainReturnedString(.{ .string = s }),
     };
 }
 

--- a/src/stdlib/arrays.zig
+++ b/src/stdlib/arrays.zig
@@ -574,7 +574,10 @@ fn native_rsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 }
 
 fn reindexArray(arr: *PhpArray) void {
-    for (arr.entries.items, 0..) |*entry, i| entry.key = .{ .int = @intCast(i) };
+    for (arr.entries.items, 0..) |*entry, i| {
+        if (entry.key == .string) entry.key.string.release();
+        entry.key = .{ .int = @intCast(i) };
+    }
     arr.next_int_key = @intCast(arr.entries.items.len);
     arr.has_int_keys = arr.entries.items.len > 0;
     arr.string_index.clearRetainingCapacity();

--- a/src/stdlib/exceptions.zig
+++ b/src/stdlib/exceptions.zig
@@ -251,7 +251,9 @@ fn buildAndAttachTrace(ctx: *NativeContext, obj: *@import("../runtime/value.zig"
 fn exceptionGetMessage(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
     if (this_val != .object) return .null;
-    return this_val.object.get("message");
+    const message = this_val.object.get("message");
+    if (message == .string) message.string.retain();
+    return message;
 }
 
 fn exceptionToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {

--- a/src/stdlib/http.zig
+++ b/src/stdlib/http.zig
@@ -203,7 +203,7 @@ fn native_ob_list_handlers(ctx: *NativeContext, _: []const Value) RuntimeError!V
 
 fn native_header(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0 or args[0] != .string) return .null;
-    const hdr = args[0].string.bytes();
+    const hdr = try ctx.createString(args[0].string.bytes());
     const replace = args.len < 2 or args[1] != .bool or args[1].bool;
 
     if (startsWithIgnoreCase(hdr, "Content-Type:")) {

--- a/src/stdlib/pdo.zig
+++ b/src/stdlib/pdo.zig
@@ -10,6 +10,11 @@ const ClassDef = vm_mod.ClassDef;
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
+fn retainReturned(value: Value) Value {
+    if (value == .string) value.string.retain();
+    return value;
+}
+
 const sqlite = struct {
     const Db = opaque {};
     const Stmt = opaque {};
@@ -481,12 +486,12 @@ fn stmtIterRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 
 fn stmtIterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
-    return obj.get("__iter_current");
+    return retainReturned(obj.get("__iter_current"));
 }
 
 fn stmtIterKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return obj.get("__iter_key");
+    return retainReturned(obj.get("__iter_key"));
 }
 
 fn stmtIterNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -824,7 +829,7 @@ fn pdoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const driver = dsn[0..colon];
     const rest = dsn[colon + 1 ..];
 
-    try obj.set(ctx.allocator, "__driver", .{ .string = Value.String.borrowed(driver) });
+    try obj.set(ctx.allocator, "__driver", .{ .string = Value.String.borrowed(try ctx.createString(driver)) });
 
     if (std.mem.eql(u8, driver, "sqlite")) {
         const path_z = try dupeZ(ctx, rest);

--- a/src/stdlib/reflection.zig
+++ b/src/stdlib/reflection.zig
@@ -1043,7 +1043,8 @@ fn rcConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         return throwReflection(ctx, msg);
     }
 
-    try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(class_name) });
+    const stable_name = try ctx.createString(class_name);
+    try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(stable_name) });
     try this.set(ctx.allocator, "_is_interface", .{ .bool = ctx.vm.interfaces.contains(class_name) });
     try this.set(ctx.allocator, "_is_trait", .{ .bool = ctx.vm.traits.contains(class_name) });
     return .null;
@@ -4301,7 +4302,8 @@ fn reConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         return throwReflection(ctx, msg);
     }
 
-    try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(class_name) });
+    const stable_name = try ctx.createString(class_name);
+    try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(stable_name) });
     try this.set(ctx.allocator, "_is_interface", .{ .bool = false });
     try this.set(ctx.allocator, "_is_trait", .{ .bool = false });
     return .null;

--- a/src/stdlib/reflection.zig
+++ b/src/stdlib/reflection.zig
@@ -12,6 +12,11 @@ const ObjFunction = @import("../pipeline/bytecode.zig").ObjFunction;
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
+fn retainReturned(value: Value) Value {
+    if (value == .string) value.string.retain();
+    return value;
+}
+
 pub fn register(vm: *VM, a: Allocator) !void {
     // Unit enum cases are request-lifetime objects, just like RoundingMode.
     var hook_type = ClassDef{ .name = "PropertyHookType", .is_enum = true, .is_final = true };
@@ -752,7 +757,7 @@ fn rextConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn rextGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn rextGetVersion(_: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1046,7 +1051,7 @@ fn rcConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn rcGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn rcGetConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1946,7 +1951,7 @@ fn rcGetConstant(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
         if (cls.constant_names.contains(target)) {
-            if (cls.static_props.get(target)) |val| return val;
+            if (cls.static_props.get(target)) |val| return retainReturned(val);
         }
         current = cls.parent;
     }
@@ -1965,7 +1970,7 @@ fn buildReflectionClassConstant(ctx: *NativeContext, class_name: []const u8, con
 
 fn rccGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn rccGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2015,7 +2020,7 @@ fn rccGetValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     var current: ?[]const u8 = class_name;
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
-        if (cls.static_props.get(const_name)) |val| return val;
+        if (cls.static_props.get(const_name)) |val| return retainReturned(val);
         current = cls.parent;
     }
     return .null;
@@ -2353,7 +2358,7 @@ fn rmConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn rmGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn rmLookupFunc(ctx: *NativeContext) ?@TypeOf(ctx.vm.functions.get("").?) {
@@ -2511,7 +2516,7 @@ fn rmGetNumberOfRequiredParameters(ctx: *NativeContext, _: []const Value) Runtim
 
 fn rpGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn rpGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2543,7 +2548,7 @@ fn rpGetDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
     const has_default = this.get("_has_default");
     if (has_default != .bool or !has_default.bool) return throwReflection(ctx, "Internal error: no default value available");
-    return this.get("_default_value");
+    return retainReturned(this.get("_default_value"));
 }
 
 fn rpIsOptional(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2839,7 +2844,7 @@ fn rfInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn rfGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn rfGetParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -3589,7 +3594,7 @@ fn rpWrite(ctx: *NativeContext, args: []const Value, skip: bool) RuntimeError!Va
 
 fn rpropGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn rpropGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -3749,7 +3754,7 @@ fn rpropGetDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!Valu
     const this = getThis(ctx) orelse return .null;
     const has_default = this.get("_has_default");
     if (has_default != .bool or !has_default.bool) return throwReflection(ctx, "Property does not have a default value");
-    return this.get("_default_value");
+    return retainReturned(this.get("_default_value"));
 }
 
 fn rpropHasDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -4099,7 +4104,7 @@ fn attributeConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Val
 
 fn raGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn raGetArguments(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -4383,7 +4388,7 @@ fn reucConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn reucGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("name");
+    return retainReturned(this.get("name"));
 }
 
 fn reucGetValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {

--- a/src/stdlib/spl.zig
+++ b/src/stdlib/spl.zig
@@ -12,6 +12,11 @@ const RuntimeError = error{ RuntimeError, OutOfMemory };
 const arrays_mod = @import("arrays.zig");
 const phpTypeName = @import("types.zig").phpTypeName;
 
+fn retainReturned(value: Value) Value {
+    if (value == .string) value.string.retain();
+    return value;
+}
+
 // PHP's SplObjectStorage offset* methods strictly require an object key
 // and throw TypeError on any other type. centralized helper so all four
 // offsetExists/Get/Set/Unset emit the same PHP-format message
@@ -645,7 +650,7 @@ fn wmiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const target = wmiCursorObj(this) orelse return .null;
     const info_v = this.get("__info");
     if (info_v != .array) return .null;
-    return info_v.array.get(.{ .int = sosObjKey(target) });
+    return retainReturned(info_v.array.get(.{ .int = sosObjKey(target) }));
 }
 
 fn wmiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -690,7 +695,7 @@ fn weakRefCreate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
 fn weakRefGet(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const this = getThis(ctx) orelse return .null;
-    return this.get("__target");
+    return retainReturned(this.get("__target"));
 }
 
 fn weakRefConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -772,7 +777,7 @@ fn stackTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return arr.entries.items[arr.entries.items.len - 1].value;
+    return retainReturned(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
 fn stackBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -782,7 +787,7 @@ fn stackBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return arr.entries.items[0].value;
+    return retainReturned(arr.entries.items[0].value);
 }
 
 fn stackCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -835,7 +840,7 @@ fn stackCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .null;
     const cursor = Value.toInt(obj.get("__cursor"));
     if (cursor < 0 or cursor >= arr.length()) return .{ .bool = false };
-    return arr.entries.items[@intCast(cursor)].value;
+    return retainReturned(arr.entries.items[@intCast(cursor)].value);
 }
 
 fn stackKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -940,7 +945,7 @@ fn aoMagicGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const has_props = flags == .int and (flags.int & 2) != 0; // ArrayObject::ARRAY_AS_PROPS
     if (!has_props) return .null;
     const arr = getData(obj) orelse return .null;
-    return arr.get(args[0].toArrayKey());
+    return retainReturned(arr.get(args[0].toArrayKey()));
 }
 
 fn aoMagicSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -983,10 +988,10 @@ fn aoMagicUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 fn aoOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
     if (args.len > 0 and obj.get("__data") == .object and args[0] == .string)
-        return obj.get("__data").object.get(args[0].string.bytes());
+        return retainReturned(obj.get("__data").object.get(args[0].string.bytes()));
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
-    return arr.get(args[0].toArrayKey());
+    return retainReturned(arr.get(args[0].toArrayKey()));
 }
 
 fn aoOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1210,7 +1215,7 @@ fn aiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
     if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return arr.entries.items[cursor].value;
+    return retainReturned(arr.entries.items[cursor].value);
 }
 
 fn aiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1260,10 +1265,10 @@ fn aiCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 fn aiOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
     if (args.len > 0 and obj.get("__data") == .object and args[0] == .string)
-        return obj.get("__data").object.get(args[0].string.bytes());
+        return retainReturned(obj.get("__data").object.get(args[0].string.bytes()));
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
-    return arr.get(args[0].toArrayKey());
+    return retainReturned(arr.get(args[0].toArrayKey()));
 }
 
 fn aiOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1379,7 +1384,7 @@ fn wmOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
     const key = wmObjKey(args[0]) orelse return .null;
-    return arr.get(.{ .int = key });
+    return retainReturned(arr.get(.{ .int = key }));
 }
 
 fn wmOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1408,7 +1413,7 @@ fn wmOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .null;
     if (args.len == 0) return .null;
     const key = wmObjKey(args[0]) orelse return .null;
-    arr.remove(.{ .int = key });
+    ctx.vm.arrayRemoveOwned(arr, .{ .int = key });
     if (args[0] == .object) {
         const keys_v = obj.get("__keys");
         if (keys_v == .array) {
@@ -1542,7 +1547,7 @@ fn pqFormatEntry(ctx: *NativeContext, obj: *PhpObject, entry: Value) Value {
     const flags = Value.toInt(obj.get("__flags"));
     if (entry != .array) return entry;
     const pair = entry.array;
-    if (flags == EXTR_PRIORITY) return pair.get(.{ .int = 1 });
+    if (flags == EXTR_PRIORITY) return retainReturned(pair.get(.{ .int = 1 }));
     if (flags == EXTR_BOTH) {
         const result = ctx.allocator.create(PhpArray) catch return entry;
         result.* = .{};
@@ -1551,7 +1556,7 @@ fn pqFormatEntry(ctx: *NativeContext, obj: *PhpObject, entry: Value) Value {
         result.set(ctx.allocator, .{ .string = Value.String.borrowed("priority") }, pair.get(.{ .int = 1 })) catch return entry;
         return .{ .array = result };
     }
-    return pair.get(.{ .int = 0 });
+    return retainReturned(pair.get(.{ .int = 0 }));
 }
 
 fn pqExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1682,7 +1687,7 @@ fn userHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const obj = getThis(ctx) orelse return .null;
     const arr = getData(obj) orelse return .null;
     const idx = (findUserBestIdx(ctx, obj, arr) catch return .null) orelse return .null;
-    return arr.entries.items[idx].value;
+    return retainReturned(arr.entries.items[idx].value);
 }
 
 fn minHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1702,7 +1707,7 @@ fn minHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty heap");
         return error.RuntimeError;
     };
-    return arr.entries.items[idx].value;
+    return retainReturned(arr.entries.items[idx].value);
 }
 
 fn maxHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1722,7 +1727,7 @@ fn maxHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty heap");
         return error.RuntimeError;
     };
-    return arr.entries.items[idx].value;
+    return retainReturned(arr.entries.items[idx].value);
 }
 
 fn heapCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1742,7 +1747,7 @@ fn heapCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
     if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return arr.entries.items[cursor].value;
+    return retainReturned(arr.entries.items[cursor].value);
 }
 
 fn heapKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -1920,7 +1925,7 @@ fn faOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("OutOfBoundsException", "Index invalid or out of range");
         return error.RuntimeError;
     }
-    return arr.entries.items[@intCast(raw)].value;
+    return retainReturned(arr.entries.items[@intCast(raw)].value);
 }
 
 fn faOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -1967,7 +1972,7 @@ fn faCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
     if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return arr.entries.items[cursor].value;
+    return retainReturned(arr.entries.items[cursor].value);
 }
 
 fn faKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2035,7 +2040,7 @@ fn sqBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return arr.entries.items[0].value;
+    return retainReturned(arr.entries.items[0].value);
 }
 
 fn sqTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2045,7 +2050,7 @@ fn sqTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return arr.entries.items[arr.entries.items.len - 1].value;
+    return retainReturned(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
 fn sqCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2065,7 +2070,7 @@ fn sqCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
     if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return arr.entries.items[cursor].value;
+    return retainReturned(arr.entries.items[cursor].value);
 }
 
 fn sqKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2162,7 +2167,7 @@ fn dllTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return arr.entries.items[arr.entries.items.len - 1].value;
+    return retainReturned(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
 fn dllBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2172,7 +2177,7 @@ fn dllBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return arr.entries.items[0].value;
+    return retainReturned(arr.entries.items[0].value);
 }
 
 fn dllCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2221,7 +2226,7 @@ fn dllCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const arr = getData(obj) orelse return .{ .bool = false };
     const cursor = Value.toInt(obj.get("__cursor"));
     if (cursor < 0 or cursor >= @as(i64, @intCast(arr.entries.items.len))) return .{ .bool = false };
-    return arr.entries.items[@intCast(cursor)].value;
+    return retainReturned(arr.entries.items[@intCast(cursor)].value);
 }
 
 fn dllKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
@@ -2284,7 +2289,7 @@ fn stackOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("OutOfRangeException", "Offset invalid or out of range");
         return error.RuntimeError;
     }
-    return arr.entries.items[@intCast(n - 1 - idx)].value;
+    return retainReturned(arr.entries.items[@intCast(n - 1 - idx)].value);
 }
 
 fn stackOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -2332,7 +2337,7 @@ fn dllOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("OutOfRangeException", "Offset invalid or out of range");
         return error.RuntimeError;
     }
-    return arr.entries.items[@intCast(idx)].value;
+    return retainReturned(arr.entries.items[@intCast(idx)].value);
 }
 
 fn dllOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -2499,7 +2504,7 @@ fn sosDetach(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const idx = sosFindIndexByKey(objs, real_key).?;
         _ = objs.entries.orderedRemove(idx);
         if (real_key == .string) _ = objs.string_index.remove(real_key.string.bytes());
-        info.remove(real_key);
+        ctx.vm.arrayRemoveOwned(info, real_key);
         if (real_key == .string) {
             objs.rebuildStringIndexAssumeCapacity();
         }
@@ -2527,7 +2532,7 @@ fn sosGetInfoMethod(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const info = sosGetInfo(obj) orelse return .null;
     const cursor = Value.toInt(obj.get("__cursor"));
     if (cursor < 0 or cursor >= @as(i64, @intCast(objs.entries.items.len))) return .null;
-    return info.get(objs.entries.items[@intCast(cursor)].key);
+    return retainReturned(info.get(objs.entries.items[@intCast(cursor)].key));
 }
 
 fn sosSetInfoMethod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -2599,7 +2604,7 @@ fn sosRemoveAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 _ = objs.string_index.remove(key.string.bytes());
                 objs.rebuildStringIndexAssumeCapacity();
             }
-            info.remove(key);
+            ctx.vm.arrayRemoveOwned(info, key);
         }
     }
     return .null;
@@ -2636,7 +2641,7 @@ fn sosRemoveAllExcept(ctx: *NativeContext, args: []const Value) RuntimeError!Val
             if (key == .string) {
                 _ = objs.string_index.remove(key.string.bytes());
             }
-            info.remove(key);
+            ctx.vm.arrayRemoveOwned(info, key);
         } else {
             i += 1;
         }
@@ -2680,7 +2685,7 @@ fn sosOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("UnexpectedValueException", "Object not found");
         return error.RuntimeError;
     };
-    return info.get(real_key);
+    return retainReturned(info.get(real_key));
 }
 
 fn sosOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {

--- a/src/stdlib/strings.zig
+++ b/src/stdlib/strings.zig
@@ -177,10 +177,10 @@ fn substr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             length = @max(0, slen - @as(i64, @intCast(ustart)) + length);
         }
         const end: usize = @min(s.len, ustart + @as(usize, @intCast(@max(0, length))));
-        if (args[0] == .string) return .{ .string = args[0].string.retainedSlice(ustart, end) };
+        if (args[0] == .string) return .{ .string = args[0].string.borrowedSlice(ustart, end) };
         return .{ .string = Value.String.borrowed(s[ustart..end]) };
     }
-    if (args[0] == .string) return .{ .string = args[0].string.retainedSlice(ustart, s.len) };
+    if (args[0] == .string) return .{ .string = args[0].string.borrowedSlice(ustart, s.len) };
     return .{ .string = Value.String.borrowed(s[ustart..]) };
 }
 
@@ -351,8 +351,7 @@ fn implode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
     const s = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, s);
-    return .{ .string = Value.String.borrowed(s) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, s) };
 }
 
 const default_trim_chars = " \t\n\r\x0b\x00";
@@ -391,7 +390,7 @@ fn trim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const s = try coerceToString(ctx, args[0]);
     const chars = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else default_trim_chars;
     const set = buildTrimSet(chars);
-    return .{ .string = Value.String.borrowed(try ctx.createString(trimWithSet(s, set, true, true))) };
+    return .{ .string = try Value.String.create(ctx.allocator, trimWithSet(s, set, true, true)) };
 }
 
 fn ltrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -399,7 +398,7 @@ fn ltrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const s = try coerceToString(ctx, args[0]);
     const chars = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else default_trim_chars;
     const set = buildTrimSet(chars);
-    return .{ .string = Value.String.borrowed(try ctx.createString(trimWithSet(s, set, true, false))) };
+    return .{ .string = try Value.String.create(ctx.allocator, trimWithSet(s, set, true, false)) };
 }
 
 fn rtrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -407,7 +406,7 @@ fn rtrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const s = try coerceToString(ctx, args[0]);
     const chars = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else default_trim_chars;
     const set = buildTrimSet(chars);
-    return .{ .string = Value.String.borrowed(try ctx.createString(trimWithSet(s, set, false, true))) };
+    return .{ .string = try Value.String.create(ctx.allocator, trimWithSet(s, set, false, true)) };
 }
 
 fn strtolower(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -416,8 +415,7 @@ fn strtolower(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const s = try coerceToString(ctx, args[0]);
     const buf = try ctx.allocator.alloc(u8, s.len);
     for (s, 0..) |c, i| buf[i] = std.ascii.toLower(c);
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
 }
 
 fn strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -431,8 +429,7 @@ fn strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const s = try coerceToString(ctx, args[0]);
     const buf = try ctx.allocator.alloc(u8, s.len);
     for (s, 0..) |c, i| buf[i] = std.ascii.toUpper(c);
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
 }
 
 fn str_contains(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -460,7 +457,7 @@ fn str_ends_with(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 fn str_shuffle(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0) return .{ .string = Value.String.borrowed("") };
     const s = try coerceToString(ctx, args[0]);
-    if (s.len <= 1) return .{ .string = Value.String.borrowed(s) };
+    if (s.len <= 1) return if (args[0] == .string) args[0] else .{ .string = Value.String.borrowed(s) };
     const buf = try ctx.allocator.alloc(u8, s.len);
     @memcpy(buf, s);
     // Fisher-Yates with the default PRNG
@@ -472,8 +469,7 @@ fn str_shuffle(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         buf[i] = buf[j];
         buf[j] = tmp;
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
 }
 
 fn str_repeat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -484,13 +480,11 @@ fn str_repeat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("ValueError", "str_repeat(): Argument #2 ($times) must be greater than or equal to 0");
         return error.RuntimeError;
     }
-    const times = raw_times;
+    const times: usize = std.math.cast(usize, raw_times) orelse return error.OutOfMemory;
     if (times == 0 or s.len == 0) return .{ .string = Value.String.borrowed("") };
-
-    var buf = std.ArrayListUnmanaged(u8){};
-    var i: i64 = 0;
-    while (i < times) : (i += 1) try buf.appendSlice(ctx.allocator, s);
-    const result = try buf.toOwnedSlice(ctx.allocator);
+    const length = std.math.mul(usize, s.len, times) catch return error.OutOfMemory;
+    const result = try ctx.allocator.alloc(u8, length);
+    for (0..times) |i| @memcpy(result[i * s.len ..][0..s.len], s);
     return .{ .string = try Value.String.adopt(ctx.allocator, result) };
 }
 
@@ -501,8 +495,7 @@ fn ucfirst(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const buf = try ctx.allocator.alloc(u8, s.len);
     @memcpy(buf, s);
     buf[0] = std.ascii.toUpper(buf[0]);
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
 }
 
 fn lcfirst(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -512,15 +505,14 @@ fn lcfirst(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const buf = try ctx.allocator.alloc(u8, s.len);
     @memcpy(buf, s);
     buf[0] = std.ascii.toLower(buf[0]);
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
 }
 
 fn str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len < 2) return if (args.len > 0) args[0] else Value{ .string = Value.String.borrowed("") };
     const s = try coerceToString(ctx, args[0]);
     const target_len: usize = @intCast(@max(0, Value.toInt(args[1])));
-    if (s.len >= target_len) return .{ .string = Value.String.borrowed(s) };
+    if (s.len >= target_len) return if (args[0] == .string) args[0] else .{ .string = Value.String.borrowed(s) };
     const pad_str = if (args.len >= 3 and args[2] != .null) try coerceToString(ctx, args[2]) else " ";
     if (pad_str.len == 0) {
         try ctx.vm.setPendingException("ValueError", "str_pad(): Argument #3 ($pad_string) must not be empty");
@@ -552,8 +544,7 @@ fn str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         while (i < diff) : (i += 1) try buf.append(ctx.allocator, pad_str[i % pad_str.len]);
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, result) };
 }
 
 fn native_strcmp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
@@ -877,9 +868,9 @@ fn native_str_word_count(ctx: *NativeContext, args: []const Value) RuntimeError!
         } else {
             if (in_word) {
                 if (format == 2) {
-                    try arr.set(ctx.allocator, .{ .int = @intCast(word_start) }, .{ .string = args[0].string.retainedSlice(word_start, i) });
+                    try arr.set(ctx.allocator, .{ .int = @intCast(word_start) }, .{ .string = args[0].string.borrowedSlice(word_start, i) });
                 } else {
-                    try arr.append(ctx.allocator, .{ .string = args[0].string.retainedSlice(word_start, i) });
+                    try arr.append(ctx.allocator, .{ .string = args[0].string.borrowedSlice(word_start, i) });
                 }
                 in_word = false;
             }
@@ -887,9 +878,9 @@ fn native_str_word_count(ctx: *NativeContext, args: []const Value) RuntimeError!
     }
     if (in_word) {
         if (format == 2) {
-            try arr.set(ctx.allocator, .{ .int = @intCast(word_start) }, .{ .string = args[0].string.retainedSlice(word_start, s.len) });
+            try arr.set(ctx.allocator, .{ .int = @intCast(word_start) }, .{ .string = args[0].string.borrowedSlice(word_start, s.len) });
         } else {
-            try arr.append(ctx.allocator, .{ .string = args[0].string.retainedSlice(word_start, s.len) });
+            try arr.append(ctx.allocator, .{ .string = args[0].string.borrowedSlice(word_start, s.len) });
         }
     }
     return .{ .array = arr };

--- a/src/stdlib/types.zig
+++ b/src/stdlib/types.zig
@@ -200,11 +200,17 @@ fn native_defined(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 fn native_constant(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len == 0 or args[0] != .string) return .null;
     const name = args[0].string.bytes();
-    if (ctx.vm.php_constants.get(name)) |v| return v;
+    if (ctx.vm.php_constants.get(name)) |v| {
+        if (v == .string) v.string.retain();
+        return v;
+    }
     if (std.mem.indexOf(u8, name, "::")) |sep| {
         const class_name = name[0..sep];
         const prop_name = name[sep + 2 ..];
-        if (ctx.vm.getStaticProp(class_name, prop_name)) |v| return v;
+        if (ctx.vm.getStaticProp(class_name, prop_name)) |v| {
+            if (v == .string) v.string.retain();
+            return v;
+        }
     }
     const msg = try std.fmt.allocPrint(ctx.allocator, "Undefined constant \"{s}\"", .{name});
     try ctx.strings.append(ctx.allocator, msg);

--- a/src/stdlib/types.zig
+++ b/src/stdlib/types.zig
@@ -173,8 +173,10 @@ pub const entries = .{
 fn native_define(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len < 2 or args[0] != .string) return .{ .bool = false };
     if (ctx.vm.php_constants.contains(args[0].string.bytes())) return .{ .bool = false };
-    try ctx.vm.user_constants.put(ctx.allocator, args[0].string.bytes(), {});
-    try ctx.vm.php_constants.put(ctx.allocator, args[0].string.bytes(), args[1]);
+    const name = try ctx.createString(args[0].string.bytes());
+    try ctx.vm.user_constants.put(ctx.allocator, name, {});
+    try ctx.vm.php_constants.put(ctx.allocator, name, args[1]);
+    VM.retainValue(args[1]);
     return .{ .bool = true };
 }
 

--- a/tests/array_getter_owned_strings.php
+++ b/tests/array_getter_owned_strings.php
@@ -1,0 +1,17 @@
+<?php
+foreach (['current', 'reset', 'end', 'array_pop', 'array_shift'] as $getter) {
+    if (!function_exists($getter)) continue;
+    $value = 'retained-' . 42;
+    $array = [$value];
+    $result = $getter($array);
+    unset($array, $value);
+    gc_collect_cycles();
+    var_dump($result);
+}
+foreach (['key', 'array_key_first', 'array_key_last'] as $getter) {
+    $array = ['key-' . 7 => 1];
+    $result = $getter($array);
+    unset($array);
+    gc_collect_cycles();
+    var_dump($result);
+}

--- a/tests/array_search_owned_key.php
+++ b/tests/array_search_owned_key.php
@@ -1,0 +1,9 @@
+<?php
+function findThenRemove(): string {
+    $values = ['temporary-' . 42 => 7];
+    $key = array_search(7, $values, true);
+    unset($values[$key]);
+    gc_collect_cycles();
+    return $key;
+}
+var_dump(findThenRemove());

--- a/tests/concat_owned_lifetime.php
+++ b/tests/concat_owned_lifetime.php
@@ -1,0 +1,19 @@
+<?php
+function concatenate(): array {
+    $s = 'start-' . 1;
+    $copy = $s;
+    $values = [$s];
+    $s .= '-next';
+    $s .= $s;
+    $values[] = $s;
+    $alias = &$s;
+    $alias .= '-reference';
+    return [$copy, $values, $s, static fn() => $s];
+}
+[$copy, $values, $s, $closure] = concatenate();
+gc_collect_cycles();
+var_dump($copy, $values, $s, $closure());
+$s = 'x' . 1;
+$prefix = substr($s, 0, 1);
+for ($i = 0; $i < 100; ++$i) $s .= 'abc';
+var_dump($prefix, strlen($s));

--- a/tests/constant_owned_string_lifetime.php
+++ b/tests/constant_owned_string_lifetime.php
@@ -1,0 +1,9 @@
+<?php
+function defineOwnedStrings(): void {
+    define('OWNED_' . 'VALUE', 'constant-' . 42);
+    define('OWNED_' . 'ARRAY', ['nested-' . 7]);
+}
+defineOwnedStrings();
+gc_collect_cycles();
+for ($i = 0; $i < 100; ++$i) $temporary = 'overwrite-' . $i;
+var_dump(OWNED_VALUE, OWNED_ARRAY, constant('OWNED_' . 'VALUE'));

--- a/tests/dynamic_class_owned_name.php
+++ b/tests/dynamic_class_owned_name.php
@@ -1,0 +1,16 @@
+<?php
+class DurableController {
+    function value(): string { return 'alive'; }
+}
+function constructDynamic() {
+    $name = 'Durable' . 'Controller';
+    return new $name();
+}
+$object = constructDynamic();
+gc_collect_cycles();
+var_dump(get_class($object), $object->value());
+$reflection = new ReflectionClass('Durable' . 'Controller');
+$reflected = $reflection->newInstance();
+unset($reflection);
+gc_collect_cycles();
+var_dump(get_class($reflected), $reflected->value());

--- a/tests/exception_stack_owned_strings.php
+++ b/tests/exception_stack_owned_strings.php
@@ -1,0 +1,20 @@
+<?php
+function failWithString(): string {
+    throw new RuntimeException('failure');
+}
+function consumeStrings(string $first, string $second): void {}
+class StringTarget {
+    public array $values = [];
+}
+$target = new StringTarget();
+for ($i = 0; $i < 20; ++$i) {
+    try {
+        consumeStrings('argument-' . $i, failWithString());
+    } catch (RuntimeException $e) {}
+    try {
+        $target->values['key-' . $i] = failWithString();
+    } catch (RuntimeException $e) {}
+}
+gc_collect_cycles();
+var_dump($target->values);
+echo "caught\n";

--- a/tests/include_owned_dynamic_mirror.php
+++ b/tests/include_owned_dynamic_mirror.php
@@ -1,0 +1,14 @@
+<?php
+$file = sys_get_temp_dir() . '/zphp_owned_include_' . getmypid() . '.php';
+file_put_contents($file, '<?php ${$name} = "replacement-" . 2;');
+function includeOwnedMirror(string $file): void {
+    $value = 'original-' . 1;
+    $name = 'value';
+    include $file;
+    gc_collect_cycles();
+    var_dump($value);
+    $value .= '-suffix';
+    var_dump($value);
+}
+includeOwnedMirror($file);
+unlink($file);

--- a/tests/method_cache_owned_names.php
+++ b/tests/method_cache_owned_names.php
@@ -1,0 +1,14 @@
+<?php
+class CachedMethods {
+    function add() { return 'add'; }
+    function sub() { return 'sub'; }
+    function yes() { return true; }
+    function not() { return false; }
+}
+$object = new CachedMethods();
+foreach (['ADD', 'SUB', 'YES', 'NOT', 'ADD', 'SUB'] as $name) {
+    $method = strtolower($name);
+    var_dump(method_exists($object, $method), $object->$method());
+    unset($method);
+    gc_collect_cycles();
+}

--- a/tests/native_owned_string_lifetime.php
+++ b/tests/native_owned_string_lifetime.php
@@ -1,0 +1,29 @@
+<?php
+function changeCharacter(string $value): string {
+    $copy = $value;
+    $value[0] = 'A';
+    return $copy . ':' . $value;
+}
+var_dump(changeCharacter('word-' . 7));
+$words = str_word_count(strtolower('ONE TWO ' . 'THREE'), 1);
+$positions = str_word_count(strtoupper('one two ' . 'three'), 2);
+gc_collect_cycles();
+var_dump($words, $positions);
+class NamedStringMethod {
+    public static function getValue(): string { return 'ok'; }
+}
+$method = 'get' . 'Value';
+var_dump(NamedStringMethod::$method());
+$map = new WeakMap();
+$key = new stdClass();
+$map[$key] = 'temporary-' . 8;
+unset($map[$key]);
+var_dump(count($map));
+function namedMirrorBatch(): string {
+    for ($i = 0; $i < 10; ++$i) {
+        $value = 'start-' . $i;
+        $value .= '-end';
+    }
+    return $value;
+}
+var_dump(call_user_func('namedMirrorBatch'));

--- a/tests/run
+++ b/tests/run
@@ -21,16 +21,30 @@ trap 'rm -rf "$capture_dir"' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+bounded() {
+    python3 - "$@" <<'PY'
+import subprocess
+import sys
+try:
+    result = subprocess.run(sys.argv[1:], timeout=60)
+    sys.exit(result.returncode if result.returncode >= 0 else 128 - result.returncode)
+except subprocess.TimeoutExpired:
+    print("test exceeded 60 seconds", file=sys.stderr)
+    sys.exit(124)
+PY
+}
+
 for f in "$SCRIPT_DIR"/*.php; do
     name="$(basename "$f")"
     # skip tests that require external database servers
     case "$name" in pdo_mysql.php|pdo_pgsql.php) continue ;; esac
     php_status=0
     zphp_status=0
-    php -d error_reporting='E_ALL & ~E_DEPRECATED' -d display_errors=0 -d zend.exception_ignore_args=0 -d zend.exception_string_param_max_len=15 "$f" >"$capture_dir/php.stdout" 2>"$capture_dir/php.stderr" || php_status=$?
-    "$ZPHP" run "$f" >"$capture_dir/zphp.stdout" 2>"$capture_dir/zphp.stderr" || zphp_status=$?
+    bounded php -d error_reporting='E_ALL & ~E_DEPRECATED' -d display_errors=0 -d zend.exception_ignore_args=0 -d zend.exception_string_param_max_len=15 "$f" >"$capture_dir/php.stdout" 2>"$capture_dir/php.stderr" || php_status=$?
+    bounded "$ZPHP" run "$f" >"$capture_dir/zphp.stdout" 2>"$capture_dir/zphp.stderr" || zphp_status=$?
 
-    if [ "$php_status" -eq "$zphp_status" ] &&
+    if [ "$php_status" -ne 124 ] && [ "$zphp_status" -ne 124 ] &&
+        [ "$php_status" -eq "$zphp_status" ] &&
         cmp -s "$capture_dir/php.stdout" "$capture_dir/zphp.stdout" &&
         cmp -s "$capture_dir/php.stderr" "$capture_dir/zphp.stderr"; then
         passed=$((passed + 1))

--- a/tests/sort_owned_string_keys.php
+++ b/tests/sort_owned_string_keys.php
@@ -1,0 +1,9 @@
+<?php
+foreach (['sort', 'rsort', 'shuffle'] as $operation) {
+    $array = [strtolower('FIRST') => 2, strtolower('SECOND') => 1];
+    $operation($array);
+    var_dump(array_keys($array));
+}
+$array = [strtolower('FIRST') => 2, strtolower('SECOND') => 1];
+usort($array, fn($a, $b) => $a <=> $b);
+var_dump($array);

--- a/tests/transient_string_batches.php
+++ b/tests/transient_string_batches.php
@@ -1,0 +1,17 @@
+<?php
+function stringBatch(int $count): void {
+    for ($i = 0; $i < $count; ++$i) {
+        $a = 'temporary-' . $i;
+        $b = $a . '-suffix';
+        $c = 'prefix';
+        $c .= $b;
+        $c .= $i;
+    }
+}
+$held = [];
+for ($batch = 0; $batch < 8; ++$batch) {
+    stringBatch(20000);
+    $held[] = 'retained-' . $batch;
+    gc_collect_cycles();
+    echo 'batch:', $batch, ':', implode(',', $held), "\n";
+}


### PR DESCRIPTION
Work in progress. Reclaim temporary strings while preserving retained values. Add lifetime regression tests and bounded allocation reuse. Use CI to identify remaining correctness and performance failures. Not ready to merge.