### PR TITLE
Fix HTTP response header ownership and regression tests

### DIFF
--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -738,6 +738,7 @@ pub const VM = struct {
     response_code: i64 = 200,
     response_content_type: []const u8 = "text/html",
     response_headers: ?*PhpArray = null,
+    last_http_response_headers: ?*PhpArray = null,
     headers_sent: bool = false,
     default_tz_name: []const u8 = "UTC",
     // populated by DateTime/createFromFormat parsers when input is unparseable.
@@ -2735,6 +2736,7 @@ pub const VM = struct {
         self.response_code = 200;
         self.response_content_type = "text/html";
         self.response_headers = null;
+        self.last_http_response_headers = null;
         self.headers_sent = false;
         self.default_tz_name = "UTC";
         self.default_tz_offset = 0;

--- a/src/stdlib/filesystem.zig
+++ b/src/stdlib/filesystem.zig
@@ -431,12 +431,10 @@ fn curlWriteCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaqu
 fn curlHeaderCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
     const total = size * nmemb;
     const hd: *CurlHeaderData = @ptrCast(@alignCast(userdata));
-    var raw = data[0..total];
-    while (raw.len > 0 and (raw[raw.len - 1] == '\r' or raw[raw.len - 1] == '\n')) {
-        raw = raw[0 .. raw.len - 1];
-    }
-    if (raw.len > 0) {
-        const owned = hd.ctx.createString(raw) catch return 0;
+    const raw = data[0..total];
+    const cleaned_raw = std.mem.trimEnd(u8, raw, "\r\n");
+    if (cleaned_raw.len > 0) {
+        const owned = hd.ctx.createString(cleaned_raw) catch return 0;
         hd.headers.append(hd.ctx.allocator, .{ .string = Value.String.borrowed(owned) }) catch return 0;
     }
     return total;

--- a/src/stdlib/filesystem.zig
+++ b/src/stdlib/filesystem.zig
@@ -416,6 +416,11 @@ const CurlWriteData = struct {
     buffer: std.ArrayListUnmanaged(u8),
 };
 
+const CurlHeaderData = struct {
+    ctx: *NativeContext,
+    headers: *PhpArray,
+};
+
 fn curlWriteCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
     const total = size * nmemb;
     const wd: *CurlWriteData = @ptrCast(@alignCast(userdata));
@@ -423,7 +428,23 @@ fn curlWriteCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaqu
     return total;
 }
 
+fn curlHeaderCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
+    const total = size * nmemb;
+    const hd: *CurlHeaderData = @ptrCast(@alignCast(userdata));
+    var raw = data[0..total];
+    while (raw.len > 0 and (raw[raw.len - 1] == '\r' or raw[raw.len - 1] == '\n')) {
+        raw = raw[0 .. raw.len - 1];
+    }
+    if (raw.len > 0) {
+        const owned = hd.ctx.createString(raw) catch return 0;
+        hd.headers.append(hd.ctx.allocator, .{ .string = Value.String.borrowed(owned) }) catch return 0;
+    }
+    return total;
+}
+
 fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
+    ctx.vm.last_http_response_headers = null;
+
     if (!curl_global_init_done) {
         _ = c_curl.curl_global_init(c_curl.CURL_GLOBAL_DEFAULT);
         curl_global_init_done = true;
@@ -447,11 +468,21 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
     };
     defer wd.buffer.deinit(wd.allocator);
 
+    const headers_arr = ctx.createArray() catch return .{ .bool = false };
+    var hd = CurlHeaderData{
+        .ctx = ctx,
+        .headers = headers_arr,
+    };
+
     _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_WRITEFUNCTION, @as(?*const fn ([*]u8, usize, usize, *anyopaque) callconv(.c) usize, &curlWriteCallback));
     _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_WRITEDATA, @as(*anyopaque, @ptrCast(&wd)));
+    _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_HEADERFUNCTION, @as(?*const fn ([*]u8, usize, usize, *anyopaque) callconv(.c) usize, &curlHeaderCallback));
+    _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_HEADERDATA, @as(*anyopaque, @ptrCast(&hd)));
 
     const result = c_curl.curl_easy_perform(handle);
     if (result != c_curl.CURLE_OK) return .{ .bool = false };
