### PR TITLE
Reclaim temporary regex captures

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -1954,3 +1954,48 @@ test "discarded replacement strings release allocations between batches" {
     _ = try vm.callByName("verifyHeld", &.{});
     try std.testing.expectEqualStrings("retained-1,RETAINED-2", vm.output.items);
 }
+
+test "discarded regex captures release allocations between batches" {
+    var gpa = std.heap.DebugAllocator(.{ .enable_memory_limit = true }){};
+    defer std.testing.expect(gpa.deinit() == .ok) catch @panic("string batch leak");
+    const alloc = gpa.allocator();
+    const source =
+        \\<?php
+        \\preg_match('/(?<word>retained)-([0-9]+)/', 'retained-' . 1, $heldMatch);
+        \\$heldSplit = preg_split('/:/', 'RETAINED-' . '2:extra');
+        \\$held = [$heldMatch['word'] . '-' . $heldMatch[2], $heldSplit[0]];
+        \\function verifyHeld() { global $held; echo implode(',', $held); }
+        \\function batch() {
+        \\    for ($i = 0; $i < 1000; ++$i) {
+        \\        $s = 'temporary-' . $i . ':again-2';
+        \\        preg_match('/(?<word>[a-z]+)-([0-9]+)/', $s, $one);
+        \\        preg_match_all('/(?<word>[a-z]+)-([0-9]+)/', $s, $all);
+        \\        $parts = preg_split('/([-:])/', $s, -1, PREG_SPLIT_DELIM_CAPTURE);
+        \\    }
+        \\}
+    ;
+    var ast = try parser.parse(alloc, source);
+    defer ast.deinit();
+    var result = try @import("pipeline/compiler.zig").compile(&ast, alloc);
+    defer result.deinit();
+    const vm = try VM.initOnHeap(alloc);
+    defer {
+        vm.deinit();
+        alloc.destroy(vm);
+    }
+    try vm.interpret(&result);
+    for (0..3) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+    }
+    const warm_bytes = gpa.total_requested_bytes;
+    const warm_strings = vm.strings.items.len;
+    for (0..20) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+        try std.testing.expectEqual(warm_strings, vm.strings.items.len);
+        try std.testing.expectEqual(warm_bytes, gpa.total_requested_bytes);
+    }
+    _ = try vm.callByName("verifyHeld", &.{});
+    try std.testing.expectEqualStrings("retained-1,RETAINED-2", vm.output.items);
+}

--- a/src/stdlib/pcre.zig
+++ b/src/stdlib/pcre.zig
@@ -383,10 +383,12 @@ fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const end = ovector[i * 2 + 1];
             if (start == pcre2.UNSET or end == pcre2.UNSET) {
                 const val: Value = if (unmatched_as_null) .null else if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
+                defer if (val == .string) val.string.release();
                 try matches_arr.append(ctx.allocator, val);
             } else {
-                const str = try ctx.createString(subject[start..end]);
-                const val = if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = Value.String.borrowed(str) };
+                const str = subject[start..end];
+                const val = if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, str) };
+                defer if (val == .string) val.string.release();
                 try matches_arr.append(ctx.allocator, val);
             }
         }
@@ -394,7 +396,9 @@ fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (pcre2.pcre2_get_mark_8(match_data)) |mark_ptr| {
             const mark = std.mem.sliceTo(mark_ptr, 0);
             if (mark.len > 0) {
-                try matches_arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString("MARK")) }, .{ .string = Value.String.borrowed(try ctx.createString(mark)) });
+                const owned = try Value.String.create(ctx.allocator, mark);
+                defer owned.release();
+                try matches_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("MARK") }, .{ .string = owned });
             }
         }
         if (args[2] != .array) {
@@ -474,11 +478,13 @@ fn addNamedGroupsInterleaved(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.C
             if (unmatched_as_null) break :blk .null;
             break :blk if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
         } else blk: {
-            const s = try ctx.createString(subject[start..end]);
-            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = Value.String.borrowed(s) };
+            const s = subject[start..end];
+            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, s) };
         };
         const insert_pos = lowest;
-        const named_entry = PhpArray.Entry{ .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) }, .value = val };
+        const named_entry = PhpArray.Entry{ .key = .{ .string = try Value.String.create(ctx.allocator, ng.name) }, .value = val };
+        defer named_entry.key.string.release();
+        defer if (val == .string) val.string.release();
         try insertNamedMatch(ctx, arr, insert_pos, named_entry);
         arr.rebuildStringIndexAssumeCapacity();
         inserted_names[inserted_count] = ng.name;
@@ -508,8 +514,11 @@ fn addNamedGroups(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.Code, ovecto
             const val: Value = if (start == pcre2.UNSET or end == pcre2.UNSET)
                 .{ .string = Value.String.borrowed("") }
             else
-                .{ .string = Value.String.borrowed(try ctx.createString(subject[start..end])) };
-            try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(name)) }, val);
+                .{ .string = try Value.String.create(ctx.allocator, subject[start..end]) };
+            defer if (val == .string) val.string.release();
+            const key = try Value.String.create(ctx.allocator, name);
+            defer key.release();
+            try arr.set(ctx.allocator, .{ .string = key }, val);
         }
     }
 }
@@ -584,6 +593,7 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             };
             for (0..last_idx + 1) |i| {
                 const val = try matchGroupValue(ctx, subject, ovector, count, i, offset_capture);
+                defer if (val == .string) val.string.release();
                 try match_arr.append(ctx.allocator, val);
             }
             try addNamedGroupsToMatch(ctx, match_arr, code, ovector, subject, count, offset_capture);
