### PR TITLE
Reclaim temporary split strings

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -1855,3 +1855,58 @@ test "discarded concatenations release allocations between batches" {
     _ = try vm.callByName("verifyHeld", &.{});
     try std.testing.expectEqualStrings("retained-1,RETAINED-2", vm.output.items);
 }
+
+test "discarded split strings release allocations between batches" {
+    var gpa = std.heap.DebugAllocator(.{ .enable_memory_limit = true }){};
+    defer std.testing.expect(gpa.deinit() == .ok) catch @panic("string batch leak");
+    const alloc = gpa.allocator();
+    const source =
+        \\<?php
+        \\$held = [explode(':', 'retained-' . '1:extra', -1)[0], implode('', str_split('RETAINED-' . 2, 3))];
+        \\function verifyHeld() {
+        \\    global $held;
+        \\    echo implode(',', $held);
+        \\}
+        \\function batch() {
+        \\    for ($i = 0; $i < 1000; ++$i) {
+        \\        $a = 'temporary-' . $i;
+        \\        $b = $a . '-suffix';
+        \\        $c = 'prefix';
+        \\        $c .= $b;
+        \\        $c .= $i;
+        \\        $upper = strtoupper($c);
+        \\        $trimmed = trim($upper);
+        \\        $repeated = str_repeat($trimmed, 2);
+        \\        $joined = implode(':', [$upper, $repeated]);
+        \\        $parts = explode(':', $joined);
+        \\        $limited = explode(':', $joined, -1);
+        \\        $tail = explode(':', $joined, 1);
+        \\        $chunks = str_split($joined, 7);
+        \\    }
+        \\}
+    ;
+    var ast = try parser.parse(alloc, source);
+    defer ast.deinit();
+    var result = try @import("pipeline/compiler.zig").compile(&ast, alloc);
+    defer result.deinit();
+    const vm = try VM.initOnHeap(alloc);
+    defer {
+        vm.deinit();
+        alloc.destroy(vm);
+    }
+    try vm.interpret(&result);
+    for (0..3) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+    }
+    const warm_bytes = gpa.total_requested_bytes;
+    const warm_strings = vm.strings.items.len;
+    for (0..20) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+        try std.testing.expectEqual(warm_strings, vm.strings.items.len);
+        try std.testing.expectEqual(warm_bytes, gpa.total_requested_bytes);
+    }
+    _ = try vm.callByName("verifyHeld", &.{});
+    try std.testing.expectEqualStrings("retained-1,RETAINED-2", vm.output.items);
+}

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -981,7 +981,8 @@ pub const VM = struct {
     }
 
     fn regRefArray(self: *VM, owner: RefIndex.OwnerId, cell: *Value, arr: *PhpArray, key: PhpArray.Key) RuntimeError!void {
-        try (try self.refIndex()).addOwned(self.allocator, owner, cell, .{ .array = .{ .array = arr, .key = key } });
+        const entry = arr.getPtr(key) orelse return;
+        try (try self.refIndex()).addOwned(self.allocator, owner, cell, .{ .array = .{ .array = arr, .key = entry.key } });
     }
     fn regRefObject(self: *VM, owner: RefIndex.OwnerId, cell: *Value, obj: *PhpObject, prop_name: []const u8) RuntimeError!void {
         try (try self.refIndex()).addOwned(self.allocator, owner, cell, .{ .object = .{ .object = obj, .prop_name = prop_name } });

--- a/src/stdlib/strings.zig
+++ b/src/stdlib/strings.zig
@@ -295,22 +295,31 @@ fn explode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var count: i64 = 0;
     while (i <= s.len) {
         if (limit > 0 and count >= limit - 1) {
-            try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(s[i..])) });
+            const part = try Value.String.create(ctx.allocator, s[i..]);
+            defer part.release();
+            try arr.append(ctx.allocator, .{ .string = part });
             break;
         }
         if (std.mem.indexOf(u8, s[i..], delim)) |pos| {
-            try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(s[i .. i + pos])) });
+            const part = try Value.String.create(ctx.allocator, s[i .. i + pos]);
+            defer part.release();
+            try arr.append(ctx.allocator, .{ .string = part });
             i += pos + delim.len;
             count += 1;
         } else {
-            try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(s[i..])) });
+            const part = try Value.String.create(ctx.allocator, s[i..]);
+            defer part.release();
+            try arr.append(ctx.allocator, .{ .string = part });
             break;
         }
     }
 
     if (limit < 0) {
         const drop: usize = @intCast(@min(@as(i64, @intCast(arr.entries.items.len)), -limit));
-        arr.entries.items.len = arr.entries.items.len -| drop;
+        for (0..drop) |_| {
+            const entry = arr.entries.items[arr.entries.items.len - 1];
+            ctx.vm.arrayRemoveOwned(arr, entry.key);
+        }
     }
 
     return .{ .array = arr };
@@ -700,7 +709,9 @@ fn native_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     var i: usize = 0;
     while (i < s.len) {
         const end = @min(i + chunk_len, s.len);
-        try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(s[i..end])) });
+        const part = try Value.String.create(ctx.allocator, s[i..end]);
+        defer part.release();
+        try arr.append(ctx.allocator, .{ .string = part });
         i = end;
     }
     return .{ .array = arr };


### PR DESCRIPTION
Reclaim strings produced by explode() and str_split() when their arrays are released. Release discarded negative-limit elements and bind array references to stored keys instead of temporary lookup strings.

Add repeated-batch tests verifying stable allocations and preserved live values. Local unit tests, 999 compatibility tests, and 160 examples pass. Paired benchmarks show no regression above 10%.

Draft pending CI validation.