+
+    ctx.vm.last_http_response_headers = headers_arr;
 
     return .{ .string = Value.String.borrowed(try ctx.createString(wd.buffer.items)) };
 }

--- a/src/stdlib/filesystem.zig
+++ b/src/stdlib/filesystem.zig
@@ -419,7 +419,16 @@ const CurlWriteData = struct {
 const CurlHeaderData = struct {
     ctx: *NativeContext,
     headers: *PhpArray,
+    in_1xx: bool = false,
+    oom: bool = false,
 };
+
+fn parseHttpStatus(line: []const u8) ?u16 {
+    var it = std.mem.tokenizeScalar(u8, line, ' ');
+    _ = it.next() orelse return null;
+    const code_str = it.next() orelse return null;
+    return std.fmt.parseInt(u16, code_str, 10) catch null;
+}
 
 fn curlWriteCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
     const total = size * nmemb;
@@ -433,16 +442,45 @@ fn curlHeaderCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaq
     const hd: *CurlHeaderData = @ptrCast(@alignCast(userdata));
     const raw = data[0..total];
     const cleaned_raw = std.mem.trimEnd(u8, raw, "\r\n");
-    if (cleaned_raw.len > 0) {
-        const owned = hd.ctx.createString(cleaned_raw) catch return 0;
-        hd.headers.append(hd.ctx.allocator, .{ .string = Value.String.borrowed(owned) }) catch return 0;
-    }
+        if (std.mem.startsWith(u8, cleaned_raw, "HTTP/")) {
+            if (parseHttpStatus(cleaned_raw)) |code| {
+                if (code >= 100 and code < 200 and code != 101) {
+                    hd.in_1xx = true;
+                    return total;
+                }
+            }
+            hd.in_1xx = false;
+            // Note: ctx.createString creates an owned copy of line in ctx.strings,
+            // safely detached from cURL's transient buffer.
+            const owned = hd.ctx.createString(cleaned_raw) catch {
+                hd.oom = true;
+                return 0;
+            };
+            hd.headers.append(hd.ctx.allocator, .{ .string = Value.String.borrowed(owned) }) catch {
+                hd.oom = true;
+                return 0;
+            };
+        } else if (!hd.in_1xx) {
+            const line = std.mem.trimEnd(u8, cleaned_raw, " \t");
+            if (line.len > 0) {
+                // Note: ctx.createString creates an owned copy in ctx.strings.
+                const owned = hd.ctx.createString(line) catch {
+                    hd.oom = true;
+                    return 0;
+                };
+                hd.headers.append(hd.ctx.allocator, .{ .string = Value.String.borrowed(owned) }) catch {
+                    hd.oom = true;
+                    return 0;
+                };
+            }
+        }
     return total;
 }
 
 fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
     ctx.vm.last_http_response_headers = null;
 
+    // Note: process-local curl_global_init is safe under zphp serve's fork-based worker model.
     if (!curl_global_init_done) {
         _ = c_curl.curl_global_init(c_curl.CURL_GLOBAL_DEFAULT);
         curl_global_init_done = true;
@@ -458,7 +496,7 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
 
     _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_URL, &url_buf);
     _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_FOLLOWLOCATION, @as(c_long, 1));
-    _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_MAXREDIRS, @as(c_long, 10));
+    _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_MAXREDIRS, @as(c_long, 20));
 
     var wd = CurlWriteData{
         .allocator = ctx.allocator,
@@ -466,6 +504,8 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
     };
     defer wd.buffer.deinit(wd.allocator);
 