@@ -591,6 +601,7 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         } else {
             for (0..group_count) |i| {
                 const val = try matchGroupValue(ctx, subject, ovector, count, i, offset_capture);
+                defer if (val == .string) val.string.release();
                 try group_arrays.?.items[i].append(ctx.allocator, val);
             }
         }
@@ -661,9 +672,10 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
             const insert_pos = lowest;
             const named_entry = PhpArray.Entry{
-                .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) },
+                .key = .{ .string = try Value.String.create(ctx.allocator, ng.name) },
                 .value = .{ .array = group_arrays.?.items[ng.group_num] },
             };
+            defer named_entry.key.string.release();
             try insertNamedMatch(ctx, out, insert_pos, named_entry);
             inserted_names[inserted_count] = ng.name;
             inserted_count += 1;
@@ -685,15 +697,17 @@ fn matchGroupValue(ctx: *NativeContext, subject: []const u8, ovector: [*]usize, 
         if (start == pcre2.UNSET or end == pcre2.UNSET) {
             return if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
         }
-        const str = try ctx.createString(subject[start..end]);
-        return if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = Value.String.borrowed(str) };
+        const str = subject[start..end];
+        return if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, str) };
     }
     return if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
 }
 
 fn makeOffsetPair(ctx: *NativeContext, str: []const u8, offset: i64) RuntimeError!Value {
     const pair = try ctx.createArray();
-    try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(str) });
+    const owned = try Value.String.create(ctx.allocator, str);
+    defer owned.release();
+    try pair.append(ctx.allocator, .{ .string = owned });
     try pair.append(ctx.allocator, .{ .int = offset });
     return Value{ .array = pair };
 }
@@ -734,11 +748,13 @@ fn addNamedGroupsToMatch(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.Code,
         const val: Value = if (start == pcre2.UNSET or end == pcre2.UNSET) blk: {
             break :blk if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
         } else blk: {
-            const s = try ctx.createString(subject[start..end]);
-            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = Value.String.borrowed(s) };
+            const s = subject[start..end];
+            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, s) };
         };
         const insert_pos = ng.group_num;
-        const named_entry = PhpArray.Entry{ .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) }, .value = val };
+        const named_entry = PhpArray.Entry{ .key = .{ .string = try Value.String.create(ctx.allocator, ng.name) }, .value = val };
+        defer named_entry.key.string.release();
+        defer if (val == .string) val.string.release();
         try insertNamedMatch(ctx, arr, insert_pos, named_entry);
     }
     arr.rebuildStringIndexAssumeCapacity();
@@ -1337,15 +1353,16 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             continue;
         }
 
-        const piece = try ctx.createString(subject[prev_end..match_start]);
+        const piece = try Value.String.create(ctx.allocator, subject[prev_end..match_start]);
+        defer piece.release();
         if (!no_empty or piece.len > 0) {
             if (offset_capture) {
                 var pair = try ctx.createArray();
-                try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(piece) });
+                try pair.append(ctx.allocator, .{ .string = piece });
                 try pair.append(ctx.allocator, .{ .int = @intCast(prev_end) });
                 try result.append(ctx.allocator, .{ .array = pair });
             } else {
-                try result.append(ctx.allocator, .{ .string = Value.String.borrowed(piece) });
+                try result.append(ctx.allocator, .{ .string = piece });
             }
         }
         splits += 1;
@@ -1356,15 +1373,16 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 const gs = ovector[2 * i];
                 const ge = ovector[2 * i + 1];
                 if (gs <= subject.len and ge <= subject.len) {
-                    const cap = try ctx.createString(subject[gs..ge]);
+                    const cap = try Value.String.create(ctx.allocator, subject[gs..ge]);
+                    defer cap.release();
                     if (!no_empty or cap.len > 0) {
                         if (offset_capture) {
                             var pair = try ctx.createArray();
-                            try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(cap) });
+                            try pair.append(ctx.allocator, .{ .string = cap });
                             try pair.append(ctx.allocator, .{ .int = @intCast(gs) });
                             try result.append(ctx.allocator, .{ .array = pair });
                         } else {
-                            try result.append(ctx.allocator, .{ .string = Value.String.borrowed(cap) });
+                            try result.append(ctx.allocator, .{ .string = cap });
                         }
                     }
                 } else if (!no_empty) {
@@ -1395,15 +1413,16 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
 
-    const tail = try ctx.createString(subject[prev_end..]);
+    const tail = try Value.String.create(ctx.allocator, subject[prev_end..]);
+    defer tail.release();
     if (!no_empty or tail.len > 0) {
         if (offset_capture) {
             var pair = try ctx.createArray();
-            try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(tail) });
+            try pair.append(ctx.allocator, .{ .string = tail });
             try pair.append(ctx.allocator, .{ .int = @intCast(prev_end) });
             try result.append(ctx.allocator, .{ .array = pair });
         } else {
-            try result.append(ctx.allocator, .{ .string = Value.String.borrowed(tail) });
+            try result.append(ctx.allocator, .{ .string = tail });
         }
     }
 


### PR DESCRIPTION
Give preg_match(), preg_match_all(), and preg_split() results counted string ownership, including named captures and offset pairs.

Add repeated-batch allocation tests verifying stable allocations and preserved retained captures. All 379 unit tests, 1,001 compatibility tests, and 160 examples pass locally. Paired benchmarks show no regression above 10%.

Draft pending CI validation.