+    // headers_arr is tracked in VM.arrays and swept by freeHeapItems on request reset;
+    // only published to ctx.vm.last_http_response_headers if valid headers were received.
     const headers_arr = ctx.createArray() catch return .{ .bool = false };
     var hd = CurlHeaderData{
         .ctx = ctx,
@@ -478,9 +518,10 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
     _ = c_curl.curl_easy_setopt(handle, c_curl.CURLOPT_HEADERDATA, @as(*anyopaque, @ptrCast(&hd)));
 
     const result = c_curl.curl_easy_perform(handle);
+    if (!hd.oom and headers_arr.entries.items.len > 0) {
+        ctx.vm.last_http_response_headers = headers_arr;
+    }
     if (result != c_curl.CURLE_OK) return .{ .bool = false };
-
-    ctx.vm.last_http_response_headers = headers_arr;
 
     return .{ .string = Value.String.borrowed(try ctx.createString(wd.buffer.items)) };
 }

--- a/src/stdlib/filesystem.zig
+++ b/src/stdlib/filesystem.zig
@@ -438,46 +438,31 @@ fn curlWriteCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaqu
 }
 
 fn curlHeaderCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
-    const total = size * nmemb;
+    const total = std.math.mul(usize, size, nmemb) catch return 0;
     const hd: *CurlHeaderData = @ptrCast(@alignCast(userdata));
-    const raw = data[0..total];
-    const cleaned_raw = std.mem.trimEnd(u8, raw, "\r\n");
-        if (std.mem.startsWith(u8, cleaned_raw, "HTTP/")) {
-            if (parseHttpStatus(cleaned_raw)) |code| {
-                if (code >= 100 and code < 200 and code != 101) {
-                    hd.in_1xx = true;
-                    return total;
-                }
-            }
-            hd.in_1xx = false;
-            // Note: ctx.createString creates an owned copy of line in ctx.strings,
-            // safely detached from cURL's transient buffer.
-            const owned = hd.ctx.createString(cleaned_raw) catch {
-                hd.oom = true;
-                return 0;
-            };
-            hd.headers.append(hd.ctx.allocator, .{ .string = Value.String.borrowed(owned) }) catch {
-                hd.oom = true;
-                return 0;
-            };
-        } else if (!hd.in_1xx) {
-            const line = std.mem.trimEnd(u8, cleaned_raw, " \t");
-            if (line.len > 0) {
-                // Note: ctx.createString creates an owned copy in ctx.strings.
-                const owned = hd.ctx.createString(line) catch {
-                    hd.oom = true;
-                    return 0;
-                };
-                hd.headers.append(hd.ctx.allocator, .{ .string = Value.String.borrowed(owned) }) catch {
-                    hd.oom = true;
-                    return 0;
-                };
-            }
-        }
+    const raw = std.mem.trimEnd(u8, data[0..total], "\r\n");
+    const status = std.mem.startsWith(u8, raw, "HTTP/");
+    if (status) {
+        const code = parseHttpStatus(raw) orelse return total;
+        hd.in_1xx = code >= 100 and code < 200 and code != 101;
+    }
+    if (hd.in_1xx) return total;
+    const line = if (status) raw else std.mem.trimEnd(u8, raw, " \t");
+    if (line.len == 0) return total;
+    const owned = Value.String.create(hd.ctx.allocator, line) catch {
+        hd.oom = true;
+        return 0;
+    };
+    defer owned.release();
+    hd.headers.append(hd.ctx.allocator, .{ .string = owned }) catch {
+        hd.oom = true;
+        return 0;
+    };
     return total;
 }
 
 fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
+    if (ctx.vm.last_http_response_headers) |previous| ctx.vm.arrayRelease(previous);
     ctx.vm.last_http_response_headers = null;
 
     // Note: process-local curl_global_init is safe under zphp serve's fork-based worker model.
@@ -504,9 +489,9 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
     };
     defer wd.buffer.deinit(wd.allocator);
 
-    // headers_arr is tracked in VM.arrays and swept by freeHeapItems on request reset;
-    // only published to ctx.vm.last_http_response_headers if valid headers were received.
     const headers_arr = ctx.createArray() catch return .{ .bool = false };
+    @import("../runtime/vm.zig").VM.arrayRetain(headers_arr);
+    defer ctx.vm.arrayRelease(headers_arr);
     var hd = CurlHeaderData{
         .ctx = ctx,
         .headers = headers_arr,
@@ -519,6 +504,7 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
 
     const result = c_curl.curl_easy_perform(handle);
     if (!hd.oom and headers_arr.entries.items.len > 0) {
+        @import("../runtime/vm.zig").VM.arrayRetain(headers_arr);
         ctx.vm.last_http_response_headers = headers_arr;
     }
     if (result != c_curl.CURLE_OK) return .{ .bool = false };

--- a/src/stdlib/http.zig
+++ b/src/stdlib/http.zig
@@ -296,7 +296,9 @@ fn native_headers_list(ctx: *NativeContext, _: []const Value) RuntimeError!Value
 }
 
 fn native_http_get_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.last_http_response_headers) |arr| return .{ .array = arr };
+    if (ctx.vm.last_http_response_headers) |arr| {
+        return .{ .array = try ctx.vm.cloneArray(arr) };
+    }
     return .null;
 }
 

--- a/src/stdlib/http.zig
+++ b/src/stdlib/http.zig
@@ -26,6 +26,8 @@ pub const entries = .{
     .{ "header_remove", native_header_remove },
     .{ "headers_sent", native_headers_sent },
     .{ "headers_list", native_headers_list },
+    .{ "http_get_last_response_headers", native_http_get_last_response_headers },
+    .{ "http_clear_last_response_headers", native_http_clear_last_response_headers },
 };
 
 fn isCallable(v: Value) bool {
@@ -291,6 +293,16 @@ fn native_headers_sent(ctx: *NativeContext, _: []const Value) RuntimeError!Value
 fn native_headers_list(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     if (getResponseHeaders(ctx)) |arr| return .{ .array = arr };
     return .{ .array = try ctx.createArray() };
+}
+
+fn native_http_get_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    if (ctx.vm.last_http_response_headers) |arr| return .{ .array = arr };
+    return .null;
+}
+
+fn native_http_clear_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    ctx.vm.last_http_response_headers = null;
+    return .null;
 }
 
 fn appendCookieOptionsArray(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, opts: *PhpArray) !void {

--- a/src/stdlib/http.zig
+++ b/src/stdlib/http.zig
@@ -303,6 +303,7 @@ fn native_http_get_last_response_headers(ctx: *NativeContext, _: []const Value) 
 }
 
 fn native_http_clear_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+    if (ctx.vm.last_http_response_headers) |arr| ctx.vm.arrayRelease(arr);
     ctx.vm.last_http_response_headers = null;
     return .null;
 }
@@ -376,7 +377,7 @@ fn getResponseHeaders(ctx: *NativeContext) ?*PhpArray {
     return ctx.vm.response_headers;
 }
 
-fn appendResponseHeader(ctx: *NativeContext, hdr: []const u8) !void {
+pub fn appendResponseHeader(ctx: *NativeContext, hdr: []const u8) !void {
     if (ctx.vm.response_headers) |arr| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(hdr) });
     } else {

--- a/src/stdlib/native_params.zig
+++ b/src/stdlib/native_params.zig
@@ -50,6 +50,8 @@ pub const map = std.StaticStringMap([]const []const u8).initComptime(.{
     .{ "parse_url", &.{ "$url", "$component" } },
     .{ "parse_str", &.{ "$string", "$result" } },
     .{ "http_build_query", &.{ "$data", "$numeric_prefix", "$arg_separator", "$encoding_type" } },
+    .{ "http_get_last_response_headers", &.{} },
+    .{ "http_clear_last_response_headers", &.{} },
     .{ "urlencode", &.{"$string"} },
     .{ "urldecode", &.{"$string"} },
     .{ "rawurlencode", &.{"$string"} },

--- a/src/stdlib/session.zig
+++ b/src/stdlib/session.zig
@@ -137,15 +137,7 @@ fn setSessionCookie(ctx: *NativeContext, sid: []const u8) !void {
     const cookie = std.fmt.bufPrint(&buf, "Set-Cookie: {s}={s}; Path=/; HttpOnly; SameSite=Lax", .{ default_name, sid }) catch return;
     const hdr = try ctx.createString(cookie);
 
-    const key = "__response_headers";
-    const existing = ctx.vm.frames[0].vars.get(key);
-    if (existing != null and existing.? == .array) {
-        try existing.?.array.append(ctx.allocator, .{ .string = Value.String.borrowed(hdr) });
-    } else {
-        const arr = try ctx.createArray();
-        try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(hdr) });
-        try ctx.vm.putGlobalVar(key, .{ .array = arr });
-    }
+    try @import("http.zig").appendResponseHeader(ctx, hdr);
 }
 
 fn native_session_start(ctx: *NativeContext, _: []const Value) RuntimeError!Value {

--- a/tests/php84_http_response_headers.php
+++ b/tests/php84_http_response_headers.php
@@ -1,0 +1,30 @@
+<?php
+
+echo function_exists("http_get_last_response_headers") ? "y" : "n", "\n";
+echo function_exists("http_clear_last_response_headers") ? "y" : "n", "\n";
+
+// initial state without requests
+$initial = http_get_last_response_headers();
+var_dump($initial === null);
+
+// clear headers return value
+$clear_result = http_clear_last_response_headers();
+var_dump($clear_result === null);
+
+// state after clear
+$after_clear = http_get_last_response_headers();
+var_dump($after_clear === null);
+
+// repeated clear calls
+http_clear_last_response_headers();
+http_clear_last_response_headers();
+var_dump(http_get_last_response_headers() === null);
+
+// reflection parameter counts
+$rf_get = new ReflectionFunction("http_get_last_response_headers");
+var_dump($rf_get->getNumberOfParameters());
+var_dump($rf_get->getNumberOfRequiredParameters());
+
+$rf_clear = new ReflectionFunction("http_clear_last_response_headers");
+var_dump($rf_clear->getNumberOfParameters());
+var_dump($rf_clear->getNumberOfRequiredParameters());

--- a/tests/php84_http_response_headers.php
+++ b/tests/php84_http_response_headers.php
@@ -20,6 +20,11 @@ http_clear_last_response_headers();
 http_clear_last_response_headers();
 var_dump(http_get_last_response_headers() === null);
 
+// failed request resets headers to null
+$bad = @file_get_contents("http://127.0.0.1:1/nope");
+var_dump($bad === false);
+var_dump(http_get_last_response_headers() === null);
+
 // reflection parameter counts
 $rf_get = new ReflectionFunction("http_get_last_response_headers");
 var_dump($rf_get->getNumberOfParameters());

--- a/tests/serve/app.php
+++ b/tests/serve/app.php
@@ -100,6 +100,11 @@ if ($path === "/health") {
 } elseif ($path === "/redirect") {
     header("Location: /headers", true, 302);
     echo "redirecting";
+} elseif ($path === "/header-trailing-space") {
+    header("X-Trailing-Space: hello    ");
+    header("X-Tab-Space: world\t  ");
+    header("X-Empty-Value:   ");
+    echo "whitespace-test";
 } else {
     http_response_code(404);
     echo json_encode(["error" => "not found", "path" => $path]);

--- a/tests/serve/app.php
+++ b/tests/serve/app.php
@@ -97,6 +97,9 @@ if ($path === "/health") {
     }
     setHeaders();
     echo "from-func";
+} elseif ($path === "/redirect") {
+    header("Location: /headers", true, 302);
+    echo "redirecting";
 } else {
     http_response_code(404);
     echo json_encode(["error" => "not found", "path" => $path]);

--- a/tests/serve/curl_client.php
+++ b/tests/serve/curl_client.php
@@ -107,8 +107,34 @@ $fgc = file_get_contents("$base/health");
 test("fgc http body", '{"status":"ok"}', $fgc);
 test("fgc http type", "string", gettype($fgc));
 
-// file_get_contents with bad URL
-$fgc_bad = file_get_contents("http://127.0.0.1:1/nope");
+// http_get_last_response_headers with successful request
+$fgc_headers_body = file_get_contents("$base/headers");
+$hdrs = http_get_last_response_headers();
+test("http_get_last_response_headers is array after request", true, is_array($hdrs));
+test("http_get_last_response_headers status 200", true, isset($hdrs[0]) && str_contains($hdrs[0], "200"));
+test("http_get_last_response_headers contains custom header", true, in_array("X-Custom: hello", $hdrs, true) || in_array("x-custom: hello", $hdrs, true) || str_contains(implode("\n", $hdrs), "X-Custom: hello"));
+
+// http_clear_last_response_headers after real request
+http_clear_last_response_headers();
+test("http_clear_last_response_headers clears headers", null, http_get_last_response_headers());
+
+// http_get_last_response_headers with 404 response
+$fgc_404 = @file_get_contents("$base/nonexistent");
+$hdrs_404 = http_get_last_response_headers();
+test("http_get_last_response_headers on 404 is array", true, is_array($hdrs_404));
+test("http_get_last_response_headers on 404 status", true, isset($hdrs_404[0]) && str_contains($hdrs_404[0], "404"));
+
+// http_get_last_response_headers with redirect chain (302 -> 200)
+$fgc_redir = file_get_contents("$base/redirect");
+$hdrs_redir = http_get_last_response_headers();
+test("http_get_last_response_headers on redirect is array", true, is_array($hdrs_redir));
+$redir_str = implode("\n", $hdrs_redir ?: []);
+test("http_get_last_response_headers contains 302", true, str_contains($redir_str, "302"));
+test("http_get_last_response_headers contains final 200", true, str_contains($redir_str, "200"));
+
+// file_get_contents with bad URL resets headers to null
+$fgc_bad = @file_get_contents("http://127.0.0.1:1/nope");
 test("fgc bad returns false", false, $fgc_bad);
+test("http_get_last_response_headers on failed request is null", null, http_get_last_response_headers());
 
 echo "done\n";

--- a/tests/serve/curl_client.php
+++ b/tests/serve/curl_client.php
@@ -132,9 +132,38 @@ $redir_str = implode("\n", $hdrs_redir ?: []);
 test("http_get_last_response_headers contains 302", true, str_contains($redir_str, "302"));
 test("http_get_last_response_headers contains final 200", true, str_contains($redir_str, "200"));
 
+// http_get_last_response_headers trailing whitespace handling
+$fgc_ws = file_get_contents("$base/header-trailing-space");
+$hdrs_ws = http_get_last_response_headers();
+test("http_get_last_response_headers trailing space stripped", true, in_array("X-Trailing-Space: hello", $hdrs_ws ?: [], true));
+test("http_get_last_response_headers trailing tab and space stripped", true, in_array("X-Tab-Space: world", $hdrs_ws ?: [], true));
+test("http_get_last_response_headers empty value with spaces stripped", true, in_array("X-Empty-Value:", $hdrs_ws ?: [], true));
+test("http_get_last_response_headers status line preserved", true, isset($hdrs_ws[0]) && str_starts_with($hdrs_ws[0], "HTTP/"));
+
 // file_get_contents with bad URL resets headers to null
 $fgc_bad = @file_get_contents("http://127.0.0.1:1/nope");
 test("fgc bad returns false", false, $fgc_bad);
 test("http_get_last_response_headers on failed request is null", null, http_get_last_response_headers());
 
+// http_get_last_response_headers preserved on failed transfer after headers received
+$fail_port = getenv('CURL_FAIL_PORT');
+if ($fail_port) {
+    http_clear_last_response_headers();
+    $fgc_fail = @file_get_contents("http://127.0.0.1:$fail_port");
+    test("fgc on transfer failure returns false", false, $fgc_fail);
+    $hdrs_fail = http_get_last_response_headers();
+    test("http_get_last_response_headers preserved on failed transfer", true, is_array($hdrs_fail));
+    test("http_get_last_response_headers contains header from failed transfer", true, in_array("X-Transfer-Fail: true", $hdrs_fail ?: [], true));
+    test("status line trailing whitespace preserved exact", "HTTP/1.1 200 OK   ", $hdrs_fail[0] ?? "");
+    test("100 Continue discarded from headers", false, in_array("HTTP/1.1 100 Continue", $hdrs_fail ?: [], true));
+    test("1xx intermediate headers discarded", false, in_array("X-100-Ignore: true", $hdrs_fail ?: [], true));
+
+    // copy-on-write / isolation test: modifying returned array does not mutate internal VM state
+    $copy = $hdrs_fail;
+    $copy[0] = "MODIFIED_STATUS_LINE";
+    $hdrs_second = http_get_last_response_headers();
+    test("http_get_last_response_headers array isolation (COW)", "HTTP/1.1 200 OK   ", $hdrs_second[0] ?? "");
+}
+
 echo "done\n";
+

--- a/tests/serve_test
+++ b/tests/serve_test
@@ -18,7 +18,7 @@ errors=""
 # start server
 "$ZPHP" serve "$APP" --port $PORT --workers 2 &
 SERVER_PID=$!
-cleanup() { kill $SERVER_PID 2>/dev/null || true; wait $SERVER_PID 2>/dev/null || true; exit "${EXIT_CODE:-0}"; }
+cleanup() { kill $SERVER_PID 2>/dev/null || true; kill ${FAIL_PID:-} 2>/dev/null || true; rm -f /tmp/zphp_fail_server_*.ready; wait $SERVER_PID 2>/dev/null || true; exit "${EXIT_CODE:-0}"; }
 trap cleanup EXIT
 
 # wait for server to start
@@ -437,7 +437,49 @@ kill $WSS_PID 2>/dev/null; wait $WSS_PID 2>/dev/null || true
 rm -f /tmp/zphp_test.key /tmp/zphp_test.crt
 
 # --- curl client tests (zphp curl bindings against zphp serve) ---
-curl_out=$(CURL_TEST_PORT=$PORT "$ZPHP" run "$SCRIPT_DIR/serve/curl_client.php" 2>&1)
+FAIL_PORT="${CURL_FAIL_PORT:-$((PORT + 25))}"
+READY_FILE="/tmp/zphp_fail_server_${FAIL_PORT}.ready"
+rm -f "$READY_FILE"
+python3 -c "
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', $FAIL_PORT))
+s.listen(1)
+with open('$READY_FILE', 'w') as f:
+    f.write('ready')
+while True:
+    try:
+        conn, _ = s.accept()
+        _ = conn.recv(1024)
+        conn.sendall(b'HTTP/1.1 100 Continue\r\nX-100-Ignore: true\r\n\r\nHTTP/1.1 200 OK   \r\nX-Transfer-Fail: true\r\nContent-Length: 1000\r\n\r\npartial')
+        conn.close()
+    except Exception:
+        break
+" &
+FAIL_PID=$!
+
+for i in $(seq 1 60); do
+    if [ -f "$READY_FILE" ]; then
+        break
+    fi
+    sleep 0.05
+done
+
+if [ ! -f "$READY_FILE" ]; then
+    echo "  FAIL  mock fail server failed to become ready"
+    failed=$((failed + 1))
+    kill $FAIL_PID 2>/dev/null || true; wait $FAIL_PID 2>/dev/null || true
+    FAIL_PID=
+    curl_fail_arg=""
+else
+    rm -f "$READY_FILE"
+    curl_fail_arg="CURL_FAIL_PORT=$FAIL_PORT"
+fi
+
+curl_out=$(CURL_TEST_PORT=$PORT $curl_fail_arg "$ZPHP" run "$SCRIPT_DIR/serve/curl_client.php" 2>&1)
+kill ${FAIL_PID:-} 2>/dev/null || true; wait ${FAIL_PID:-} 2>/dev/null || true
+FAIL_PID=
 curl_passes=$(echo "$curl_out" | grep -c "^  pass")
 curl_fails=$(echo "$curl_out" | grep -c "^  FAIL")
 echo "$curl_out" | grep -E "^  (pass|FAIL)"

--- a/tests/serve_test
+++ b/tests/serve_test
@@ -18,7 +18,17 @@ errors=""
 # start server
 "$ZPHP" serve "$APP" --port $PORT --workers 2 &
 SERVER_PID=$!
-cleanup() { kill $SERVER_PID 2>/dev/null || true; kill ${FAIL_PID:-} 2>/dev/null || true; rm -f /tmp/zphp_fail_server_*.ready; wait $SERVER_PID 2>/dev/null || true; exit "${EXIT_CODE:-0}"; }
+cleanup() {
+    local status=$?
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+    if [ -n "${FAIL_PID:-}" ]; then
+        kill "$FAIL_PID" 2>/dev/null || true
+        wait "$FAIL_PID" 2>/dev/null || true
+    fi
+    if [ -n "${READY_FILE:-}" ]; then rm -f "$READY_FILE"; fi
+    exit "$status"
+}
 trap cleanup EXIT
 
 # wait for server to start
@@ -438,7 +448,7 @@ rm -f /tmp/zphp_test.key /tmp/zphp_test.crt
 
 # --- curl client tests (zphp curl bindings against zphp serve) ---
 FAIL_PORT="${CURL_FAIL_PORT:-$((PORT + 25))}"
-READY_FILE="/tmp/zphp_fail_server_${FAIL_PORT}.ready"
+READY_FILE=$(mktemp /tmp/zphp_fail_server.XXXXXX)
 rm -f "$READY_FILE"
 python3 -c "
 import socket
@@ -460,29 +470,33 @@ while True:
 FAIL_PID=$!
 
 for i in $(seq 1 60); do
-    if [ -f "$READY_FILE" ]; then
+    if [ -s "$READY_FILE" ]; then
         break
     fi
     sleep 0.05
 done
 
-if [ ! -f "$READY_FILE" ]; then
+if [ ! -s "$READY_FILE" ]; then
     echo "  FAIL  mock fail server failed to become ready"
     failed=$((failed + 1))
     kill $FAIL_PID 2>/dev/null || true; wait $FAIL_PID 2>/dev/null || true
     FAIL_PID=
-    curl_fail_arg=""
+    exit 1
 else
     rm -f "$READY_FILE"
-    curl_fail_arg="CURL_FAIL_PORT=$FAIL_PORT"
 fi
 
-curl_out=$(CURL_TEST_PORT=$PORT $curl_fail_arg "$ZPHP" run "$SCRIPT_DIR/serve/curl_client.php" 2>&1)
+curl_status=0
+curl_out=$(CURL_TEST_PORT=$PORT CURL_FAIL_PORT=$FAIL_PORT "$ZPHP" run "$SCRIPT_DIR/serve/curl_client.php" 2>&1) || curl_status=$?
 kill ${FAIL_PID:-} 2>/dev/null || true; wait ${FAIL_PID:-} 2>/dev/null || true
 FAIL_PID=
-curl_passes=$(echo "$curl_out" | grep -c "^  pass")
-curl_fails=$(echo "$curl_out" | grep -c "^  FAIL")
-echo "$curl_out" | grep -E "^  (pass|FAIL)"
+curl_passes=$(echo "$curl_out" | grep -c "^  pass" || true)
+curl_fails=$(echo "$curl_out" | grep -c "^  FAIL" || true)
+echo "$curl_out"
+if [ "$curl_status" -ne 0 ] || [ "$curl_passes" -eq 0 ]; then
+    failed=$((failed + 1))
+    echo "  FAIL  curl client execution (exit $curl_status)"
+fi
 passed=$((passed + curl_passes))
 failed=$((failed + curl_fails))
 if [ $curl_fails -gt 0 ]; then
@@ -491,8 +505,8 @@ fi
 
 # test: graceful shutdown
 kill -TERM $SERVER_PID
-wait $SERVER_PID 2>/dev/null
-exit_code=$?
+exit_code=0
+wait $SERVER_PID 2>/dev/null || exit_code=$?
 # override cleanup since server is already dead
 trap - EXIT
 if [ $exit_code -eq 0 ] || [ $exit_code -eq 143 ]; then


### PR DESCRIPTION
Integrate #42 with current main. Release response header storage when replaced or cleared, preserve test failures, and fix session cookies exposed by the repaired harness.

Local serve tests pass all 117 assertions, and Laravel passes all seven harnesses. Full validation is in progress.

This branch is intended to feed fixes into #42, not merge independently into main.