### PR TITLE
Native result ownership contract

### DIFF
--- a/src/integration_tests.zig
+++ b/src/integration_tests.zig
@@ -1954,3 +1954,48 @@ test "discarded replacement strings release allocations between batches" {
     _ = try vm.callByName("verifyHeld", &.{});
     try std.testing.expectEqualStrings("retained-1,RETAINED-2", vm.output.items);
 }
+
+test "discarded regex captures release allocations between batches" {
+    var gpa = std.heap.DebugAllocator(.{ .enable_memory_limit = true }){};
+    defer std.testing.expect(gpa.deinit() == .ok) catch @panic("string batch leak");
+    const alloc = gpa.allocator();
+    const source =
+        \\<?php
+        \\preg_match('/(?<word>retained)-([0-9]+)/', 'retained-' . 1, $heldMatch);
+        \\$heldSplit = preg_split('/:/', 'RETAINED-' . '2:extra');
+        \\$held = [$heldMatch['word'] . '-' . $heldMatch[2], $heldSplit[0]];
+        \\function verifyHeld() { global $held; echo implode(',', $held); }
+        \\function batch() {
+        \\    for ($i = 0; $i < 1000; ++$i) {
+        \\        $s = 'temporary-' . $i . ':again-2';
+        \\        preg_match('/(?<word>[a-z]+)-([0-9]+)/', $s, $one);
+        \\        preg_match_all('/(?<word>[a-z]+)-([0-9]+)/', $s, $all);
+        \\        $parts = preg_split('/([-:])/', $s, -1, PREG_SPLIT_DELIM_CAPTURE);
+        \\    }
+        \\}
+    ;
+    var ast = try parser.parse(alloc, source);
+    defer ast.deinit();
+    var result = try @import("pipeline/compiler.zig").compile(&ast, alloc);
+    defer result.deinit();
+    const vm = try VM.initOnHeap(alloc);
+    defer {
+        vm.deinit();
+        alloc.destroy(vm);
+    }
+    try vm.interpret(&result);
+    for (0..3) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+    }
+    const warm_bytes = gpa.total_requested_bytes;
+    const warm_strings = vm.strings.items.len;
+    for (0..20) |_| {
+        _ = try vm.callByName("batch", &.{});
+        _ = try vm.callByName("gc_collect_cycles", &.{});
+        try std.testing.expectEqual(warm_strings, vm.strings.items.len);
+        try std.testing.expectEqual(warm_bytes, gpa.total_requested_bytes);
+    }
+    _ = try vm.callByName("verifyHeld", &.{});
+    try std.testing.expectEqualStrings("retained-1,RETAINED-2", vm.output.items);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -606,6 +606,7 @@ test {
     _ = @import("pipeline/bytecode.zig");
     _ = @import("pipeline/compiler.zig");
     _ = @import("runtime/value.zig");
+    _ = @import("runtime/native_result.zig");
     _ = @import("runtime/vm.zig");
     _ = @import("stdlib/exceptions.zig");
     _ = @import("stdlib/registry.zig");

--- a/src/runtime/native_result.zig
+++ b/src/runtime/native_result.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+const Value = @import("value.zig").Value;
+
+pub const NativeResult = struct {
+    value: Value,
+
+    pub fn scalar(value: Value) NativeResult {
+        std.debug.assert(value != .string and value != .array and value != .object and value != .generator and value != .fiber);
+        return .{ .value = value };
+    }
+
+    pub fn borrowed(value: Value) NativeResult {
+        std.debug.assert(value != .string);
+        return .{ .value = value };
+    }
+
+    pub fn share(value: Value) NativeResult {
+        if (value == .string) return shareString(value.string);
+        return borrowed(value);
+    }
+
+    pub fn shareString(value: Value.String) NativeResult {
+        value.retain();
+        return .{ .value = .{ .string = value } };
+    }
+
+    pub fn takeString(value: Value.String) NativeResult {
+        std.debug.assert(value.owner != null);
+        std.debug.assert(value.owner.?.refcount > 0);
+        return .{ .value = .{ .string = value } };
+    }
+
+    pub fn copyString(allocator: std.mem.Allocator, bytes: []const u8) !NativeResult {
+        return takeString(try Value.String.create(allocator, bytes));
+    }
+
+    pub fn literal(comptime bytes: []const u8) NativeResult {
+        return .{ .value = .{ .string = Value.String.borrowed(bytes) } };
+    }
+
+    // a value the VM handed over with its reference: a result popped off the
+    // operand stack (eval) or a freshly minted closure instance. strings keep
+    // the reference they arrived with, everything else stays borrowed
+    pub fn transfer(value: Value) NativeResult {
+        if (value == .string and value.string.owner != null) return takeString(value.string);
+        return .{ .value = value };
+    }
+};
+
+test "shared native strings survive release of their original owner" {
+    const source = try Value.String.create(std.testing.allocator, "kept");
+    const result = NativeResult.shareString(source);
+    source.release();
+    defer result.value.string.release();
+    try std.testing.expectEqualStrings("kept", result.value.string.bytes());
+    try std.testing.expectEqual(@as(usize, 1), result.value.string.owner.?.refcount);
+}
+
+test "transferred native strings do not gain another reference" {
+    const source = try Value.String.create(std.testing.allocator, "owned");
+    const result = NativeResult.takeString(source);
+    defer result.value.string.release();
+    try std.testing.expectEqual(@as(usize, 1), result.value.string.owner.?.refcount);
+}
+
+test "copied native results do not borrow temporary bytes" {
+    var bytes = [_]u8{ 'a', 'b' };
+    const result = try NativeResult.copyString(std.testing.allocator, &bytes);
+    defer result.value.string.release();
+    bytes[0] = 'z';
+    try std.testing.expectEqualStrings("ab", result.value.string.bytes());
+}

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -98,15 +98,6 @@ pub const NativeContext = struct {
         return self.vm.callByName(name, args);
     }
 
-    // native result contract: an owned string result is a transferred
-    // reference, objects and arrays are borrowed. a native handing back a
-    // string it does not own (a registry entry, a container element) must
-    // add the reference the caller will consume
-    pub fn returnShared(self: *NativeContext, value: Value) void {
-        _ = self;
-        if (value == .string) value.string.retain();
-    }
-
     pub fn callMethod(self: *NativeContext, obj: *PhpObject, method: []const u8, args: []const Value) RuntimeError!Value {
         return self.vm.callMethod(obj, method, args);
     }
@@ -231,7 +222,8 @@ pub const NativeContext = struct {
     }
 };
 
-const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!Value;
+pub const NativeResult = @import("native_result.zig").NativeResult;
+const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!NativeResult;
 
 pub const CaptureEntry = struct {
     closure_name: []const u8,
@@ -7793,7 +7785,7 @@ pub const VM = struct {
 
                             const saved_fc = self.frame_count;
                             var ctx = self.makeContext(null);
-                            _ = self.invokeNative(native, &ctx, args_buf[0..ac], cn) catch {
+                            const ctor_result = self.invokeNative(native, &ctx, args_buf[0..ac], cn) catch {
                                 // clean up temp frame if throwBuiltinException didn't already unwind past it
                                 if (self.frame_count >= saved_fc) {
                                     self.frame_count -= 1;
@@ -7820,6 +7812,7 @@ pub const VM = struct {
                                 }
                                 return error.RuntimeError;
                             };
+                            if (ctor_result == .string) ctor_result.string.release();
 
                             self.frame_count -= 1;
                             self.deinitFrameSlot(self.frame_count);
@@ -8006,7 +7999,7 @@ pub const VM = struct {
                             self.retainFrameObjects(self.frame_count - 1);
                             if (self.frame_count > self.frame_high_water) self.frame_high_water = self.frame_count;
                             var ctx = self.makeContext(null);
-                            _ = self.invokeNative(native, &ctx, args_buf[0..ac], cn) catch {
+                            const ctor_result = self.invokeNative(native, &ctx, args_buf[0..ac], cn) catch {
                                 self.frame_count -= 1;
                                 self.deinitFrameSlot(self.frame_count);
                                 if (self.pending_exception) |exc| {
@@ -8031,6 +8024,7 @@ pub const VM = struct {
                                 }
                                 return error.RuntimeError;
                             };
+                            if (ctor_result == .string) ctor_result.string.release();
                             self.frame_count -= 1;
                             self.deinitFrameSlot(self.frame_count);
                         } else if (self.functions.get(cn)) |func| {
@@ -11860,7 +11854,14 @@ pub const VM = struct {
             }
             var ctx = self.makeContext(null);
             const result = self.invokeNative(native, &ctx, &.{}, null) catch return "Object";
-            if (result == .string) return result.string.bytes();
+            if (result == .string) {
+                const owner = result.string.owner orelse return result.string.bytes();
+                defer result.string.release();
+                if (owner.refcount > 1) return result.string.bytes();
+                const copy = self.allocator.dupe(u8, result.string.bytes()) catch return "Object";
+                self.strings.append(self.allocator, copy) catch return "Object";
+                return copy;
+            }
             var buf = std.ArrayListUnmanaged(u8){};
             result.format(&buf, self.allocator) catch return "Object";
             const s = buf.toOwnedSlice(self.allocator) catch return "Object";
@@ -16109,15 +16110,7 @@ pub const VM = struct {
             };
         }
         const result = try native(ctx, native_args);
-        if (result == .string and result.string.owner != null) {
-            for (native_args) |arg| {
-                if (arg == .string and arg.string.owner == result.string.owner) {
-                    result.string.retain();
-                    break;
-                }
-            }
-        }
-        return result;
+        return result.value;
     }
 
     pub fn bindClosures(self: *VM, vars: *std.StringHashMapUnmanaged(Value), ref_slots: ?*std.StringHashMapUnmanaged(*Value), name: []const u8) !void {

--- a/src/stdlib/arrays.zig
+++ b/src/stdlib/arrays.zig
@@ -5,6 +5,7 @@ const PhpArray = @import("../runtime/value.zig").PhpArray;
 const vm_mod = @import("../runtime/vm.zig");
 const NativeContext = vm_mod.NativeContext;
 const VM = vm_mod.VM;
+const NativeResult = vm_mod.NativeResult;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
 pub const entries = .{
@@ -94,20 +95,20 @@ pub const entries = .{
     .{ "array_change_key_case", array_change_key_case },
 };
 
-fn array_push(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .{ .int = 0 };
+fn array_push(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.{ .int = 0 });
     const arr = args[0].array;
     if (args.len >= 2) {
         for (args[1..]) |val| try arr.append(ctx.allocator, val);
     }
-    return .{ .int = arr.length() };
+    return NativeResult.scalar(.{ .int = arr.length() });
 }
 
-fn array_pop(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_pop(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return .null;
-    const entry = arr.entries.pop() orelse return .null;
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.null);
+    const entry = arr.entries.pop() orelse return NativeResult.scalar(.null);
     if (entry.key == .string) _ = arr.string_index.remove(entry.key.string.bytes());
     // PHP: array_pop recomputes next int key from the remaining entries
     var max_int: i64 = -1;
@@ -118,13 +119,13 @@ fn array_pop(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // native strings transfer ownership; other heap results remain borrowed.
     if (entry.key == .string) entry.key.string.release();
     if (entry.value != .string) ctx.vm.releaseValue(entry.value);
-    return entry.value;
+    return if (entry.value == .string and entry.value.string.owner != null) NativeResult.takeString(entry.value.string) else NativeResult.share(entry.value);
 }
 
-fn array_shift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_shift(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return .null;
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.null);
     const first = arr.entries.items[0];
     if (first.value == .string) first.value.string.retain();
     ctx.vm.arrayRemoveOwned(arr, first.key);
@@ -141,11 +142,11 @@ fn array_shift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     arr.rebuildStringIndexAssumeCapacity();
 
-    return first.value;
+    return if (first.value == .string and first.value.string.owner != null) NativeResult.takeString(first.value.string) else NativeResult.share(first.value);
 }
 
-fn array_keys(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_keys(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const has_search = args.len >= 2;
     const search_val = if (has_search) args[1] else Value.null;
@@ -162,25 +163,25 @@ fn array_keys(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         };
         try arr.append(ctx.allocator, key_val);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn array_is_list(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .{ .bool = false };
+fn array_is_list(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const arr = args[0].array;
     for (arr.entries.items, 0..) |entry, i| {
         switch (entry.key) {
             .int => |k| {
-                if (k != @as(i64, @intCast(i))) return .{ .bool = false };
+                if (k != @as(i64, @intCast(i))) return NativeResult.scalar(.{ .bool = false });
             },
-            .string => return .{ .bool = false },
+            .string => return NativeResult.scalar(.{ .bool = false }),
         }
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn array_values(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn array_values(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     if (args[0] != .array) {
         try ctx.vm.setPendingException("TypeError", "array_values(): Argument #1 ($array) must be of type array");
         return error.RuntimeError;
@@ -190,36 +191,36 @@ fn array_values(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     for (src.entries.items) |entry| {
         try arr.append(ctx.allocator, entry.value);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn in_array(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .array) return .{ .bool = false };
+fn in_array(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .array) return NativeResult.scalar(.{ .bool = false });
     const needle = args[0];
     const arr = args[1].array;
     const strict = args.len >= 3 and args[2].isTruthy();
     for (arr.entries.items) |entry| {
         if (strict) {
-            if (Value.identical(needle, entry.value)) return .{ .bool = true };
+            if (Value.identical(needle, entry.value)) return NativeResult.scalar(.{ .bool = true });
         } else {
-            if (try ctx.vm.looseEqualWithStringable(needle, entry.value)) return .{ .bool = true };
+            if (try ctx.vm.looseEqualWithStringable(needle, entry.value)) return NativeResult.scalar(.{ .bool = true });
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn array_key_exists(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .array) return .{ .bool = false };
+fn array_key_exists(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .array) return NativeResult.scalar(.{ .bool = false });
     const key = PhpArray.normalizeKey(Value.toArrayKey(args[0]));
     const arr = args[1].array;
     for (arr.entries.items) |entry| {
-        if (entry.key.eql(key)) return .{ .bool = true };
+        if (entry.key.eql(key)) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn array_search(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .array) return .{ .bool = false };
+fn array_search(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .array) return NativeResult.scalar(.{ .bool = false });
     const needle = args[0];
     const arr = args[1].array;
     const strict = args.len >= 3 and args[2] == .bool and args[2].bool;
@@ -227,19 +228,16 @@ fn array_search(_: *NativeContext, args: []const Value) RuntimeError!Value {
         const match = if (strict) Value.identical(needle, entry.value) else Value.equal(needle, entry.value);
         if (match) {
             return switch (entry.key) {
-                .int => |i| .{ .int = i },
-                .string => |s| blk: {
-                    s.retain();
-                    break :blk .{ .string = s };
-                },
+                .int => |i| NativeResult.scalar(.{ .int = i }),
+                .string => |s| NativeResult.shareString(s),
             };
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn array_reverse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_reverse(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const preserve = args.len >= 2 and args[1].isTruthy();
     var arr = try ctx.createArray();
@@ -252,31 +250,31 @@ fn array_reverse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             .string => try arr.set(ctx.allocator, entry.key, entry.value),
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn array_merge(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    var arr = try ctx.createArray();
+fn array_merge(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const arr = try ctx.createArray();
     for (args) |arg| {
         if (arg != .array) continue;
         for (arg.array.entries.items) |entry| {
             switch (entry.key) {
                 .int => try arr.append(ctx.allocator, entry.value),
-                .string => |s| try arr.set(ctx.allocator, .{ .string = s }, entry.value),
+                .string => |s| try ctx.vm.arraySetOwned(arr, .{ .string = s }, entry.value),
             }
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn array_slice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .null;
+fn array_slice(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const slen: i64 = @intCast(src.entries.items.len);
     var offset = Value.toInt(args[1]);
     if (offset < 0) offset = @max(0, slen + offset);
     if (offset >= slen) {
-        return .{ .array = try ctx.createArray() };
+        return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     }
     const uoffset: usize = @intCast(offset);
     var raw_length: i64 = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else slen - offset;
@@ -296,11 +294,11 @@ fn array_slice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             },
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn array_unique(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_unique(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     // default in PHP is SORT_STRING (2)
     const raw_flag: i64 = if (args.len >= 2) Value.toInt(args[1]) else 2;
@@ -314,8 +312,10 @@ fn array_unique(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 1 => Value.toFloat(entry.value) == Value.toFloat(existing.value), // SORT_NUMERIC
                 2, 5, 6 => blk: { // SORT_STRING, SORT_LOCALE_STRING, SORT_NATURAL
                     const a_str = try valueAsStringForCompare(ctx, entry.value);
+                    defer a_str.release();
                     const b_str = try valueAsStringForCompare(ctx, existing.value);
-                    break :blk if (case_insensitive) std.ascii.eqlIgnoreCase(a_str, b_str) else std.mem.eql(u8, a_str, b_str);
+                    defer b_str.release();
+                    break :blk if (case_insensitive) std.ascii.eqlIgnoreCase(a_str.bytes(), b_str.bytes()) else std.mem.eql(u8, a_str.bytes(), b_str.bytes());
                 },
                 else => Value.equal(entry.value, existing.value), // SORT_REGULAR
             };
@@ -326,7 +326,7 @@ fn array_unique(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         if (!found) try arr.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn valueAsString(v: Value, buf: *[64]u8) []const u8 {
@@ -340,22 +340,25 @@ fn valueAsString(v: Value, buf: *[64]u8) []const u8 {
     };
 }
 
-fn valueAsStringForCompare(ctx: *NativeContext, v: Value) RuntimeError![]const u8 {
+fn valueAsStringForCompare(ctx: *NativeContext, v: Value) RuntimeError!Value.String {
     if (v == .object) {
         if (ctx.vm.hasMethod(v.object.class_name, "__toString")) {
             const result = try ctx.vm.callMethod(v.object, "__toString", &.{});
-            if (result == .string) return result.string.bytes();
+            if (result == .string) {
+                result.string.retain();
+                return result.string;
+            }
         }
         var buf: [256]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "Object of class {s} could not be converted to string", .{v.object.class_name}) catch "Object could not be converted to string";
-        try ctx.vm.setPendingException("Error", msg);
+        try ctx.vm.setPendingException("Error", try ctx.createString(msg));
         return error.RuntimeError;
     }
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     try v.format(&buf, ctx.allocator);
     const owned = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return owned;
+    return Value.String.adopt(ctx.allocator, owned);
 }
 
 const SortFlags = struct {
@@ -532,18 +535,18 @@ fn natsortImpl(arr: *PhpArray, fold_case: bool) void {
     arr.string_index.clearRetainingCapacity();
 }
 
-fn natsort_impl(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn natsort_impl(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "natsort", 1, args[0]);
     natsortImpl(args[0].array, false);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn natcasesort_impl(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn natcasesort_impl(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "natcasesort", 1, args[0]);
     natsortImpl(args[0].array, true);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn throwArrayTypeError(ctx: *NativeContext, fn_name: []const u8, arg_pos: u8, got: Value) RuntimeError {
@@ -553,24 +556,24 @@ fn throwArrayTypeError(ctx: *NativeContext, fn_name: []const u8, arg_pos: u8, go
     return error.RuntimeError;
 }
 
-fn native_sort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_sort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "sort", 1, args[0]);
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortWithFlags(arr, flags, false);
     reindexArray(arr);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_rsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_rsort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "rsort", 1, args[0]);
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortWithFlags(arr, flags, true);
     reindexArray(arr);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn reindexArray(arr: *PhpArray) void {
@@ -656,8 +659,8 @@ fn invokeSortCmp(comptime T: type, a: T, b: T, ctx: *NativeContext, callback: Va
     return ctx.invokeCallable(callback, &.{ a.value, b.value });
 }
 
-fn array_map(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
+fn array_map(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
     for (args[1..], 1..) |a, i| {
         if (a != .array) {
             // PHP labels arg #2 as '($array)' but drops the param-name for
@@ -692,10 +695,10 @@ fn array_map(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
             try result.append(ctx.allocator, .{ .array = tuple });
         }
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
-    if (args[1] != .array) return .null;
+    if (args[1] != .array) return NativeResult.scalar(.null);
     const src = args[1].array;
 
     // null callback with single array returns a copy preserving keys
@@ -704,7 +707,7 @@ fn array_map(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         for (src.entries.items) |entry| {
             try result.set(ctx.allocator, entry.key, entry.value);
         }
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     // validate callable - PHP throws TypeError for unknown function names.
@@ -726,8 +729,9 @@ fn array_map(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         for (args[1..]) |a| {
             if (a == .array) max_len = @max(max_len, a.array.entries.items.len);
         }
-        var cb_args_buf: [8]Value = undefined;
         const n_arrays = args.len - 1;
+        const cb_args_buf = try ctx.allocator.alloc(Value, n_arrays);
+        defer ctx.allocator.free(cb_args_buf);
         var result = try ctx.createArray();
         for (0..max_len) |i| {
             for (0..n_arrays) |j| {
@@ -737,7 +741,7 @@ fn array_map(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const mapped = try ctx.invokeCallable(callback, cb_args_buf[0..n_arrays]);
             try result.append(ctx.allocator, mapped);
         }
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     var result = try ctx.createArray();
@@ -745,11 +749,11 @@ fn array_map(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const mapped = try ctx.invokeCallable(callback, &.{entry.value});
         try result.set(ctx.allocator, entry.key, mapped);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_filter(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_filter(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const flag: i64 = if (args.len >= 3) Value.toInt(args[2]) else 0;
 
@@ -775,21 +779,21 @@ fn array_filter(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             if (keep.isTruthy()) try result.set(ctx.allocator, entry.key, entry.value);
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_usort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn native_usort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "usort", 1, args[0]);
     const arr = args[0].array;
     const callback = args[1];
     try mergeSort(PhpArray.Entry, arr.entries.items, ctx, callback, .value);
     reindexArray(arr);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_range(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
+fn native_range(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
 
     // character range: single-char strings
     if (args[0] == .string and args[0].string.bytes().len == 1 and args[1] == .string and args[1].string.bytes().len == 1) {
@@ -802,8 +806,9 @@ fn native_range(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             while (c <= hi) {
                 const s = try ctx.allocator.alloc(u8, 1);
                 s[0] = c;
-                try ctx.strings.append(ctx.allocator, s);
-                try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+                const owned = try Value.String.adopt(ctx.allocator, s);
+                defer owned.release();
+                try arr.append(ctx.allocator, .{ .string = owned });
                 if (c > hi - step) break;
                 c += step;
             }
@@ -812,13 +817,14 @@ fn native_range(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             while (c >= hi) {
                 const s = try ctx.allocator.alloc(u8, 1);
                 s[0] = c;
-                try ctx.strings.append(ctx.allocator, s);
-                try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+                const owned = try Value.String.adopt(ctx.allocator, s);
+                defer owned.release();
+                try arr.append(ctx.allocator, .{ .string = owned });
                 if (c < hi + step) break;
                 c -= step;
             }
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
     // use floats if any arg is a float
@@ -856,7 +862,7 @@ fn native_range(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             i += 1;
             if (i > 100_000_000) break; // sanity cap
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
     const lo = Value.toInt(args[0]);
@@ -884,11 +890,11 @@ fn native_range(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         var i = lo;
         while (i >= hi) : (i -= step) try arr.append(ctx.allocator, .{ .int = i });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn array_splice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .null;
+fn array_splice(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
     const alen: i64 = @intCast(arr.entries.items.len);
     var offset = Value.toInt(args[1]);
@@ -979,11 +985,11 @@ fn array_splice(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     arr.has_int_keys = next_int > 0;
     arr.rebuildStringIndexAssumeCapacity();
 
-    return .{ .array = removed };
+    return NativeResult.borrowed(.{ .array = removed });
 }
 
-fn array_combine(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array or args[1] != .array) return .{ .bool = false };
+fn array_combine(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array or args[1] != .array) return NativeResult.scalar(.{ .bool = false });
     const keys_arr = args[0].array;
     const vals_arr = args[1].array;
     if (keys_arr.entries.items.len != vals_arr.entries.items.len) {
@@ -996,31 +1002,34 @@ fn array_combine(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         return error.RuntimeError;
     }
 
-    var arr = try ctx.createArray();
+    const arr = try ctx.createArray();
     for (keys_arr.entries.items, vals_arr.entries.items) |k, v| {
         if (k.value == .object or k.value == .array) {
             try ctx.vm.setPendingException("TypeError", "array_combine(): Argument #1 ($keys) must contain only string and integer keys");
             return error.RuntimeError;
         }
         // PHP array_combine casts each key to string first, then canonicalizes.
+        var temporary: ?Value.String = null;
+        defer if (temporary) |value| value.release();
         const key: PhpArray.Key = switch (k.value) {
             .int => |i| .{ .int = i },
             .string => |s| PhpArray.normalizeKey(.{ .string = s }),
             else => blk: {
                 var buf = std.ArrayListUnmanaged(u8){};
+                defer buf.deinit(ctx.allocator);
                 try k.value.format(&buf, ctx.allocator);
                 const owned = try buf.toOwnedSlice(ctx.allocator);
-                try ctx.vm.strings.append(ctx.allocator, owned);
-                break :blk PhpArray.normalizeKey(.{ .string = Value.String.borrowed(owned) });
+                temporary = try Value.String.adopt(ctx.allocator, owned);
+                break :blk PhpArray.normalizeKey(.{ .string = temporary.? });
             },
         };
-        try arr.set(ctx.allocator, key, v.value);
+        try ctx.vm.arraySetOwned(arr, key, v.value);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn array_chunk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .null;
+fn array_chunk(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const raw_size = Value.toInt(args[1]);
     if (raw_size <= 0) {
@@ -1045,11 +1054,11 @@ fn array_chunk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try result.append(ctx.allocator, .{ .array = chunk });
         i = end;
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_pad(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const target: i64 = Value.toInt(args[1]);
     const pad_val = args[2];
@@ -1064,7 +1073,7 @@ fn array_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var result = try ctx.createArray();
     if (current >= abs_target) {
         for (src.entries.items) |entry| try result.set(ctx.allocator, entry.key, entry.value);
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     const pad_count = abs_target - current;
@@ -1081,13 +1090,13 @@ fn array_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (target > 0) {
         for (0..pad_count) |_| try result.append(ctx.allocator, pad_val);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_flip(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_flip(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
-    var result = try ctx.createArray();
+    const result = try ctx.createArray();
     for (src.entries.items) |entry| {
         if (entry.value != .int and entry.value != .string) continue;
         const new_key = Value.toArrayKey(entry.value);
@@ -1095,13 +1104,13 @@ fn array_flip(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             .int => |i| .{ .int = i },
             .string => |s| .{ .string = s },
         };
-        try result.set(ctx.allocator, new_key, new_val);
+        try ctx.vm.arraySetOwned(result, new_key, new_val);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_column(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .null;
+fn array_column(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const col_key = args[1];
 
@@ -1122,13 +1131,13 @@ fn array_column(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             if (idx_val == .null) {
                 try result.append(ctx.allocator, val);
             } else {
-                try result.set(ctx.allocator, Value.toArrayKey(idx_val), val);
+                try ctx.vm.arraySetOwned(result, Value.toArrayKey(idx_val), val);
             }
         } else {
             try result.append(ctx.allocator, val);
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 fn rowGet(row: Value, key: Value) Value {
@@ -1147,8 +1156,8 @@ fn rowGet(row: Value, key: Value) Value {
     };
 }
 
-fn array_fill(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .null;
+fn array_fill(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.null);
     const start_idx = Value.toInt(args[0]);
     const count: usize = @intCast(@max(0, Value.toInt(args[1])));
     const val = args[2];
@@ -1161,20 +1170,21 @@ fn array_fill(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     result.next_int_key = start_idx + @as(i64, @intCast(count));
     result.has_int_keys = count > 0;
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_fill_keys(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .null;
+fn array_fill_keys(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.null);
     const keys_arr = args[0].array;
     const val = args[1];
 
-    var result = try ctx.createArray();
+    const result = try ctx.createArray();
     for (keys_arr.entries.items) |entry| {
         const key = try arrayFillKeysKey(ctx, entry.value);
-        try result.set(ctx.allocator, key, val);
+        defer if (key == .string) key.string.release();
+        try ctx.vm.arraySetOwned(result, key, val);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 // PHP's array_fill_keys uses a different key conversion than normal array
@@ -1183,15 +1193,18 @@ fn array_fill_keys(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
 fn arrayFillKeysKey(ctx: *NativeContext, v: Value) !PhpArray.Key {
     return switch (v) {
         .int => |i| .{ .int = i },
-        .string => |s| .{ .string = s },
+        .string => |value| blk: {
+            value.retain();
+            break :blk .{ .string = value };
+        },
         .bool => |b| if (b) PhpArray.Key{ .int = 1 } else PhpArray.Key{ .string = Value.String.borrowed("") },
         .null => .{ .string = Value.String.borrowed("") },
         .float => |f| blk: {
             var buf = std.ArrayListUnmanaged(u8){};
+            defer buf.deinit(ctx.allocator);
             try (Value{ .float = f }).format(&buf, ctx.allocator);
             const s = try buf.toOwnedSlice(ctx.allocator);
-            try ctx.strings.append(ctx.allocator, s);
-            break :blk PhpArray.Key{ .string = Value.String.borrowed(s) };
+            break :blk PhpArray.Key{ .string = try Value.String.adopt(ctx.allocator, s) };
         },
         else => .{ .int = 0 },
     };
@@ -1224,10 +1237,10 @@ fn valuesEqualAsString(a: Value, b: Value) bool {
 
 const ArrayCmp = enum { values, keys, assoc };
 
-fn arraySetOp(comptime cmp: ArrayCmp, comptime keep_matches: bool) fn (*NativeContext, []const Value) RuntimeError!Value {
+fn arraySetOp(comptime cmp: ArrayCmp, comptime keep_matches: bool) fn (*NativeContext, []const Value) RuntimeError!NativeResult {
     return struct {
-        fn f(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-            if (args.len < 2 or args[0] != .array) return .null;
+        fn f(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+            if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.null);
             const src = args[0].array;
             var result = try ctx.createArray();
             for (src.entries.items) |entry| {
@@ -1239,7 +1252,7 @@ fn arraySetOp(comptime cmp: ArrayCmp, comptime keep_matches: bool) fn (*NativeCo
                     if (!matchesAny(entry, args[1..])) try result.set(ctx.allocator, entry.key, entry.value);
                 }
             }
-            return .{ .array = result };
+            return NativeResult.borrowed(.{ .array = result });
         }
         fn matchesAll(entry: PhpArray.Entry, others: []const Value) bool {
             for (others) |arg| {
@@ -1276,8 +1289,8 @@ const array_diff_key = arraySetOp(.keys, false);
 const array_intersect_assoc = arraySetOp(.assoc, true);
 const array_diff_assoc = arraySetOp(.assoc, false);
 
-fn array_count_values(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_count_values(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     var result = try ctx.createArray();
     for (src.entries.items) |entry| {
@@ -1294,11 +1307,11 @@ fn array_count_values(ctx: *NativeContext, args: []const Value) RuntimeError!Val
             try result.set(ctx.allocator, key, .{ .int = 1 });
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_sum(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn array_sum(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
     if (args[0] != .array) return throwArrayTypeError(ctx, "array_sum", 1, args[0]);
     const src = args[0].array;
     var has_float = false;
@@ -1324,15 +1337,15 @@ fn array_sum(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             },
         }
     }
-    if (has_float) return .{ .float = float_sum };
-    return .{ .int = int_sum };
+    if (has_float) return NativeResult.scalar(.{ .float = float_sum });
+    return NativeResult.scalar(.{ .int = int_sum });
 }
 
-fn array_product(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn array_product(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
     if (args[0] != .array) return throwArrayTypeError(ctx, "array_product", 1, args[0]);
     const src = args[0].array;
-    if (src.entries.items.len == 0) return .{ .int = 1 };
+    if (src.entries.items.len == 0) return NativeResult.scalar(.{ .int = 1 });
     var has_float = false;
     var int_prod: i64 = 1;
     var float_prod: f64 = 1;
@@ -1352,17 +1365,17 @@ fn array_product(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             },
         }
     }
-    if (has_float) return .{ .float = float_prod };
-    return .{ .int = int_prod };
+    if (has_float) return NativeResult.scalar(.{ .float = float_prod });
+    return NativeResult.scalar(.{ .int = int_prod });
 }
 
-fn array_walk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn array_walk(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array and !(args[0] == .object and ctx.vm.isInstanceOf(args[0].object.class_name, "Traversable"))) {
         try ctx.vm.setPendingException("TypeError", "array_walk(): Argument #1 ($array) must be of type array|object");
         return error.RuntimeError;
     }
-    if (args[0] != .array) return .{ .bool = false };
+    if (args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const arr = args[0].array;
     const callback = args[1];
     const has_userdata = args.len >= 3;
@@ -1375,6 +1388,8 @@ fn array_walk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var i: usize = 0;
     while (i < arr.entries.items.len) : (i += 1) {
         const key = arr.entries.items[i].key;
+        if (key == .string) key.string.retain();
+        defer if (key == .string) key.string.release();
         const key_val: Value = switch (key) {
             .int => |k| .{ .int = k },
             .string => |s| .{ .string = s },
@@ -1386,7 +1401,7 @@ fn array_walk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         // or removed entries before it
         if (findEntryIndex(arr, key) != null) try ctx.vm.arraySetOwned(arr, key, call_args[0]);
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn findEntryIndex(arr: *PhpArray, key: PhpArray.Key) ?usize {
@@ -1400,8 +1415,8 @@ fn findEntryIndex(arr: *PhpArray, key: PhpArray.Key) ?usize {
     return null;
 }
 
-fn array_unshift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .{ .int = 0 };
+fn array_unshift(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.{ .int = 0 });
     const arr = args[0].array;
 
     try arr.entries.ensureUnusedCapacity(ctx.allocator, args.len - 1);
@@ -1421,11 +1436,11 @@ fn array_unshift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     arr.next_int_key = next_int;
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .int = arr.length() };
+    return NativeResult.scalar(.{ .int = arr.length() });
 }
 
-fn native_shuffle(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .{ .bool = false };
+fn native_shuffle(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const arr = args[0].array;
     var i: usize = arr.entries.items.len;
     while (i > 1) {
@@ -1436,13 +1451,13 @@ fn native_shuffle(_: *NativeContext, args: []const Value) RuntimeError!Value {
         arr.entries.items[j] = tmp;
     }
     reindexArray(arr);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn array_rand(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_rand(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return .null;
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.null);
     const num: i64 = if (args.len >= 2) Value.toInt(args[1]) else 1;
     if (num < 1 or num > @as(i64, @intCast(arr.entries.items.len))) {
         try ctx.vm.setPendingException("ValueError", "array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)");
@@ -1452,8 +1467,8 @@ fn array_rand(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         // single-arg form returns scalar
         const idx = std.crypto.random.intRangeAtMost(usize, 0, arr.entries.items.len - 1);
         return switch (arr.entries.items[idx].key) {
-            .int => |i| .{ .int = i },
-            .string => |s| .{ .string = s },
+            .int => |i| NativeResult.scalar(.{ .int = i }),
+            .string => |s| NativeResult.shareString(s),
         };
     }
     // PHP returns scalar key when num=1 (default), array of keys otherwise.
@@ -1465,7 +1480,7 @@ fn array_rand(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             .string => |s| .{ .string = s },
         };
         try out.append(ctx.allocator, v);
-        return .{ .array = out };
+        return NativeResult.borrowed(.{ .array = out });
     }
     // Fisher-Yates partial shuffle for `num` distinct picks
     var pool = try ctx.allocator.alloc(usize, arr.entries.items.len);
@@ -1489,38 +1504,38 @@ fn array_rand(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         };
         try out.append(ctx.allocator, v);
     }
-    return .{ .array = out };
+    return NativeResult.borrowed(.{ .array = out });
 }
 
-fn native_compact(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_compact(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     const frame = ctx.vm.currentFrame();
     const slot_names = if (frame.func) |func| func.slot_names else ctx.vm.global_slot_names;
     for (args) |arg| try compactValue(ctx, arg, arr, frame, slot_names);
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn compactValue(ctx: *NativeContext, arg: Value, arr: *PhpArray, frame: anytype, slot_names: []const []const u8) RuntimeError!void {
     if (arg == .string) {
         const name = arg.string.bytes();
         const var_name = try std.fmt.allocPrint(ctx.allocator, "${s}", .{name});
-        try ctx.strings.append(ctx.allocator, var_name);
+        defer ctx.allocator.free(var_name);
         var in_slot = false;
         for (slot_names, 0..) |sn, i| {
             if (std.mem.eql(u8, sn, var_name)) {
                 in_slot = true;
                 if (i < frame.locals.len) {
-                    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, frame.locals[i]);
+                    try ctx.vm.arraySetOwned(arr, .{ .string = arg.string }, frame.locals[i]);
                 }
                 break;
             }
         }
         if (!in_slot) {
             if (frame.vars.get(var_name)) |val| {
-                try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, val);
+                try ctx.vm.arraySetOwned(arr, .{ .string = arg.string }, val);
             } else {
                 const w = try std.fmt.allocPrint(ctx.allocator, "compact(): Undefined variable ${s}", .{name});
-                try ctx.strings.append(ctx.allocator, w);
+                defer ctx.allocator.free(w);
                 ctx.vm.emitWarning(w);
             }
         }
@@ -1529,8 +1544,8 @@ fn compactValue(ctx: *NativeContext, arg: Value, arr: *PhpArray, frame: anytype,
     }
 }
 
-fn native_extract(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .{ .int = 0 };
+fn native_extract(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.{ .int = 0 });
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     // strip EXTR_REFS bit (256) so the type bits stay intact
@@ -1613,7 +1628,7 @@ fn native_extract(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setVariableByName(frame, var_name, try ctx.vm.copyValue(entry.value));
         count_val += 1;
     }
-    return .{ .int = count_val };
+    return NativeResult.scalar(.{ .int = count_val });
 }
 
 fn keyLessThan(_: void, a: PhpArray.Entry, b: PhpArray.Entry) bool {
@@ -1623,58 +1638,63 @@ fn keyLessThan(_: void, a: PhpArray.Entry, b: PhpArray.Entry) bool {
     return false;
 }
 
-fn native_ksort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_ksort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "ksort", 1, args[0]);
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortKeysWithFlags(arr, flags, false);
     arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_krsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_krsort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "krsort", 1, args[0]);
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortKeysWithFlags(arr, flags, true);
     arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_asort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_asort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "asort", 1, args[0]);
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortWithFlags(arr, flags, false);
     arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_arsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_arsort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "arsort", 1, args[0]);
     const arr = args[0].array;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     sortWithFlags(arr, flags, true);
     arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn array_reduce(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .null;
+fn array_reduce(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
     var carry: Value = if (args.len >= 3) args[2] else .null;
+    if (carry == .string) carry.string.retain();
+    defer if (carry == .string) carry.string.release();
     for (arr.entries.items) |entry| {
-        carry = try ctx.invokeCallable(args[1], &.{ carry, entry.value });
+        const next = try ctx.invokeCallable(args[1], &.{ carry, entry.value });
+        if (next == .string) next.string.retain();
+        if (carry == .string) carry.string.release();
+        carry = next;
     }
-    return carry;
+    return NativeResult.share(carry);
 }
 
 fn retainReturnedString(value: Value) Value {
@@ -1682,86 +1702,86 @@ fn retainReturnedString(value: Value) Value {
     return value;
 }
 
-fn array_key_first(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_key_first(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return .null;
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.null);
     return switch (arr.entries.items[0].key) {
-        .int => |i| .{ .int = i },
-        .string => |s| retainReturnedString(.{ .string = s }),
+        .int => |i| NativeResult.scalar(.{ .int = i }),
+        .string => |s| NativeResult.shareString(s),
     };
 }
 
-fn array_key_last(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_key_last(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return .null;
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.null);
     return switch (arr.entries.items[arr.entries.items.len - 1].key) {
-        .int => |i| .{ .int = i },
-        .string => |s| retainReturnedString(.{ .string = s }),
+        .int => |i| NativeResult.scalar(.{ .int = i }),
+        .string => |s| NativeResult.shareString(s),
     };
 }
 
-fn array_first(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn array_first(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP 8.4
-    if (args.len == 0 or args[0] != .array) return .null;
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return .null;
-    return retainReturnedString(arr.entries.items[0].value);
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.null);
+    return NativeResult.share(arr.entries.items[0].value);
 }
 
-fn array_last(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn array_last(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP 8.4
-    if (args.len == 0 or args[0] != .array) return .null;
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return .null;
-    return retainReturnedString(arr.entries.items[arr.entries.items.len - 1].value);
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.null);
+    return NativeResult.share(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
-fn native_uasort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn native_uasort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "uasort", 1, args[0]);
     const arr = args[0].array;
     const callback = args[1];
     try mergeSort(PhpArray.Entry, arr.entries.items, ctx, callback, .value);
     arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_uksort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn native_uksort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) return throwArrayTypeError(ctx, "uksort", 1, args[0]);
     const arr = args[0].array;
     const callback = args[1];
     try mergeSort(PhpArray.Entry, arr.entries.items, ctx, callback, .key);
     arr.rebuildStringIndexAssumeCapacity();
     arr.cursor = 0;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn array_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn array_replace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // unlike array_merge, array_replace requires at least one argument
     if (args.len == 0) {
         try ctx.vm.setPendingException("ArgumentCountError", "array_replace() expects at least 1 argument, 0 given");
         return error.RuntimeError;
     }
-    if (args[0] != .array) return .null;
-    var result = try ctx.createArray();
+    if (args[0] != .array) return NativeResult.scalar(.null);
+    const result = try ctx.createArray();
     for (args[0].array.entries.items) |entry| {
-        try result.set(ctx.allocator, entry.key, entry.value);
+        try ctx.vm.arraySetOwned(result, entry.key, entry.value);
     }
     for (args[1..]) |arg| {
         if (arg != .array) continue;
         for (arg.array.entries.items) |entry| {
-            try result.set(ctx.allocator, entry.key, entry.value);
+            try ctx.vm.arraySetOwned(result, entry.key, entry.value);
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_find(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
+fn array_find(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (args[0] != .array) {
         try ctx.vm.setPendingException("TypeError", "array_find(): Argument #1 ($array) must be of type array");
         return error.RuntimeError;
@@ -1773,13 +1793,13 @@ fn array_find(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             .string => |s| .{ .string = s },
         };
         const result = try ctx.invokeCallable(args[1], &.{ entry.value, key_val });
-        if (result.isTruthy()) return entry.value;
+        if (result.isTruthy()) return NativeResult.share(entry.value);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn array_find_key(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
+fn array_find_key(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (args[0] != .array) {
         try ctx.vm.setPendingException("TypeError", "array_find_key(): Argument #1 ($array) must be of type array");
         return error.RuntimeError;
@@ -1793,16 +1813,16 @@ fn array_find_key(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const result = try ctx.invokeCallable(args[1], &.{ entry.value, key_val });
         if (result.isTruthy()) {
             return switch (entry.key) {
-                .int => |i| .{ .int = i },
-                .string => |s| .{ .string = s },
+                .int => |i| NativeResult.scalar(.{ .int = i }),
+                .string => |s| NativeResult.shareString(s),
             };
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn array_any(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn array_any(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     if (args[0] != .array) {
         try ctx.vm.setPendingException("TypeError", "array_any(): Argument #1 ($array) must be of type array");
         return error.RuntimeError;
@@ -1814,13 +1834,13 @@ fn array_any(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             .string => |s| .{ .string = s },
         };
         const result = try ctx.invokeCallable(args[1], &.{ entry.value, key_val });
-        if (result.isTruthy()) return .{ .bool = true };
+        if (result.isTruthy()) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn array_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = true };
+fn array_all(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = true });
     if (args[0] != .array) {
         try ctx.vm.setPendingException("TypeError", "array_all(): Argument #1 ($array) must be of type array");
         return error.RuntimeError;
@@ -1832,93 +1852,93 @@ fn array_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             .string => |s| .{ .string = s },
         };
         const result = try ctx.invokeCallable(args[1], &.{ entry.value, key_val });
-        if (!result.isTruthy()) return .{ .bool = false };
+        if (!result.isTruthy()) return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_current(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return Value{ .bool = false };
+fn native_current(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(Value{ .bool = false });
     const arr = args[0].array;
-    if (arr.cursor >= arr.entries.items.len) return Value{ .bool = false };
-    return retainReturnedString(arr.entries.items[arr.cursor].value);
+    if (arr.cursor >= arr.entries.items.len) return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.share(arr.entries.items[arr.cursor].value);
 }
 
-fn native_next(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return Value{ .bool = false };
+fn native_next(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(Value{ .bool = false });
     const arr = args[0].array;
     if (arr.cursor < arr.entries.items.len) arr.cursor += 1;
-    if (arr.cursor >= arr.entries.items.len) return Value{ .bool = false };
-    return retainReturnedString(arr.entries.items[arr.cursor].value);
+    if (arr.cursor >= arr.entries.items.len) return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.share(arr.entries.items[arr.cursor].value);
 }
 
-fn native_prev(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return Value{ .bool = false };
+fn native_prev(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(Value{ .bool = false });
     const arr = args[0].array;
     if (arr.cursor == 0 or arr.cursor > arr.entries.items.len) {
         arr.cursor = std.math.maxInt(usize);
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
     }
     arr.cursor -= 1;
-    return retainReturnedString(arr.entries.items[arr.cursor].value);
+    return NativeResult.share(arr.entries.items[arr.cursor].value);
 }
 
-fn native_reset(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return Value{ .bool = false };
+fn native_reset(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(Value{ .bool = false });
     const arr = args[0].array;
     arr.cursor = 0;
-    if (arr.entries.items.len == 0) return Value{ .bool = false };
-    return retainReturnedString(arr.entries.items[0].value);
+    if (arr.entries.items.len == 0) return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.share(arr.entries.items[0].value);
 }
 
-fn native_end(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return Value{ .bool = false };
+fn native_end(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(Value{ .bool = false });
     const arr = args[0].array;
-    if (arr.entries.items.len == 0) return Value{ .bool = false };
+    if (arr.entries.items.len == 0) return NativeResult.scalar(Value{ .bool = false });
     arr.cursor = arr.entries.items.len - 1;
-    return retainReturnedString(arr.entries.items[arr.cursor].value);
+    return NativeResult.share(arr.entries.items[arr.cursor].value);
 }
 
-fn native_key(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn native_key(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
-    if (arr.cursor >= arr.entries.items.len) return .null;
+    if (arr.cursor >= arr.entries.items.len) return NativeResult.scalar(.null);
     return switch (arr.entries.items[arr.cursor].key) {
-        .int => |i| Value{ .int = i },
-        .string => |s| retainReturnedString(.{ .string = s }),
+        .int => |i| NativeResult.scalar(.{ .int = i }),
+        .string => |s| NativeResult.shareString(s),
     };
 }
 
-fn native_sizeof(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .{ .int = 0 };
-    return .{ .int = args[0].array.length() };
+fn native_sizeof(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = args[0].array.length() });
 }
 
 fn deepReplace(ctx: *NativeContext, base: *PhpArray, overlay: *PhpArray) RuntimeError!*PhpArray {
-    var result = try ctx.createArray();
+    const result = try ctx.createArray();
     for (base.entries.items) |entry| {
-        try result.set(ctx.allocator, entry.key, entry.value);
+        try ctx.vm.arraySetOwned(result, entry.key, entry.value);
     }
     for (overlay.entries.items) |entry| {
         const existing = result.get(entry.key);
         if (existing == .array and entry.value == .array) {
             const merged = try deepReplace(ctx, existing.array, entry.value.array);
-            try result.set(ctx.allocator, entry.key, .{ .array = merged });
+            try ctx.vm.arraySetOwned(result, entry.key, .{ .array = merged });
         } else {
-            try result.set(ctx.allocator, entry.key, entry.value);
+            try ctx.vm.arraySetOwned(result, entry.key, entry.value);
         }
     }
     return result;
 }
 
-fn array_replace_recursive(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_replace_recursive(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     var result = args[0].array;
     for (args[1..]) |arg| {
         if (arg != .array) continue;
         result = try deepReplace(ctx, result, arg.array);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 fn walkRecursive(ctx: *NativeContext, arr: *PhpArray, callback: Value, userdata: ?Value) RuntimeError!void {
@@ -1938,17 +1958,17 @@ fn walkRecursive(ctx: *NativeContext, arr: *PhpArray, callback: Value, userdata:
     }
 }
 
-fn array_walk_recursive(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return .{ .bool = false };
+fn array_walk_recursive(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const userdata: ?Value = if (args.len >= 3) args[2] else null;
     try walkRecursive(ctx, args[0].array, args[1], userdata);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn deepMerge(ctx: *NativeContext, a: *PhpArray, b: *PhpArray) RuntimeError!*PhpArray {
-    var result = try ctx.createArray();
+    const result = try ctx.createArray();
     for (a.entries.items) |entry| {
-        try result.set(ctx.allocator, entry.key, entry.value);
+        try ctx.vm.arraySetOwned(result, entry.key, entry.value);
     }
     for (b.entries.items) |entry| {
         switch (entry.key) {
@@ -1957,7 +1977,7 @@ fn deepMerge(ctx: *NativeContext, a: *PhpArray, b: *PhpArray) RuntimeError!*PhpA
                 const existing = result.get(entry.key);
                 if (existing == .array and entry.value == .array) {
                     const merged = try deepMerge(ctx, existing.array, entry.value.array);
-                    try result.set(ctx.allocator, entry.key, .{ .array = merged });
+                    try ctx.vm.arraySetOwned(result, entry.key, .{ .array = merged });
                 } else if (existing != .null) {
                     // both are scalars - wrap into array
                     if (entry.value == .array) {
@@ -1967,7 +1987,7 @@ fn deepMerge(ctx: *NativeContext, a: *PhpArray, b: *PhpArray) RuntimeError!*PhpA
                         for (entry.value.array.entries.items) |sub| {
                             try merged.append(ctx.allocator, sub.value);
                         }
-                        try result.set(ctx.allocator, entry.key, .{ .array = merged });
+                        try ctx.vm.arraySetOwned(result, entry.key, .{ .array = merged });
                     } else if (existing == .array) {
                         // existing is array, incoming is scalar
                         var merged = try ctx.createArray();
@@ -1975,16 +1995,16 @@ fn deepMerge(ctx: *NativeContext, a: *PhpArray, b: *PhpArray) RuntimeError!*PhpA
                             try merged.append(ctx.allocator, sub.value);
                         }
                         try merged.append(ctx.allocator, entry.value);
-                        try result.set(ctx.allocator, entry.key, .{ .array = merged });
+                        try ctx.vm.arraySetOwned(result, entry.key, .{ .array = merged });
                     } else {
                         // both scalars - combine into array
                         var merged = try ctx.createArray();
                         try merged.append(ctx.allocator, existing);
                         try merged.append(ctx.allocator, entry.value);
-                        try result.set(ctx.allocator, entry.key, .{ .array = merged });
+                        try ctx.vm.arraySetOwned(result, entry.key, .{ .array = merged });
                     }
                 } else {
-                    try result.set(ctx.allocator, entry.key, entry.value);
+                    try ctx.vm.arraySetOwned(result, entry.key, entry.value);
                 }
             },
         }
@@ -1992,20 +2012,20 @@ fn deepMerge(ctx: *NativeContext, a: *PhpArray, b: *PhpArray) RuntimeError!*PhpA
     return result;
 }
 
-fn array_merge_recursive(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn array_merge_recursive(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP allows array_merge_recursive() with no arguments, returning []
-    if (args.len == 0) return .{ .array = try ctx.createArray() };
-    if (args[0] != .array) return .null;
+    if (args.len == 0) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    if (args[0] != .array) return NativeResult.scalar(.null);
     var result = args[0].array;
     for (args[1..]) |arg| {
         if (arg != .array) continue;
         result = try deepMerge(ctx, result, arg.array);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_multisort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .{ .bool = false };
+fn array_multisort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
 
     const SortSpec = struct { arr: *PhpArray, order: i64, kind: i64 };
     var specs: [32]SortSpec = undefined;
@@ -2026,11 +2046,11 @@ fn array_multisort(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         }
     }
 
-    if (spec_count == 0) return .{ .bool = false };
+    if (spec_count == 0) return NativeResult.scalar(.{ .bool = false });
 
     const n = specs[0].arr.entries.items.len;
     for (specs[0..spec_count]) |s| {
-        if (s.arr.entries.items.len != n) return .{ .bool = false };
+        if (s.arr.entries.items.len != n) return NativeResult.scalar(.{ .bool = false });
     }
 
     var indices = try ctx.allocator.alloc(usize, n);
@@ -2110,7 +2130,7 @@ fn array_multisort(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         s.arr.cursor = 0;
     }
 
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn keyToValue(key: PhpArray.Key) Value {
@@ -2120,8 +2140,8 @@ fn keyToValue(key: PhpArray.Key) Value {
     };
 }
 
-fn array_diff_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_diff_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
 
@@ -2142,11 +2162,11 @@ fn array_diff_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         }
         if (!in_any) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_udiff(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_udiff(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
     var result = try ctx.createArray();
@@ -2165,11 +2185,11 @@ fn array_udiff(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         if (!in_any) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_uintersect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_uintersect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
     var result = try ctx.createArray();
@@ -2195,11 +2215,11 @@ fn array_uintersect(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         }
         if (in_all) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_udiff_assoc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_udiff_assoc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
     var result = try ctx.createArray();
@@ -2219,11 +2239,11 @@ fn array_udiff_assoc(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         }
         if (!in_any) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_uintersect_assoc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_uintersect_assoc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
     var result = try ctx.createArray();
@@ -2250,11 +2270,11 @@ fn array_uintersect_assoc(ctx: *NativeContext, args: []const Value) RuntimeError
         }
         if (in_all) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_udiff_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 4 or args[0] != .array) return .null;
+fn array_udiff_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 4 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const value_cb = args[args.len - 2];
     const key_cb = args[args.len - 1];
@@ -2276,11 +2296,11 @@ fn array_udiff_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         }
         if (!in_any) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_uintersect_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 4 or args[0] != .array) return .null;
+fn array_uintersect_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 4 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const value_cb = args[args.len - 2];
     const key_cb = args[args.len - 1];
@@ -2309,11 +2329,11 @@ fn array_uintersect_uassoc(ctx: *NativeContext, args: []const Value) RuntimeErro
         }
         if (in_all) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_intersect_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_intersect_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
     var result = try ctx.createArray();
@@ -2339,11 +2359,11 @@ fn array_intersect_uassoc(ctx: *NativeContext, args: []const Value) RuntimeError
         }
         if (in_all) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_intersect_ukey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_intersect_ukey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
     var result = try ctx.createArray();
@@ -2369,11 +2389,11 @@ fn array_intersect_ukey(ctx: *NativeContext, args: []const Value) RuntimeError!V
         }
         if (in_all) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_diff_ukey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .array) return .null;
+fn array_diff_ukey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const callback = args[args.len - 1];
 
@@ -2393,11 +2413,11 @@ fn array_diff_ukey(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         }
         if (!in_any) try result.set(ctx.allocator, entry.key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn array_change_key_case(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .null;
+fn array_change_key_case(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.scalar(.null);
     const src = args[0].array;
     const case_upper = args.len >= 2 and args[1] == .int and args[1].int == 1;
     const result = try ctx.createArray();
@@ -2405,18 +2425,18 @@ fn array_change_key_case(ctx: *NativeContext, args: []const Value) RuntimeError!
     for (src.entries.items) |entry| {
         const new_key: PhpArray.Key = switch (entry.key) {
             .string => |s| blk: {
-                const buf = ctx.allocator.alloc(u8, s.bytes().len) catch break :blk .{ .string = s };
-                ctx.strings.append(ctx.allocator, buf) catch {};
+                const buf = try ctx.allocator.alloc(u8, s.bytes().len);
                 for (s.bytes(), 0..) |c, i| {
                     buf[i] = if (case_upper) std.ascii.toUpper(c) else std.ascii.toLower(c);
                 }
-                break :blk .{ .string = Value.String.borrowed(buf) };
+                break :blk .{ .string = try Value.String.adopt(ctx.allocator, buf) };
             },
             .int => entry.key,
         };
-        try result.set(ctx.allocator, new_key, entry.value);
+        defer if (new_key == .string) new_key.string.release();
+        try ctx.vm.arraySetOwned(result, new_key, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 test "unshift allocation failure preserves entries and ownership" {

--- a/src/stdlib/bcmath.zig
+++ b/src/stdlib/bcmath.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
 const VM = vm_mod.VM;
+const NativeResult = vm_mod.NativeResult;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 const Allocator = std.mem.Allocator;
@@ -73,7 +74,7 @@ fn parseBc(allocator: Allocator, s: []const u8) !BcNum {
     return n;
 }
 
-fn formatBc(allocator: Allocator, n: BcNum, target_scale: usize) ![]const u8 {
+fn formatBc(allocator: Allocator, n: BcNum, target_scale: usize) ![]u8 {
     var out = std.ArrayListUnmanaged(u8){};
     errdefer out.deinit(allocator);
 
@@ -476,15 +477,9 @@ fn argToString(args: []const Value, idx: usize) ?[]const u8 {
     };
 }
 
-fn returnStr(ctx: *NativeContext, s: []const u8) !Value {
-    const owned = try ctx.allocator.dupe(u8, s);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
-}
-
-fn bcAdd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcAdd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
@@ -493,13 +488,13 @@ fn bcAdd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var r = try bcAddInternal(ctx.allocator, a, b);
     defer r.deinit(ctx.allocator);
     const out = try formatBc(ctx.allocator, r, scale);
-    defer ctx.allocator.free(out);
-    return try returnStr(ctx, out);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn bcSub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcSub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
@@ -508,13 +503,13 @@ fn bcSub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var r = try bcSubInternal(ctx.allocator, a, b);
     defer r.deinit(ctx.allocator);
     const out = try formatBc(ctx.allocator, r, scale);
-    defer ctx.allocator.free(out);
-    return try returnStr(ctx, out);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn bcMul(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcMul(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
@@ -523,13 +518,13 @@ fn bcMul(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var r = try bcMulInternal(ctx.allocator, a, b);
     defer r.deinit(ctx.allocator);
     const out = try formatBc(ctx.allocator, r, scale);
-    defer ctx.allocator.free(out);
-    return try returnStr(ctx, out);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn bcDiv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcDiv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
@@ -543,15 +538,15 @@ fn bcDiv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (r_opt) |*r| {
         defer r.deinit(ctx.allocator);
         const out = try formatBc(ctx.allocator, r.*, scale);
-        defer ctx.allocator.free(out);
-        return try returnStr(ctx, out);
+
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn bcMod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcMod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
@@ -559,24 +554,24 @@ fn bcMod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     defer b.deinit(ctx.allocator);
     if (b.isZero()) {
         try ctx.vm.setPendingException("DivisionByZeroError", "Modulo by zero");
-        return .null;
+        return NativeResult.scalar(.null);
     }
     // mod = a - (a / b truncated to scale=0) * b. then format to target scale
     var q_opt = try bcDivInternal(ctx.allocator, a, b, 0);
-    if (q_opt == null) return .null;
+    if (q_opt == null) return NativeResult.scalar(.null);
     defer q_opt.?.deinit(ctx.allocator);
     var qb = try bcMulInternal(ctx.allocator, q_opt.?, b);
     defer qb.deinit(ctx.allocator);
     var r = try bcSubInternal(ctx.allocator, a, qb);
     defer r.deinit(ctx.allocator);
     const out = try formatBc(ctx.allocator, r, scale);
-    defer ctx.allocator.free(out);
-    return try returnStr(ctx, out);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn bcDivmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcDivmod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
@@ -584,10 +579,10 @@ fn bcDivmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     defer b.deinit(ctx.allocator);
     if (b.isZero()) {
         try ctx.vm.setPendingException("DivisionByZeroError", "Division by zero");
-        return .null;
+        return NativeResult.scalar(.null);
     }
     var q_opt = try bcDivInternal(ctx.allocator, a, b, 0);
-    if (q_opt == null) return .null;
+    if (q_opt == null) return NativeResult.scalar(.null);
     const q = q_opt.?;
     defer @constCast(&q).deinit(ctx.allocator);
     var qb = try bcMulInternal(ctx.allocator, q, b);
@@ -597,32 +592,27 @@ fn bcDivmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     _ = &q_opt;
 
     const q_str = try formatBc(ctx.allocator, q, 0);
-    defer ctx.allocator.free(q_str);
+    const q_owned = try Value.String.adopt(ctx.allocator, q_str);
+    defer q_owned.release();
     const r_str = try formatBc(ctx.allocator, r, scale);
-    defer ctx.allocator.free(r_str);
+    const r_owned = try Value.String.adopt(ctx.allocator, r_str);
+    defer r_owned.release();
 
-    const q_owned = try ctx.allocator.dupe(u8, q_str);
-    try ctx.vm.strings.append(ctx.allocator, q_owned);
-    const r_owned = try ctx.allocator.dupe(u8, r_str);
-    try ctx.vm.strings.append(ctx.allocator, r_owned);
-
-    const arr = try ctx.allocator.create(@import("../runtime/value.zig").PhpArray);
-    arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, arr);
-    try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(q_owned) });
-    try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(r_owned) });
-    return .{ .array = arr };
+    const arr = try ctx.createArray();
+    try arr.append(ctx.allocator, .{ .string = q_owned });
+    try arr.append(ctx.allocator, .{ .string = r_owned });
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn bcPow(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcPow(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
     // exponent must be a non-negative integer (PHP allows negative but truncates)
     const exp_str = sb;
-    var exp: i64 = std.fmt.parseInt(i64, std.mem.trim(u8, exp_str, " \t"), 10) catch return .null;
+    var exp: i64 = std.fmt.parseInt(i64, std.mem.trim(u8, exp_str, " \t"), 10) catch return NativeResult.scalar(.null);
     var negative_exp = false;
     if (exp < 0) {
         negative_exp = true;
@@ -657,28 +647,28 @@ fn bcPow(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         defer one.deinit(ctx.allocator);
         var inv = (try bcDivInternal(ctx.allocator, one, r, scale)) orelse {
             r.deinit(ctx.allocator);
-            return .null;
+            return NativeResult.scalar(.null);
         };
         defer inv.deinit(ctx.allocator);
         r.deinit(ctx.allocator);
         const out = try formatBc(ctx.allocator, inv, scale);
-        defer ctx.allocator.free(out);
-        return try returnStr(ctx, out);
+
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
 
     defer r.deinit(ctx.allocator);
     const out = try formatBc(ctx.allocator, r, scale);
-    defer ctx.allocator.free(out);
-    return try returnStr(ctx, out);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
 // modular exponentiation: base^exp mod mod. arbitrary precision via the same
 // BcNum primitives bcpow uses, but exp is also a BcNum so it can be larger
 // than i64. PHP truncates fractional bits of all three args.
-fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
-    const sm = argToString(args, 2) orelse return .null;
+fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
+    const sm = argToString(args, 2) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 3);
 
     // truncate fractional parts (PHP semantics for bcpowmod)
@@ -697,11 +687,11 @@ fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     if (mod.isZero()) {
         try ctx.vm.setPendingException("DivisionByZeroError", "Modulo by zero");
-        return .null;
+        return NativeResult.scalar(.null);
     }
     if (exp.sign < 0) {
         try ctx.vm.setPendingException("ValueError", "bcpowmod(): Argument #2 ($exponent) must be greater than or equal to 0");
-        return .null;
+        return NativeResult.scalar(.null);
     }
 
     // result = 1
@@ -710,7 +700,7 @@ fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     // base = base mod mod (so subsequent multiplies stay bounded)
     {
-        var q = (try bcDivInternal(ctx.allocator, base, mod, 0)) orelse return .null;
+        var q = (try bcDivInternal(ctx.allocator, base, mod, 0)) orelse return NativeResult.scalar(.null);
         defer q.deinit(ctx.allocator);
         var qm = try bcMulInternal(ctx.allocator, q, mod);
         defer qm.deinit(ctx.allocator);
@@ -730,7 +720,7 @@ fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const odd = blk: {
             // a BcNum that's all zeros isn't reached (loop exits). check ones digit
             // by computing exp mod 2
-            var q2 = (try bcDivInternal(ctx.allocator, exp, two, 0)) orelse return .null;
+            var q2 = (try bcDivInternal(ctx.allocator, exp, two, 0)) orelse return NativeResult.scalar(.null);
             defer q2.deinit(ctx.allocator);
             var qm2 = try bcMulInternal(ctx.allocator, q2, two);
             defer qm2.deinit(ctx.allocator);
@@ -742,7 +732,7 @@ fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (odd) {
             var rb = try bcMulInternal(ctx.allocator, result, base);
             defer rb.deinit(ctx.allocator);
-            var q = (try bcDivInternal(ctx.allocator, rb, mod, 0)) orelse return .null;
+            var q = (try bcDivInternal(ctx.allocator, rb, mod, 0)) orelse return NativeResult.scalar(.null);
             defer q.deinit(ctx.allocator);
             var qm = try bcMulInternal(ctx.allocator, q, mod);
             defer qm.deinit(ctx.allocator);
@@ -753,7 +743,7 @@ fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
         // exp = exp / 2
         {
-            const new_exp = (try bcDivInternal(ctx.allocator, exp, two, 0)) orelse return .null;
+            const new_exp = (try bcDivInternal(ctx.allocator, exp, two, 0)) orelse return NativeResult.scalar(.null);
             exp.deinit(ctx.allocator);
             exp = new_exp;
         }
@@ -763,7 +753,7 @@ fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         {
             var bb = try bcMulInternal(ctx.allocator, base, base);
             defer bb.deinit(ctx.allocator);
-            var q = (try bcDivInternal(ctx.allocator, bb, mod, 0)) orelse return .null;
+            var q = (try bcDivInternal(ctx.allocator, bb, mod, 0)) orelse return NativeResult.scalar(.null);
             defer q.deinit(ctx.allocator);
             var qm = try bcMulInternal(ctx.allocator, q, mod);
             defer qm.deinit(ctx.allocator);
@@ -774,21 +764,21 @@ fn bcPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     const out = try formatBc(ctx.allocator, result, scale);
-    defer ctx.allocator.free(out);
+
     result.deinit(ctx.allocator);
-    return try returnStr(ctx, out);
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn bcSqrt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
+fn bcSqrt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 1);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
-    if (a.sign < 0) return .null;
+    if (a.sign < 0) return NativeResult.scalar(.null);
     if (a.isZero()) {
         const z = try makeZeroString(ctx.allocator, scale);
-        defer ctx.allocator.free(z);
-        return try returnStr(ctx, z);
+
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, z));
     }
 
     // newton's method on the full-precision string. work with scale+2 internal precision
@@ -799,13 +789,13 @@ fn bcSqrt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var iters: usize = 0;
     while (iters < 200) : (iters += 1) {
         // x_next = (x + a/x) / 2
-        var ax = (try bcDivInternal(ctx.allocator, a, x, work_scale)) orelse return .null;
+        var ax = (try bcDivInternal(ctx.allocator, a, x, work_scale)) orelse return NativeResult.scalar(.null);
         defer ax.deinit(ctx.allocator);
         var sum = try bcAddInternal(ctx.allocator, x, ax);
         defer sum.deinit(ctx.allocator);
         var two = try parseBc(ctx.allocator, "2");
         defer two.deinit(ctx.allocator);
-        const next = (try bcDivInternal(ctx.allocator, sum, two, work_scale)) orelse return .null;
+        const next = (try bcDivInternal(ctx.allocator, sum, two, work_scale)) orelse return NativeResult.scalar(.null);
         // check convergence: if |next - x| < 10^-work_scale
         var diff = try bcSubInternal(ctx.allocator, next, x);
         defer diff.deinit(ctx.allocator);
@@ -815,11 +805,11 @@ fn bcSqrt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (converged) break;
     }
     const out = try formatBc(ctx.allocator, x, scale);
-    defer ctx.allocator.free(out);
-    return try returnStr(ctx, out);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn makeZeroString(allocator: Allocator, scale: usize) ![]const u8 {
+fn makeZeroString(allocator: Allocator, scale: usize) ![]u8 {
     var out = std.ArrayListUnmanaged(u8){};
     errdefer out.deinit(allocator);
     try out.append(allocator, '0');
@@ -831,9 +821,9 @@ fn makeZeroString(allocator: Allocator, scale: usize) ![]const u8 {
     return try out.toOwnedSlice(allocator);
 }
 
-fn bcComp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const sa = argToString(args, 0) orelse return .null;
-    const sb = argToString(args, 1) orelse return .null;
+fn bcComp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const sa = argToString(args, 0) orelse return NativeResult.scalar(.null);
+    const sb = argToString(args, 1) orelse return NativeResult.scalar(.null);
     const scale = resolveScale(args, 2);
     var a = try parseBc(ctx.allocator, sa);
     defer a.deinit(ctx.allocator);
@@ -852,16 +842,16 @@ fn bcComp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try tb.digits.resize(ctx.allocator, tb.digits.items.len - (tb.scale - scale));
         tb.scale = scale;
     }
-    return .{ .int = @intCast(cmpFull(ta, tb)) };
+    return NativeResult.scalar(.{ .int = @intCast(cmpFull(ta, tb)) });
 }
 
-fn bcScale(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn bcScale(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const prev = currentScale();
     if (args.len > 0 and args[0] == .int and args[0].int >= 0) {
         setScale(@intCast(args[0].int));
-        return .{ .int = @intCast(prev) };
+        return NativeResult.scalar(.{ .int = @intCast(prev) });
     }
-    return .{ .int = @intCast(prev) };
+    return NativeResult.scalar(.{ .int = @intCast(prev) });
 }
 
 // ---------------- ceil / floor / round (PHP 8.4) ----------------
@@ -934,8 +924,8 @@ fn signedResult(allocator: Allocator, neg: bool, digits: []const u8) ![]u8 {
     return try allocator.dupe(u8, body);
 }
 
-fn bcCeil(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const s = argToString(args, 0) orelse return .null;
+fn bcCeil(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const s = argToString(args, 0) orelse return NativeResult.scalar(.null);
     const p = splitNumber(s);
     const has_frac = fracNonZero(p.frac_part);
     var result: []u8 = undefined;
@@ -949,12 +939,12 @@ fn bcCeil(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         defer ctx.allocator.free(inc);
         result = try signedResult(ctx.allocator, false, inc);
     }
-    defer ctx.allocator.free(result);
-    return try returnStr(ctx, result);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn bcFloor(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const s = argToString(args, 0) orelse return .null;
+fn bcFloor(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const s = argToString(args, 0) orelse return NativeResult.scalar(.null);
     const p = splitNumber(s);
     const has_frac = fracNonZero(p.frac_part);
     var result: []u8 = undefined;
@@ -967,12 +957,12 @@ fn bcFloor(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         defer ctx.allocator.free(inc);
         result = try signedResult(ctx.allocator, true, inc);
     }
-    defer ctx.allocator.free(result);
-    return try returnStr(ctx, result);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn bcRound(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const s = argToString(args, 0) orelse return .null;
+fn bcRound(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const s = argToString(args, 0) orelse return NativeResult.scalar(.null);
     const precision: i64 = if (args.len > 1 and args[1] == .int) args[1].int else 0;
     const p = splitNumber(s);
 
@@ -1047,8 +1037,8 @@ fn bcRound(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     const out = try signedResult(ctx.allocator, p.neg, result_buf.items);
-    defer ctx.allocator.free(out);
-    return try returnStr(ctx, out);
+
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
 // ---------------- registration ----------------

--- a/src/stdlib/crypto.zig
+++ b/src/stdlib/crypto.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 
 extern fn zphp_xxh3_128(data: ?[*]const u8, len: usize, out: [*]u8) void;
@@ -35,8 +36,8 @@ pub const entries = .{
 // Generates a bcrypt hash using the provided salt's cost. For non-bcrypt
 // salts (DES, MD5, SHA-256, SHA-512) we currently fall back to bcrypt with
 // cost 10, which is incorrect but preserves the calling convention.
-fn native_crypt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return Value{ .bool = false };
+fn native_crypt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(Value{ .bool = false });
     const password = args[0].string.bytes();
     const salt: []const u8 = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "";
 
@@ -49,7 +50,7 @@ fn native_crypt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (cost >= 4 and cost <= 31) rounds_log = @intCast(cost);
 
         var salt_bytes: [16]u8 = undefined;
-        if (!bcryptB64Decode(&salt_bytes, salt[7..29])) return .{ .string = Value.String.borrowed("*0") };
+        if (!bcryptB64Decode(&salt_bytes, salt[7..29])) return NativeResult.literal("*0");
 
         // PHP canonicalizes the salt encoding by re-encoding the 16 decoded
         // bytes, which forces the trailing unused bits in the last base64
@@ -73,12 +74,12 @@ fn native_crypt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             rounds_log % 10,
             salt_b64_buf,
             hash_b64_buf,
-        }) catch return .{ .string = Value.String.borrowed("*0") };
-        return .{ .string = Value.String.borrowed(try ctx.createString(out)) };
+        }) catch return NativeResult.literal("*0");
+        return NativeResult.copyString(ctx.allocator, out);
     }
 
     // PHP returns a special "*0" or "*1" failure indicator on bad salt
-    return .{ .string = Value.String.borrowed("*0") };
+    return NativeResult.literal("*0");
 }
 
 const bcrypt_alphabet = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -135,8 +136,8 @@ fn bcryptB64Encode(out: []u8, data: []const u8) void {
     }
 }
 
-fn native_password_hash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return Value{ .bool = false };
+fn native_password_hash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(Value{ .bool = false });
     const password = args[0].string.bytes();
 
     // dispatch on the algo arg: bcrypt (default), argon2i, or argon2id.
@@ -159,8 +160,8 @@ fn native_password_hash(ctx: *NativeContext, args: []const Value) RuntimeError!V
             .{ .string = args[0].string },
             .{ .int = ops },
             .{ .int = mem_kb * 1024 },
-        }) catch return Value{ .bool = false };
-        return r;
+        }) catch return NativeResult.scalar(Value{ .bool = false });
+        return NativeResult.share(r);
     }
 
     // PHP 7.4+ default cost is 12, was 10 in older versions
@@ -177,20 +178,21 @@ fn native_password_hash(ctx: *NativeContext, args: []const Value) RuntimeError!V
     const hash = std.crypto.pwhash.bcrypt.strHash(password, .{
         .params = .{ .rounds_log = rounds_log, .silently_truncate_password = true },
         .encoding = .crypt,
-    }, &buf) catch return Value{ .bool = false };
+    }, &buf) catch return NativeResult.scalar(Value{ .bool = false });
 
     // PHP uses the $2y$ prefix variant; std.crypto produces $2b$. Both are
     // verifiable by any compliant bcrypt impl, but cross-runtime hash exchange
     // (e.g. Laravel sessions) expects the $2y$ form.
-    const out = try ctx.createString(hash);
+    const owned = try Value.String.create(ctx.allocator, hash);
+    const out = owned.bytes();
     if (out.len >= 4 and out[0] == '$' and out[1] == '2' and out[2] == 'b' and out[3] == '$') {
         @as([*]u8, @ptrCast(@constCast(out.ptr)))[2] = 'y';
     }
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(owned);
 }
 
-fn native_password_verify(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return Value{ .bool = false };
+fn native_password_verify(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(Value{ .bool = false });
     const password = args[0].string.bytes();
     const hash = args[1].string.bytes();
 
@@ -199,8 +201,8 @@ fn native_password_verify(ctx: *NativeContext, args: []const Value) RuntimeError
         const r = ctx.vm.callByName("sodium_crypto_pwhash_str_verify", &.{
             .{ .string = args[1].string },
             .{ .string = args[0].string },
-        }) catch return Value{ .bool = false };
-        return r;
+        }) catch return NativeResult.scalar(Value{ .bool = false });
+        return NativeResult.share(r);
     }
 
     // std.crypto.pwhash.bcrypt only knows the $2b$ variant; PHP-generated and
@@ -213,18 +215,18 @@ fn native_password_verify(ctx: *NativeContext, args: []const Value) RuntimeError
         normalized = dup;
         std.crypto.pwhash.bcrypt.strVerify(normalized, password, .{
             .silently_truncate_password = true,
-        }) catch return Value{ .bool = false };
-        return Value{ .bool = true };
+        }) catch return NativeResult.scalar(Value{ .bool = false });
+        return NativeResult.scalar(Value{ .bool = true });
     }
 
     std.crypto.pwhash.bcrypt.strVerify(hash, password, .{
         .silently_truncate_password = true,
-    }) catch return Value{ .bool = false };
+    }) catch return NativeResult.scalar(Value{ .bool = false });
 
-    return Value{ .bool = true };
+    return NativeResult.scalar(Value{ .bool = true });
 }
 
-fn native_password_get_info(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_password_get_info(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const PhpArray = @import("../runtime/value.zig").PhpArray;
     const info = try ctx.allocator.create(PhpArray);
     info.* = .{};
@@ -237,7 +239,7 @@ fn native_password_get_info(ctx: *NativeContext, args: []const Value) RuntimeErr
         empty.* = .{};
         try ctx.vm.arrays.append(ctx.allocator, empty);
         try info.set(ctx.allocator, .{ .string = Value.String.borrowed("options") }, .{ .array = empty });
-        return .{ .array = info };
+        return NativeResult.borrowed(.{ .array = info });
     }
 
     const hash = args[0].string.bytes();
@@ -263,20 +265,20 @@ fn native_password_get_info(ctx: *NativeContext, args: []const Value) RuntimeErr
     try info.set(ctx.allocator, .{ .string = Value.String.borrowed("algo") }, algo);
     try info.set(ctx.allocator, .{ .string = Value.String.borrowed("algoName") }, .{ .string = Value.String.borrowed(try ctx.createString(algo_name)) });
     try info.set(ctx.allocator, .{ .string = Value.String.borrowed("options") }, .{ .array = options });
-    return .{ .array = info };
+    return NativeResult.borrowed(.{ .array = info });
 }
 
-fn native_password_algos(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_password_algos(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const PhpArray = @import("../runtime/value.zig").PhpArray;
     const arr = try ctx.allocator.create(PhpArray);
     arr.* = .{};
     try ctx.vm.arrays.append(ctx.allocator, arr);
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("2y") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_password_needs_rehash(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return Value{ .bool = true };
+fn native_password_needs_rehash(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(Value{ .bool = true });
     const hash = args[0].string.bytes();
 
     // PHP's default cost was 10 for years; 7.4+ raised it to 12
@@ -290,37 +292,36 @@ fn native_password_needs_rehash(_: *NativeContext, args: []const Value) RuntimeE
     }
 
     // parse cost from $2y$XX$ or $2b$XX$ format
-    if (hash.len < 7 or hash[0] != '$' or hash[1] != '2' or hash[3] != '$') return Value{ .bool = true };
-    const cost = std.fmt.parseInt(u6, hash[4..6], 10) catch return Value{ .bool = true };
+    if (hash.len < 7 or hash[0] != '$' or hash[1] != '2' or hash[3] != '$') return NativeResult.scalar(Value{ .bool = true });
+    const cost = std.fmt.parseInt(u6, hash[4..6], 10) catch return NativeResult.scalar(Value{ .bool = true });
 
-    return Value{ .bool = cost != target_cost };
+    return NativeResult.scalar(Value{ .bool = cost != target_cost });
 }
 
-fn native_random_bytes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return Value{ .bool = false };
+fn native_random_bytes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(Value{ .bool = false });
     const length = Value.toInt(args[0]);
     if (length < 1) {
         try ctx.vm.setPendingException("ValueError", "random_bytes(): Argument #1 ($length) must be greater than 0");
         return error.RuntimeError;
     }
-    if (length > 1048576) return Value{ .bool = false };
+    if (length > 1048576) return NativeResult.scalar(Value{ .bool = false });
 
     const len: usize = @intCast(length);
     const buf = try ctx.allocator.alloc(u8, len);
     std.crypto.random.bytes(buf);
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn native_random_int(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return Value{ .bool = false };
+fn native_random_int(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(Value{ .bool = false });
     const min = Value.toInt(args[0]);
     const max = Value.toInt(args[1]);
     if (min > max) {
         try ctx.vm.setPendingException("ValueError", "random_int(): Argument #1 ($min) must be less than or equal to argument #2 ($max)");
         return error.RuntimeError;
     }
-    if (min == max) return Value{ .int = min };
+    if (min == max) return NativeResult.scalar(Value{ .int = min });
 
     // span as unsigned to avoid overflow on PHP_INT_MIN .. PHP_INT_MAX
     const umin: u64 = @bitCast(min);
@@ -331,7 +332,7 @@ fn native_random_int(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     else
         std.crypto.random.intRangeAtMost(u64, 0, range);
     const result_u: u64 = umin +% random;
-    return Value{ .int = @bitCast(result_u) };
+    return NativeResult.scalar(Value{ .int = @bitCast(result_u) });
 }
 
 const HashAlgo = enum {
@@ -545,19 +546,18 @@ fn computeHmac(algo: HashAlgo, data: []const u8, key: []const u8, out: []u8) voi
     }
 }
 
-fn toHexString(ctx: *NativeContext, digest: []const u8) ![]const u8 {
+fn toHexString(ctx: *NativeContext, digest: []const u8) !Value.String {
     const hex = "0123456789abcdef";
     const result = try ctx.allocator.alloc(u8, digest.len * 2);
     for (digest, 0..) |b, i| {
         result[i * 2] = hex[b >> 4];
         result[i * 2 + 1] = hex[b & 0x0f];
     }
-    try ctx.strings.append(ctx.allocator, result);
-    return result;
+    return Value.String.adopt(ctx.allocator, result);
 }
 
-fn native_hash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return Value{ .bool = false };
+fn native_hash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(Value{ .bool = false });
     const algo_name = args[0].string.bytes();
     const data = args[1].string.bytes();
     const raw_output = args.len >= 3 and args[2].isTruthy();
@@ -571,13 +571,13 @@ fn native_hash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     computeHash(algo, data, digest[0..dlen]);
 
     if (raw_output) {
-        return .{ .string = Value.String.borrowed(try ctx.createString(digest[0..dlen])) };
+        return NativeResult.copyString(ctx.allocator, digest[0..dlen]);
     }
-    return .{ .string = Value.String.borrowed(try toHexString(ctx, digest[0..dlen])) };
+    return NativeResult.takeString(try toHexString(ctx, digest[0..dlen]));
 }
 
-fn native_hash_hmac(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return Value{ .bool = false };
+fn native_hash_hmac(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(Value{ .bool = false });
     const algo_name = args[0].string.bytes();
     const data = args[1].string.bytes();
     const key = args[2].string.bytes();
@@ -599,25 +599,25 @@ fn native_hash_hmac(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     computeHmac(algo, data, key, digest[0..dlen]);
 
     if (raw_output) {
-        return .{ .string = Value.String.borrowed(try ctx.createString(digest[0..dlen])) };
+        return NativeResult.copyString(ctx.allocator, digest[0..dlen]);
     }
-    return .{ .string = Value.String.borrowed(try toHexString(ctx, digest[0..dlen])) };
+    return NativeResult.takeString(try toHexString(ctx, digest[0..dlen]));
 }
 
-fn native_hash_hkdf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_hash_hkdf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const algo_name = args[0].string.bytes();
     const ikm = args[1].string.bytes();
     const length: i64 = if (args.len >= 3 and args[2] == .int) args[2].int else 0;
     const info: []const u8 = if (args.len >= 4 and args[3] == .string) args[3].string.bytes() else "";
     const salt: []const u8 = if (args.len >= 5 and args[4] == .string) args[4].string.bytes() else "";
 
-    const algo = HashAlgo.fromString(algo_name) orelse return .{ .bool = false };
-    if (algo == .crc32) return .{ .bool = false };
+    const algo = HashAlgo.fromString(algo_name) orelse return NativeResult.scalar(.{ .bool = false });
+    if (algo == .crc32) return NativeResult.scalar(.{ .bool = false });
     const hlen = algo.digestLen();
 
     const out_len: usize = if (length > 0) @intCast(length) else hlen;
-    if (out_len > 255 * hlen) return .{ .bool = false };
+    if (out_len > 255 * hlen) return NativeResult.scalar(.{ .bool = false });
 
     // Extract: PRK = HMAC(salt, IKM)
     const zero_salt = [_]u8{0} ** 64;
@@ -627,6 +627,8 @@ fn native_hash_hkdf(ctx: *NativeContext, args: []const Value) RuntimeError!Value
 
     // Expand
     const out = try ctx.allocator.alloc(u8, out_len);
+    const owned_out = try Value.String.adopt(ctx.allocator, out);
+    defer owned_out.release();
     var t_prev: [64]u8 = undefined;
     var t_prev_len: usize = 0;
     var written: usize = 0;
@@ -645,20 +647,20 @@ fn native_hash_hkdf(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         t_prev_len = hlen;
         written += copy_len;
     }
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+
+    return NativeResult.shareString(owned_out);
 }
 
-fn native_hash_algos(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_hash_algos(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var arr = try ctx.createArray();
     const algos = [_][]const u8{ "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "crc32", "crc32b", "crc32c", "xxh32", "xxh64", "xxh3", "xxh128", "adler32", "fnv132", "fnv1a32", "fnv164", "fnv1a64", "joaat" };
     for (algos) |name| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(name) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_hash_hmac_algos(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_hash_hmac_algos(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // HMAC requires algorithms with a fixed-size compression function; CRC and
     // similar non-cryptographic checksums are excluded. matches PHP's surface
     var arr = try ctx.createArray();
@@ -666,102 +668,104 @@ fn native_hash_hmac_algos(ctx: *NativeContext, _: []const Value) RuntimeError!Va
     for (algos) |name| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(name) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_hash_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return Value{ .bool = false };
+fn native_hash_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(Value{ .bool = false });
     const algo_name = args[0].string.bytes();
     const filename = args[1].string.bytes();
     const raw_output = args.len >= 3 and args[2].isTruthy();
-    const algo = HashAlgo.fromString(algo_name) orelse return Value{ .bool = false };
-    const data = std.fs.cwd().readFileAlloc(ctx.allocator, filename, 10 * 1024 * 1024) catch return Value{ .bool = false };
+    const algo = HashAlgo.fromString(algo_name) orelse return NativeResult.scalar(Value{ .bool = false });
+    const data = std.fs.cwd().readFileAlloc(ctx.allocator, filename, 10 * 1024 * 1024) catch return NativeResult.scalar(Value{ .bool = false });
     defer ctx.allocator.free(data);
     var digest: [64]u8 = undefined;
     const dlen = algo.digestLen();
     computeHash(algo, data, digest[0..dlen]);
-    if (raw_output) return .{ .string = Value.String.borrowed(try ctx.createString(digest[0..dlen])) };
-    return .{ .string = Value.String.borrowed(try toHexString(ctx, digest[0..dlen])) };
+    if (raw_output) return NativeResult.copyString(ctx.allocator, digest[0..dlen]);
+    return NativeResult.takeString(try toHexString(ctx, digest[0..dlen]));
 }
 
-fn native_md5_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_md5_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return hashFileWithWarning(ctx, args, "md5", "md5_file");
 }
 
-fn native_sha1_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_sha1_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return hashFileWithWarning(ctx, args, "sha1", "sha1_file");
 }
 
-fn hashFileWithWarning(ctx: *NativeContext, args: []const Value, algo: []const u8, fn_name: []const u8) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn hashFileWithWarning(ctx: *NativeContext, args: []const Value, algo: []const u8, fn_name: []const u8) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const raw = args.len >= 2 and args[1].isTruthy();
     // probe the file first so we can emit PHP's exact 'Failed to open stream'
     // warning text on missing files; hash_file returns false silently
     std.fs.cwd().access(args[0].string.bytes(), .{}) catch {
-        const msg = std.fmt.allocPrint(ctx.allocator, "{s}({s}): Failed to open stream: No such file or directory", .{ fn_name, args[0].string.bytes() }) catch return .{ .bool = false };
+        const msg = std.fmt.allocPrint(ctx.allocator, "{s}({s}): Failed to open stream: No such file or directory", .{ fn_name, args[0].string.bytes() }) catch return NativeResult.scalar(.{ .bool = false });
         ctx.vm.strings.append(ctx.allocator, msg) catch {};
         ctx.vm.emitWarning(msg);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     const hf_args = [_]Value{ .{ .string = Value.String.borrowed(algo) }, args[0], .{ .bool = raw } };
     return native_hash_file(ctx, &hf_args);
 }
 
-fn native_hash_equals(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_hash_equals(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const known = args[0].string.bytes();
     const user = args[1].string.bytes();
-    if (known.len != user.len) return .{ .bool = false };
+    if (known.len != user.len) return NativeResult.scalar(.{ .bool = false });
     var result: u8 = 0;
     for (known, user) |a, b| result |= a ^ b;
-    return .{ .bool = result == 0 };
+    return NativeResult.scalar(.{ .bool = result == 0 });
 }
 
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 
-fn native_hash_init(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const algo = HashAlgo.fromString(args[0].string.bytes()) orelse return .{ .bool = false };
+fn native_hash_init(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const algo = HashAlgo.fromString(args[0].string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
     _ = algo;
     const obj = try ctx.allocator.create(PhpObject);
     obj.* = .{ .class_name = "HashContext" };
     try ctx.vm.objects.append(ctx.allocator, obj);
-    try obj.set(ctx.allocator, "algo", .{ .string = Value.String.borrowed(try ctx.createString(args[0].string.bytes())) });
+    try obj.set(ctx.allocator, "algo", args[0]);
     // store accumulated bytes in a string buffer that grows
     try obj.set(ctx.allocator, "buffer", .{ .string = Value.String.borrowed("") });
     if (args.len >= 3 and args[2] == .string) {
-        try obj.set(ctx.allocator, "key", .{ .string = Value.String.borrowed(try ctx.createString(args[2].string.bytes())) });
+        try obj.set(ctx.allocator, "key", args[2]);
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_hash_update(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .string) return .{ .bool = false };
+fn native_hash_update(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     const cur = obj.get("buffer");
     const cur_str: []const u8 = if (cur == .string) cur.string.bytes() else "";
     const new_buf = try ctx.allocator.alloc(u8, cur_str.len + args[1].string.bytes().len);
     @memcpy(new_buf[0..cur_str.len], cur_str);
     @memcpy(new_buf[cur_str.len..], args[1].string.bytes());
-    try ctx.vm.strings.append(ctx.allocator, new_buf);
-    try obj.set(ctx.allocator, "buffer", .{ .string = Value.String.borrowed(new_buf) });
-    return .{ .bool = true };
+    const owned = try Value.String.adopt(ctx.allocator, new_buf);
+    defer owned.release();
+    try obj.set(ctx.allocator, "buffer", .{ .string = owned });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_hash_update_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .string) return .{ .bool = false };
-    const data = std.fs.cwd().readFileAlloc(ctx.allocator, args[1].string.bytes(), 64 * 1024 * 1024) catch return .{ .bool = false };
+fn native_hash_update_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const data = std.fs.cwd().readFileAlloc(ctx.allocator, args[1].string.bytes(), 64 * 1024 * 1024) catch return NativeResult.scalar(.{ .bool = false });
+    defer ctx.allocator.free(data);
     return native_hash_update(ctx, &.{ args[0], .{ .string = Value.String.borrowed(data) } });
 }
 
-fn native_hash_final(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
+fn native_hash_final(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     const algo_v = obj.get("algo");
     const buf_v = obj.get("buffer");
-    if (algo_v != .string) return .{ .bool = false };
+    if (algo_v != .string) return NativeResult.scalar(.{ .bool = false });
     const data: []const u8 = if (buf_v == .string) buf_v.string.bytes() else "";
-    const algo = HashAlgo.fromString(algo_v.string.bytes()) orelse return .{ .bool = false };
+    const algo = HashAlgo.fromString(algo_v.string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
     const raw_output = args.len >= 2 and args[1].isTruthy();
     var digest: [64]u8 = undefined;
     const dlen = algo.digestLen();
@@ -771,12 +775,12 @@ fn native_hash_final(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     } else {
         computeHash(algo, data, digest[0..dlen]);
     }
-    if (raw_output) return .{ .string = Value.String.borrowed(try ctx.createString(digest[0..dlen])) };
-    return .{ .string = Value.String.borrowed(try toHexString(ctx, digest[0..dlen])) };
+    if (raw_output) return NativeResult.copyString(ctx.allocator, digest[0..dlen]);
+    return NativeResult.takeString(try toHexString(ctx, digest[0..dlen]));
 }
 
-fn native_hash_copy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
+fn native_hash_copy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const orig = args[0].object;
     const obj = try ctx.allocator.create(PhpObject);
     obj.* = .{ .class_name = "HashContext" };
@@ -784,11 +788,11 @@ fn native_hash_copy(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     try obj.set(ctx.allocator, "algo", orig.get("algo"));
     try obj.set(ctx.allocator, "buffer", orig.get("buffer"));
     try obj.set(ctx.allocator, "key", orig.get("key"));
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_hash_pbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 4 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+fn native_hash_pbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 4 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const algo_name = args[0].string.bytes();
     const password = args[1].string.bytes();
     const salt = args[2].string.bytes();
@@ -814,6 +818,8 @@ fn native_hash_pbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         break :blk (length_arg + 1) / 2;
     };
     const out = try ctx.allocator.alloc(u8, out_bytes);
+    const owned_out = try Value.String.adopt(ctx.allocator, out);
+    defer owned_out.release();
 
     // basic PBKDF2-HMAC implementation
     var block_index: u32 = 1;
@@ -843,11 +849,10 @@ fn native_hash_pbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     }
 
     if (raw_output) {
-        try ctx.vm.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        return NativeResult.shareString(owned_out);
     }
     const hex = try toHexString(ctx, out);
-    ctx.allocator.free(out);
-    if (length_arg > 0 and length_arg < hex.len) return .{ .string = Value.String.borrowed(hex[0..length_arg]) };
-    return .{ .string = Value.String.borrowed(hex) };
+    defer hex.release();
+    if (length_arg > 0 and length_arg < hex.len) return NativeResult.copyString(ctx.allocator, hex.bytes()[0..length_arg]);
+    return NativeResult.shareString(hex);
 }

--- a/src/stdlib/curl.zig
+++ b/src/stdlib/curl.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -82,10 +83,10 @@ fn dupeZ(ctx: *NativeContext, s: []const u8) ![:0]u8 {
     return z[0..s.len :0];
 }
 
-fn curlInit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn curlInit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureGlobalInit();
 
-    const handle = c.curl_easy_init() orelse return .{ .bool = false };
+    const handle = c.curl_easy_init() orelse return NativeResult.scalar(.{ .bool = false });
 
     const obj = try ctx.createObject("CurlHandle");
     try obj.set(ctx.allocator, "__curl_ptr", .{ .int = @intCast(@intFromPtr(handle)) });
@@ -105,23 +106,23 @@ fn curlInit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         _ = c.curl_easy_setopt(handle, c.CURLOPT_URL, url_z.ptr);
     }
 
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn curlSetopt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .{ .bool = false };
-    const obj = getThisObj(args) orelse return .{ .bool = false };
-    const handle = getHandle(obj) orelse return .{ .bool = false };
-    if (args[1] != .int) return .{ .bool = false };
+fn curlSetopt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThisObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const handle = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const option = args[1].int;
     return applySetopt(ctx, handle, obj, option, args[2]);
 }
 
-fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i64, value: Value) RuntimeError!Value {
+fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i64, value: Value) RuntimeError!NativeResult {
     if (option == c.CURLOPT_SHARE) {
         // PHP ignores non-share values (including null); they do not detach.
-        if (value != .object or !std.mem.eql(u8, value.object.class_name, "CurlShareHandle")) return .{ .bool = true };
-        const share = getShareState(value.object) orelse return .{ .bool = false };
+        if (value != .object or !std.mem.eql(u8, value.object.class_name, "CurlShareHandle")) return NativeResult.scalar(.{ .bool = true });
+        const share = getShareState(value.object) orelse return NativeResult.scalar(.{ .bool = false });
         const code = c.curl_easy_setopt(handle, c.CURLOPT_SHARE, share.handle);
         if (code == c.CURLE_OK) {
             // Native references outlive PHP wrappers, including request sweeping
@@ -131,7 +132,7 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
             obj.properties.getPtr("__share_state").?.* = .{ .int = @intCast(@intFromPtr(share)) };
         }
         try obj.set(ctx.allocator, "__errno", .{ .int = @intCast(code) });
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
     // string options
     if (option == c.CURLOPT_URL or
@@ -158,11 +159,11 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         const s = switch (value) {
             .string => value.string.bytes(),
             .null => "",
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const z = try dupeZ(ctx, s);
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, @intCast(option), z.ptr));
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
 
     // long options
@@ -188,10 +189,10 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         const v: c_long = switch (value) {
             .int => @intCast(value.int),
             .bool => if (value.bool) @as(c_long, 1) else 0,
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, @intCast(option), v));
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
 
     // CURLOPT_RETURNTRANSFER - PHP-specific, not a real libcurl option
@@ -202,7 +203,7 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
             else => false,
         };
         try obj.set(ctx.allocator, "__return_transfer", .{ .bool = rt });
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
 
     // CURLOPT_FOLLOWLOCATION
@@ -210,10 +211,10 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         const v: c_long = switch (value) {
             .int => @intCast(value.int),
             .bool => if (value.bool) @as(c_long, 1) else 0,
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_FOLLOWLOCATION, v));
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
 
     // CURLOPT_POST
@@ -221,28 +222,28 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         const v: c_long = switch (value) {
             .int => @intCast(value.int),
             .bool => if (value.bool) @as(c_long, 1) else 0,
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_POST, v));
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
 
     // CURLOPT_POSTFIELDS
     if (option == c.CURLOPT_POSTFIELDS) {
         const s = switch (value) {
             .string => value.string.bytes(),
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const z = try dupeZ(ctx, s);
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_POSTFIELDS, z.ptr));
-        if (code != c.CURLE_OK) return .{ .bool = false };
+        if (code != c.CURLE_OK) return NativeResult.scalar(.{ .bool = false });
         const len_code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_POSTFIELDSIZE, @as(c_long, @intCast(s.len))));
-        return .{ .bool = len_code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = len_code == c.CURLE_OK });
     }
 
     // CURLOPT_HTTPHEADER
     if (option == c.CURLOPT_HTTPHEADER) {
-        if (value != .array) return .{ .bool = false };
+        if (value != .array) return NativeResult.scalar(.{ .bool = false });
 
         // free previous slist if any
         const prev_v = obj.get("__slist_ptr");
@@ -261,9 +262,9 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         if (slist) |sl| {
             try obj.set(ctx.allocator, "__slist_ptr", .{ .int = @intCast(@intFromPtr(sl)) });
             const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_HTTPHEADER, sl));
-            return .{ .bool = code == c.CURLE_OK };
+            return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
         }
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
 
     // CURLOPT_PUT
@@ -271,10 +272,10 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         const v: c_long = switch (value) {
             .int => @intCast(value.int),
             .bool => if (value.bool) @as(c_long, 1) else 0,
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_PUT, v));
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
 
     // CURLOPT_HEADER - include headers in output
@@ -282,10 +283,10 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         const v: c_long = switch (value) {
             .int => @intCast(value.int),
             .bool => if (value.bool) @as(c_long, 1) else 0,
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_HEADER, v));
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
 
     // CURLINFO_HEADER_OUT (debug)
@@ -300,7 +301,7 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
             const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_VERBOSE, @as(c_long, 1)));
             _ = code;
         }
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
 
     // CURLOPT_HTTPGET / CURLOPT_UPLOAD - plain long toggles
@@ -308,11 +309,11 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
         const v: c_long = switch (value) {
             .int => @intCast(value.int),
             .bool => if (value.bool) @as(c_long, 1) else 0,
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         };
         const opt: c_uint = if (option == c.CURLOPT_HTTPGET) c.CURLOPT_HTTPGET else c.CURLOPT_UPLOAD;
         const code: c_uint = @intCast(c.curl_easy_setopt(handle, opt, v));
-        return .{ .bool = code == c.CURLE_OK };
+        return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
     }
 
     // PHP throws ValueError for unrecognized CURLOPT_* constants
@@ -320,18 +321,18 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
     return error.RuntimeError;
 }
 
-fn curlSetoptArray(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
-    const obj = getThisObj(args) orelse return .{ .bool = false };
-    const handle = getHandle(obj) orelse return .{ .bool = false };
-    if (args[1] != .array) return .{ .bool = false };
+fn curlSetoptArray(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThisObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const handle = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args[1] != .array) return NativeResult.scalar(.{ .bool = false });
 
     for (args[1].array.entries.items) |entry| {
         if (entry.key != .int) continue;
         const result = try applySetopt(ctx, handle, obj, entry.key.int, entry.value);
-        if (result == .bool and !result.bool) return .{ .bool = false };
+        if (result.value == .bool and !result.value.bool) return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 const WriteCallbackData = struct {
@@ -346,10 +347,10 @@ fn writeCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaque) c
     return total;
 }
 
-fn curlExec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    const obj = getThisObj(args) orelse return .{ .bool = false };
-    const handle = getHandle(obj) orelse return .{ .bool = false };
+fn curlExec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThisObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const handle = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     const return_transfer_v = obj.get("__return_transfer");
     const return_transfer = return_transfer_v == .bool and return_transfer_v.bool;
@@ -374,7 +375,7 @@ fn curlExec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const owned = try ctx.createString(msg);
         try obj.set(ctx.allocator, "__error", .{ .string = Value.String.borrowed(owned) });
         try obj.set(ctx.allocator, "__errno", .{ .int = @intCast(result) });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     try obj.set(ctx.allocator, "__error", .{ .string = Value.String.borrowed("") });
@@ -386,19 +387,19 @@ fn curlExec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try obj.set(ctx.allocator, "__http_code", .{ .int = @intCast(http_code) });
 
     if (return_transfer) {
-        const str = try ctx.createString(cb_data.buffer.items);
-        return .{ .string = Value.String.borrowed(str) };
+        const str = try Value.String.create(ctx.allocator, cb_data.buffer.items);
+        return NativeResult.takeString(str);
     }
 
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn curlClose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn curlClose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     _ = ctx;
-    if (args.len == 0) return .null;
-    const obj = getThisObj(args) orelse return .null;
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const obj = getThisObj(args) orelse return NativeResult.scalar(.null);
     cleanupHandle(obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 pub fn cleanupHandle(obj: *PhpObject) void {
@@ -422,44 +423,44 @@ pub fn cleanupHandle(obj: *PhpObject) void {
     }
 }
 
-fn curlError(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const obj = getThisObj(args) orelse return .{ .string = Value.String.borrowed("") };
-    return obj.get("__error");
+fn curlError(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const obj = getThisObj(args) orelse return NativeResult.literal("");
+    return NativeResult.share(obj.get("__error"));
 }
 
-fn curlErrno(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const obj = getThisObj(args) orelse return .{ .int = 0 };
-    return obj.get("__errno");
+fn curlErrno(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const obj = getThisObj(args) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(obj.get("__errno"));
 }
 
-fn curlGetinfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    const obj = getThisObj(args) orelse return .{ .bool = false };
-    const handle = getHandle(obj) orelse return .{ .bool = false };
+fn curlGetinfo(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThisObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const handle = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     // no specific option - return all info as array
     if (args.len < 2 or args[1] == .null) {
         return getAllInfo(ctx, handle);
     }
 
-    if (args[1] != .int) return .{ .bool = false };
+    if (args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const option = args[1].int;
     return getInfoOption(ctx, handle, option);
 }
 
-fn getInfoOption(ctx: *NativeContext, handle: *c.CURL, option: i64) RuntimeError!Value {
+fn getInfoOption(ctx: *NativeContext, handle: *c.CURL, option: i64) RuntimeError!NativeResult {
     if (option == c.CURLINFO_COOKIELIST) {
         var list: ?*c.struct_curl_slist = null;
-        if (c.curl_easy_getinfo(handle, c.CURLINFO_COOKIELIST, &list) != c.CURLE_OK) return .{ .bool = false };
+        if (c.curl_easy_getinfo(handle, c.CURLINFO_COOKIELIST, &list) != c.CURLE_OK) return NativeResult.scalar(.{ .bool = false });
         defer c.curl_slist_free_all(list);
         const arr = try ctx.createArray();
         var node = list;
         while (node) |item| : (node = item.next) {
             try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(std.mem.span(item.data))) });
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
     // string info types
     if (option == c.CURLINFO_EFFECTIVE_URL or
@@ -471,10 +472,10 @@ fn getInfoOption(ctx: *NativeContext, handle: *c.CURL, option: i64) RuntimeError
     {
         var ptr: [*c]u8 = null;
         const code: c_uint = @intCast(c.curl_easy_getinfo(handle, @intCast(option), &ptr));
-        if (code != c.CURLE_OK or ptr == null) return .{ .bool = false };
+        if (code != c.CURLE_OK or ptr == null) return NativeResult.scalar(.{ .bool = false });
         const s = std.mem.span(ptr);
-        const owned = try ctx.createString(s);
-        return .{ .string = Value.String.borrowed(owned) };
+        const owned = try Value.String.create(ctx.allocator, s);
+        return NativeResult.takeString(owned);
     }
 
     // long info types
@@ -490,8 +491,8 @@ fn getInfoOption(ctx: *NativeContext, handle: *c.CURL, option: i64) RuntimeError
     {
         var val: c_long = 0;
         const code: c_uint = @intCast(c.curl_easy_getinfo(handle, @intCast(option), &val));
-        if (code != c.CURLE_OK) return .{ .bool = false };
-        return .{ .int = @intCast(val) };
+        if (code != c.CURLE_OK) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .int = @intCast(val) });
     }
 
     // double info types
@@ -510,14 +511,14 @@ fn getInfoOption(ctx: *NativeContext, handle: *c.CURL, option: i64) RuntimeError
     {
         var val: f64 = 0;
         const code: c_uint = @intCast(c.curl_easy_getinfo(handle, @intCast(option), &val));
-        if (code != c.CURLE_OK) return .{ .bool = false };
-        return .{ .float = val };
+        if (code != c.CURLE_OK) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .float = val });
     }
 
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn getAllInfo(ctx: *NativeContext, handle: *c.CURL) RuntimeError!Value {
+fn getAllInfo(ctx: *NativeContext, handle: *c.CURL) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
 
     var url_ptr: [*c]u8 = null;
@@ -695,13 +696,13 @@ fn getAllInfo(ctx: *NativeContext, handle: *c.CURL) RuntimeError!Value {
     if (c.curl_easy_getinfo(handle, c.CURLINFO_APPCONNECT_TIME_T, &appc_us) == c.CURLE_OK)
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("appconnect_time_us") }, .{ .int = @intCast(appc_us) });
 
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn curlReset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const obj = getThisObj(args) orelse return .null;
-    const handle = getHandle(obj) orelse return .null;
+fn curlReset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const obj = getThisObj(args) orelse return NativeResult.scalar(.null);
+    const handle = getHandle(obj) orelse return NativeResult.scalar(.null);
     c.curl_easy_reset(handle);
     try obj.set(ctx.allocator, "__return_transfer", .{ .bool = false });
     try obj.set(ctx.allocator, "__header_out", .{ .bool = false });
@@ -717,18 +718,17 @@ fn curlReset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try obj.set(ctx.allocator, "__slist_ptr", .{ .int = 0 });
     }
 
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn curlStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .null;
+fn curlStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.null);
     const code: c_uint = @intCast(args[0].int);
     const msg = c.curl_easy_strerror(code);
-    if (msg == null) return .null;
+    if (msg == null) return NativeResult.scalar(.null);
     const span = std.mem.span(msg);
     const owned = try ctx.allocator.dupe(u8, span);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
 // Separate native ownership keeps shares alive even when their PHP wrapper is
@@ -774,12 +774,12 @@ fn requireShare(ctx: *NativeContext, args: []const Value, name: []const u8) Runt
     return error.RuntimeError;
 }
 
-fn curlShareConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn curlShareConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     try ctx.vm.setPendingException("Error", "Cannot directly construct CurlShareHandle, use curl_share_init() instead");
     return error.RuntimeError;
 }
 
-fn curlShareClone(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn curlShareClone(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // The VM copies properties before invoking __clone. Remove the borrowed
     // native pointer so failed-clone teardown cannot release the original state.
     if (getThis(ctx)) |obj| {
@@ -789,27 +789,27 @@ fn curlShareClone(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     return error.RuntimeError;
 }
 
-fn curlShareInit(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn curlShareInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureGlobalInit();
-    const handle = c.curl_share_init() orelse return .{ .bool = false };
+    const handle = c.curl_share_init() orelse return NativeResult.scalar(.{ .bool = false });
     errdefer _ = c.curl_share_cleanup(handle);
     const state = try std.heap.page_allocator.create(ShareState);
     errdefer std.heap.page_allocator.destroy(state);
     const obj = try ctx.createObject("CurlShareHandle");
     state.* = .{ .handle = handle };
     try obj.set(ctx.allocator, "__share_state", .{ .int = @intCast(@intFromPtr(state)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn curlShareClose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn curlShareClose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // Like PHP 8, close is a validated no-op; destruction owns cleanup.
     _ = try requireShare(ctx, args, "curl_share_close");
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn curlShareSetopt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn curlShareSetopt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const state = try requireShare(ctx, args, "curl_share_setopt");
-    if (args.len < 3) return .{ .bool = false };
+    if (args.len < 3) return NativeResult.scalar(.{ .bool = false });
     const option = Value.toInt(args[1]);
     if (option != c.CURLSHOPT_SHARE and option != c.CURLSHOPT_UNSHARE) {
         state.errno = c.CURLSHE_BAD_OPTION;
@@ -818,19 +818,19 @@ fn curlShareSetopt(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     }
     const data: c_int = @truncate(Value.toInt(args[2]));
     state.errno = @intCast(c.curl_share_setopt(state.handle, @as(c_uint, @intCast(option)), data));
-    return .{ .bool = state.errno == c.CURLSHE_OK };
+    return NativeResult.scalar(.{ .bool = state.errno == c.CURLSHE_OK });
 }
 
-fn curlShareErrno(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .int = (try requireShare(ctx, args, "curl_share_errno")).errno };
+fn curlShareErrno(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = (try requireShare(ctx, args, "curl_share_errno")).errno });
 }
 
-fn curlShareStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn curlShareStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     const code: c_uint = @bitCast(@as(c_int, @truncate(Value.toInt(args[0]))));
     const msg = c.curl_share_strerror(code);
-    if (msg == null) return .null;
-    return .{ .string = Value.String.borrowed(try ctx.createString(std.mem.span(msg))) };
+    if (msg == null) return NativeResult.scalar(.null);
+    return try NativeResult.copyString(ctx.allocator, std.mem.span(msg));
 }
 
 // ---------------- curl_multi ----------------
@@ -848,33 +848,33 @@ fn getMultiHandle(obj: *PhpObject) ?*c.CURLM {
     return @ptrFromInt(@as(usize, @intCast(v.int)));
 }
 
-fn curlMultiInit(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn curlMultiInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureGlobalInit();
-    const mh = c.curl_multi_init() orelse return .{ .bool = false };
+    const mh = c.curl_multi_init() orelse return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("CurlMultiHandle");
     try obj.set(ctx.allocator, "__multi_ptr", .{ .int = @intCast(@intFromPtr(mh)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn curlMultiAddHandle(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .object) return .{ .int = 1 };
-    const mh = getMultiHandle(args[0].object) orelse return .{ .int = 1 };
-    const easy = getHandle(args[1].object) orelse return .{ .int = 1 };
+fn curlMultiAddHandle(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .object) return NativeResult.scalar(.{ .int = 1 });
+    const mh = getMultiHandle(args[0].object) orelse return NativeResult.scalar(.{ .int = 1 });
+    const easy = getHandle(args[1].object) orelse return NativeResult.scalar(.{ .int = 1 });
     // attach a persistent write buffer so getcontent() can read it later
     const return_transfer_v = args[1].object.get("__return_transfer");
     if (return_transfer_v == .bool and return_transfer_v.bool) {
-        const wcb = std.heap.page_allocator.create(WriteCallbackData) catch return .{ .int = 1 };
+        const wcb = std.heap.page_allocator.create(WriteCallbackData) catch return NativeResult.scalar(.{ .int = 1 });
         wcb.* = .{ .allocator = std.heap.page_allocator, .buffer = .{} };
         multi_wcb_table.put(std.heap.page_allocator, @intFromPtr(easy), wcb) catch {
             wcb.buffer.deinit(wcb.allocator);
             std.heap.page_allocator.destroy(wcb);
-            return .{ .int = 1 };
+            return NativeResult.scalar(.{ .int = 1 });
         };
         _ = c.curl_easy_setopt(easy, c.CURLOPT_WRITEFUNCTION, @as(?*const fn ([*]u8, usize, usize, *anyopaque) callconv(.c) usize, &writeCallback));
         _ = c.curl_easy_setopt(easy, c.CURLOPT_WRITEDATA, @as(*anyopaque, @ptrCast(wcb)));
     }
     const code = c.curl_multi_add_handle(mh, easy);
-    return .{ .int = @intCast(code) };
+    return NativeResult.scalar(.{ .int = @intCast(code) });
 }
 
 fn freeMultiWcb(easy: *c.CURL) void {
@@ -884,30 +884,30 @@ fn freeMultiWcb(easy: *c.CURL) void {
     }
 }
 
-fn curlMultiRemoveHandle(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .object) return .{ .int = 1 };
-    const mh = getMultiHandle(args[0].object) orelse return .{ .int = 1 };
-    const easy = getHandle(args[1].object) orelse return .{ .int = 1 };
+fn curlMultiRemoveHandle(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .object) return NativeResult.scalar(.{ .int = 1 });
+    const mh = getMultiHandle(args[0].object) orelse return NativeResult.scalar(.{ .int = 1 });
+    const easy = getHandle(args[1].object) orelse return NativeResult.scalar(.{ .int = 1 });
     const code = c.curl_multi_remove_handle(mh, easy);
     freeMultiWcb(easy);
-    return .{ .int = @intCast(code) };
+    return NativeResult.scalar(.{ .int = @intCast(code) });
 }
 
-fn curlMultiExec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .int = 1 };
-    const mh = getMultiHandle(args[0].object) orelse return .{ .int = 1 };
+fn curlMultiExec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .int = 1 });
+    const mh = getMultiHandle(args[0].object) orelse return NativeResult.scalar(.{ .int = 1 });
     var still_running: c_int = 0;
     const code = c.curl_multi_perform(mh, &still_running);
     // 2nd arg is by-ref: write the still-running count back
     if (args.len >= 2) {
         ctx.setCallerVar(1, args.len, .{ .int = @intCast(still_running) });
     }
-    return .{ .int = @intCast(code) };
+    return NativeResult.scalar(.{ .int = @intCast(code) });
 }
 
-fn curlMultiSelect(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .int = -1 };
-    const mh = getMultiHandle(args[0].object) orelse return .{ .int = -1 };
+fn curlMultiSelect(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .int = -1 });
+    const mh = getMultiHandle(args[0].object) orelse return NativeResult.scalar(.{ .int = -1 });
     const timeout_ms: c_int = if (args.len >= 2) blk: {
         const secs: f64 = switch (args[1]) {
             .float => |f| f,
@@ -918,24 +918,24 @@ fn curlMultiSelect(_: *NativeContext, args: []const Value) RuntimeError!Value {
     } else 1000;
     var numfds: c_int = 0;
     const code = c.curl_multi_poll(mh, null, 0, timeout_ms, &numfds);
-    if (code != c.CURLM_OK) return .{ .int = -1 };
-    return .{ .int = @intCast(numfds) };
+    if (code != c.CURLM_OK) return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(numfds) });
 }
 
-fn curlMultiGetcontent(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .null;
-    const easy = getHandle(args[0].object) orelse return .null;
-    const wcb = multi_wcb_table.get(@intFromPtr(easy)) orelse return .null;
-    const str = try ctx.createString(wcb.buffer.items);
-    return .{ .string = Value.String.borrowed(str) };
+fn curlMultiGetcontent(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
+    const easy = getHandle(args[0].object) orelse return NativeResult.scalar(.null);
+    const wcb = multi_wcb_table.get(@intFromPtr(easy)) orelse return NativeResult.scalar(.null);
+    const str = try Value.String.create(ctx.allocator, wcb.buffer.items);
+    return NativeResult.takeString(str);
 }
 
-fn curlMultiInfoRead(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const mh = getMultiHandle(args[0].object) orelse return .{ .bool = false };
+fn curlMultiInfoRead(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const mh = getMultiHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     var msgs_in_queue: c_int = 0;
     const msg = c.curl_multi_info_read(mh, &msgs_in_queue);
-    if (msg == null) return .{ .bool = false };
+    if (msg == null) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("msg") }, .{ .int = @intCast(msg.*.msg) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("result") }, .{ .int = @intCast(msg.*.data.result) });
@@ -945,32 +945,32 @@ fn curlMultiInfoRead(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     if (args.len >= 2) {
         ctx.setCallerVar(1, args.len, .{ .int = @intCast(msgs_in_queue) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn curlMultiClose(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .null;
-    const mh = getMultiHandle(args[0].object) orelse return .null;
+fn curlMultiClose(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
+    const mh = getMultiHandle(args[0].object) orelse return NativeResult.scalar(.null);
     _ = c.curl_multi_cleanup(mh);
     args[0].object.properties.getPtr("__multi_ptr").?.* = .{ .int = 0 };
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn curlMultiStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .null;
+fn curlMultiStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.null);
     const msg = c.curl_multi_strerror(@intCast(args[0].int));
-    const str = try ctx.createString(std.mem.span(msg));
-    return .{ .string = Value.String.borrowed(str) };
+    const str = try Value.String.create(ctx.allocator, std.mem.span(msg));
+    return NativeResult.takeString(str);
 }
 
-fn curlMultiErrno(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn curlMultiErrno(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn curlMultiSetopt(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn curlMultiSetopt(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // CURLMOPT_* options (pipelining, max connections, etc.) are accepted but
     // not all are wired - libcurl tolerates the defaults for correctness
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // ---------------- CURLFile ----------------
@@ -978,45 +978,45 @@ fn curlMultiSetopt(_: *NativeContext, _: []const Value) RuntimeError!Value {
 // just read/write those. curl_setopt(CURLOPT_POSTFIELDS) detects a CURLFile
 // inside an array and builds a multipart body
 
-fn curlFileConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn curlFileConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const name: []const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else "";
     const mime: []const u8 = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "";
     const postname: []const u8 = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else "";
     try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(name) });
     try obj.set(ctx.allocator, "mime", .{ .string = Value.String.borrowed(mime) });
     try obj.set(ctx.allocator, "postname", .{ .string = Value.String.borrowed(postname) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn curlFileGetFilename(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("name");
+fn curlFileGetFilename(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("name"));
 }
 
-fn curlFileGetMimeType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("mime");
+fn curlFileGetMimeType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("mime"));
 }
 
-fn curlFileGetPostFilename(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("postname");
+fn curlFileGetPostFilename(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("postname"));
 }
 
-fn curlFileSetMimeType(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn curlFileSetMimeType(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and args[0] == .string) try obj.set(ctx.allocator, "mime", args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn curlFileSetPostFilename(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn curlFileSetPostFilename(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and args[0] == .string) try obj.set(ctx.allocator, "postname", args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn curlFileCreate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn curlFileCreate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("CURLFile");
     const name: []const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else "";
     const mime: []const u8 = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "";
@@ -1024,40 +1024,38 @@ fn curlFileCreate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(name) });
     try obj.set(ctx.allocator, "mime", .{ .string = Value.String.borrowed(mime) });
     try obj.set(ctx.allocator, "postname", .{ .string = Value.String.borrowed(postname) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn curlEscape(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    if (args[0] != .object) return .{ .bool = false };
-    const handle = getHandle(args[0].object) orelse return .{ .bool = false };
+fn curlEscape(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const handle = getHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     const s = args[1].string.bytes();
     const encoded = c.curl_easy_escape(handle, s.ptr, @intCast(s.len));
-    if (encoded == null) return .{ .bool = false };
+    if (encoded == null) return NativeResult.scalar(.{ .bool = false });
     defer c.curl_free(encoded);
     const span = std.mem.span(encoded);
     const owned = try ctx.allocator.dupe(u8, span);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
-fn curlUnescape(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    if (args[0] != .object) return .{ .bool = false };
-    const handle = getHandle(args[0].object) orelse return .{ .bool = false };
+fn curlUnescape(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const handle = getHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     const s = args[1].string.bytes();
     var out_len: c_int = 0;
     const decoded = c.curl_easy_unescape(handle, s.ptr, @intCast(s.len), &out_len);
-    if (decoded == null) return .{ .bool = false };
+    if (decoded == null) return NativeResult.scalar(.{ .bool = false });
     defer c.curl_free(decoded);
     const slice = decoded[0..@as(usize, @intCast(out_len))];
     const owned = try ctx.allocator.dupe(u8, slice);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
-fn curlVersion(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const info = c.curl_version_info(c.CURLVERSION_NOW) orelse return .{ .bool = false };
+fn curlVersion(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const info = c.curl_version_info(c.CURLVERSION_NOW) orelse return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
 
     // PHP emits in this exact order. include every key it does so
@@ -1108,7 +1106,7 @@ fn curlVersion(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("brotli_ver_num") }, .{ .int = 0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("brotli_version") }, .{ .string = Value.String.borrowed("") });
 
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn cleanupPoolable(obj: *PhpObject) bool {
@@ -1277,7 +1275,7 @@ test "curl property growth across native contexts and allocation-free cleanup" {
     defer a.destroy(vm);
     defer vm.deinit();
     var init_ctx = vm.makeContext("curl_init");
-    const easy = try curlInit(&init_ctx, &.{});
+    const easy = (try curlInit(&init_ctx, &.{})).value;
     var later_ctx = vm.makeContext("curl_setopt");
     const headers = try later_ctx.createArray();
     try headers.append(later_ctx.allocator, .{ .string = Value.String.borrowed("X-Allocator-Test: yes") });
@@ -1299,7 +1297,7 @@ test "curl property growth across native contexts and allocation-free cleanup" {
     try std.testing.expectEqual(@as(i64, 0), easy.object.get("__curl_ptr").int);
     cleanupHandle(easy.object);
 
-    const multi = try curlMultiInit(&init_ctx, &.{});
+    const multi = (try curlMultiInit(&init_ctx, &.{})).value;
     i = 0;
     while (multi.object.properties.count() < multi.object.properties.capacity()) : (i += 1) {
         const key = try std.fmt.bufPrint(&keys[128 + i], "multi_property_{d}", .{i});

--- a/src/stdlib/datetime.zig
+++ b/src/stdlib/datetime.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
 const VM = vm_mod.VM;
+const NativeResult = vm_mod.NativeResult;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 const Allocator = std.mem.Allocator;
@@ -278,8 +279,8 @@ fn parseIsoDateToTs(s: []const u8) ?i64 {
     return dateToTimestamp(year, month, day, hour, min, sec);
 }
 
-fn dpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     // ISO 8601 recurring-interval string form: "R<n>/<start>/<interval>"
     // e.g. new DatePeriod('R3/2024-01-01T00:00:00Z/P1D'). PHP's string
@@ -288,12 +289,12 @@ fn dpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len >= 1 and args[0] == .string) {
         const spec = args[0].string.bytes();
         var it = std.mem.splitScalar(u8, spec, '/');
-        const p0 = it.next() orelse return .null;
-        const p1 = it.next() orelse return .null;
-        const p2 = it.next() orelse return .null;
-        if (p0.len < 2 or (p0[0] != 'R' and p0[0] != 'r')) return .null;
+        const p0 = it.next() orelse return NativeResult.scalar(.null);
+        const p1 = it.next() orelse return NativeResult.scalar(.null);
+        const p2 = it.next() orelse return NativeResult.scalar(.null);
+        if (p0.len < 2 or (p0[0] != 'R' and p0[0] != 'r')) return NativeResult.scalar(.null);
         const recurrences = std.fmt.parseInt(i64, p0[1..], 10) catch 0;
-        const start_ts = parseIsoDateToTs(p1) orelse return .null;
+        const start_ts = parseIsoDateToTs(p1) orelse return NativeResult.scalar(.null);
         const start_obj = try ctx.createObject("DateTime");
         try start_obj.set(ctx.allocator, "timestamp", .{ .int = start_ts });
         try obj.set(ctx.allocator, "__start", .{ .object = start_obj });
@@ -313,11 +314,11 @@ fn dpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
         try obj.set(ctx.allocator, "__recurrences", .{ .int = recurrences });
         if (args.len >= 2 and args[1] == .int) try obj.set(ctx.allocator, "__options", args[1]);
-        return .null;
+        return NativeResult.scalar(.null);
     }
 
-    if (args.len < 3) return .null;
-    if (args[0] != .object or args[1] != .object) return .null;
+    if (args.len < 3) return NativeResult.scalar(.null);
+    if (args[0] != .object or args[1] != .object) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__start", args[0]);
     try obj.set(ctx.allocator, "__interval", args[1]);
     if (args[2] == .object) {
@@ -326,35 +327,35 @@ fn dpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try obj.set(ctx.allocator, "__recurrences", args[2]);
     }
     if (args.len >= 4) try obj.set(ctx.allocator, "__options", args[3]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dpGetStart(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__start");
+fn dpGetStart(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(obj.get("__start"));
 }
 
-fn dpGetEnd(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__end");
+fn dpGetEnd(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(obj.get("__end"));
 }
 
-fn dpGetInterval(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__interval");
+fn dpGetInterval(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(obj.get("__interval"));
 }
 
-fn dpGetRecurrences(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dpGetRecurrences(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     // explicitly stored recurrence count (third constructor arg was an int).
     // when constructed with an end-DateTime instead, PHP returns null
     const rec = obj.get("__recurrences");
-    if (rec == .int) return rec;
-    return .null;
+    if (rec == .int) return NativeResult.scalar(rec);
+    return NativeResult.scalar(.null);
 }
 
-fn dpGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dpGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const iter = try ctx.vm.allocator.create(@import("../runtime/value.zig").PhpObject);
     iter.* = .{ .class_name = "DatePeriodIterator" };
     try ctx.vm.objects.append(ctx.vm.allocator, iter);
@@ -366,7 +367,7 @@ fn dpGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const exclude_start = opts == .int and (opts.int & 1) != 0;
     const include_end = opts == .int and (opts.int & 2) != 0;
     const start_v = obj.get("__start");
-    if (start_v != .object) return .null;
+    if (start_v != .object) return NativeResult.scalar(.null);
     var ts = getTimestamp(start_v.object);
     if (exclude_start) {
         const di = obj.get("__interval");
@@ -379,7 +380,7 @@ fn dpGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try iter.set(ctx.allocator, "__index", .{ .int = 0 });
     try iter.set(ctx.allocator, "__exclude_start", .{ .bool = exclude_start });
     try iter.set(ctx.allocator, "__include_end", .{ .bool = include_end });
-    return .{ .object = iter };
+    return NativeResult.borrowed(.{ .object = iter });
 }
 
 fn dpiTimestampInRange(this: *@import("../runtime/value.zig").PhpObject) bool {
@@ -399,9 +400,9 @@ fn dpiTimestampInRange(this: *@import("../runtime/value.zig").PhpObject) bool {
     return false;
 }
 
-fn dpiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    if (!dpiTimestampInRange(this)) return .{ .bool = false };
+fn dpiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (!dpiTimestampInRange(this)) return NativeResult.scalar(.{ .bool = false });
     const ts = Value.toInt(this.get("__cursor_ts"));
     const dt = try ctx.createObject("DateTime");
     try dt.set(ctx.allocator, "timestamp", .{ .int = ts });
@@ -410,16 +411,16 @@ fn dpiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         const tz = start_v.object.get("__timezone");
         if (tz == .string) try dt.set(ctx.allocator, "__timezone", tz);
     }
-    return .{ .object = dt };
+    return NativeResult.borrowed(.{ .object = dt });
 }
 
-fn dpiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return this.get("__index");
+fn dpiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.scalar(this.get("__index"));
 }
 
-fn dpiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn dpiNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const di = this.get("__interval");
     if (di == .object) {
         const cur = Value.toInt(this.get("__cursor_ts"));
@@ -429,25 +430,25 @@ fn dpiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     }
     const idx = Value.toInt(this.get("__index"));
     try this.set(ctx.allocator, "__index", .{ .int = idx + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dpiRewind(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn dpiRewind(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn dpiValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    return .{ .bool = dpiTimestampInRange(this) };
+fn dpiValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = dpiTimestampInRange(this) });
 }
 
-fn dtGetLastErrors(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn dtGetLastErrors(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP 8.2+: returns false when the most recent parse succeeded;
     // returns the structured error array on failure. zphp tracks failure
     // as a single flag without preserving per-position error detail (porting
     // PHP's full parser would be substantial), so emit two placeholder
     // entries that match the count() shape of PHP's typical responses
-    if (!ctx.vm.last_dt_parse_failed) return .{ .bool = false };
+    if (!ctx.vm.last_dt_parse_failed) return NativeResult.scalar(.{ .bool = false });
     var result = try ctx.createArray();
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("warning_count") }, .{ .int = 0 });
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("warnings") }, .{ .array = try ctx.createArray() });
@@ -456,7 +457,7 @@ fn dtGetLastErrors(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try errors_arr.set(ctx.allocator, .{ .int = 0 }, .{ .string = Value.String.borrowed("A four digit year could not be found") });
     try errors_arr.set(ctx.allocator, .{ .int = @intCast(ctx.vm.last_dt_error_pos) }, .{ .string = Value.String.borrowed(ctx.vm.last_dt_error_text) });
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("errors") }, .{ .array = errors_arr });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 fn getThis(ctx: *NativeContext) ?*PhpObject {
@@ -469,8 +470,8 @@ fn getTimestamp(obj: *PhpObject) i64 {
     return Value.toInt(obj.get("timestamp"));
 }
 
-fn dtConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dtConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     var ts: i64 = std.time.timestamp();
 
     // extract timezone from second arg
@@ -589,12 +590,12 @@ fn dtConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     try obj.set(ctx.allocator, "timestamp", .{ .int = ts });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dtFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn dtFormat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const ts = getTimestamp(obj);
     const tz_val = obj.get("__timezone");
     const tz_name = if (tz_val == .string) tz_val.string.bytes() else ctx.vm.default_tz_name;
@@ -604,17 +605,17 @@ fn dtFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return formatTimestampTzMicros(ctx, ts, args[0].string.bytes(), offset, tz_name, us);
 }
 
-pub fn formatTimestamp(ctx: *NativeContext, timestamp: i64, format: []const u8) RuntimeError!Value {
+pub fn formatTimestamp(ctx: *NativeContext, timestamp: i64, format: []const u8) RuntimeError!NativeResult {
     const tz_name = ctx.vm.default_tz_name;
     const offset = tzOffsetForName(ctx.allocator, tz_name, timestamp);
     return formatTimestampTzMicros(ctx, timestamp, format, offset, tz_name, 0);
 }
 
-pub fn formatTimestampTz(ctx: *NativeContext, timestamp: i64, format: []const u8, tz_offset: i32, tz_name: []const u8) RuntimeError!Value {
+pub fn formatTimestampTz(ctx: *NativeContext, timestamp: i64, format: []const u8, tz_offset: i32, tz_name: []const u8) RuntimeError!NativeResult {
     return formatTimestampTzMicros(ctx, timestamp, format, tz_offset, tz_name, 0);
 }
 
-pub fn formatTimestampTzMicros(ctx: *NativeContext, timestamp: i64, format: []const u8, tz_offset: i32, tz_name: []const u8, microseconds: i64) RuntimeError!Value {
+pub fn formatTimestampTzMicros(ctx: *NativeContext, timestamp: i64, format: []const u8, tz_offset: i32, tz_name: []const u8, microseconds: i64) RuntimeError!NativeResult {
     const local_ts = timestamp + @as(i64, tz_offset);
     const dc = baseComponents(local_ts);
     const day_seconds = FmtDaySec{ .h = @intCast(dc.hour), .mi = @intCast(dc.min), .s = @intCast(dc.sec) };
@@ -624,6 +625,7 @@ pub fn formatTimestampTzMicros(ctx: *NativeContext, timestamp: i64, format: []co
     const a = ctx.allocator;
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(a);
     var fi: usize = 0;
     while (fi < format.len) : (fi += 1) {
         const c = format[fi];
@@ -893,41 +895,40 @@ pub fn formatTimestampTzMicros(ctx: *NativeContext, timestamp: i64, format: []co
         }
     }
     const result = try buf.toOwnedSlice(a);
-    try ctx.strings.append(a, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(a, result));
 }
 
-fn dtGetTimestamp(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return .{ .int = getTimestamp(obj) };
+fn dtGetTimestamp(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.scalar(.{ .int = getTimestamp(obj) });
 }
 
-fn dtSetTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dtSetTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1) try obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(args[0]) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtModify(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .string) return .{ .object = obj };
+fn dtModify(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .string) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const result = parseRelativeTime(args[0].string.bytes(), ts);
     if (result == .int) try obj.set(ctx.allocator, "timestamp", result);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtiModify(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .string) return .{ .object = obj };
+fn dtiModify(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .string) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const result = parseRelativeTime(args[0].string.bytes(), ts);
-    if (result != .int) return .{ .object = obj };
+    if (result != .int) return NativeResult.borrowed(.{ .object = obj });
 
     // immutable: create a new DateTime object
     const new_obj = try ctx.createObject("DateTimeImmutable");
     try new_obj.set(ctx.allocator, "timestamp", result);
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
 fn intervalToSeconds(interval: *PhpObject) i64 {
@@ -992,49 +993,49 @@ fn objTzName(obj: *PhpObject, fallback: []const u8) []const u8 {
     return if (v == .string) v.string.bytes() else fallback;
 }
 
-fn dtAdd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .{ .object = obj };
+fn dtAdd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const new_ts = applyIntervalTz(ts, args[0].object, 1, objTzName(obj, ctx.vm.default_tz_name));
     try obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtSub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .{ .object = obj };
+fn dtSub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const new_ts = applyIntervalTz(ts, args[0].object, -1, objTzName(obj, ctx.vm.default_tz_name));
     try obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtiAdd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .{ .object = obj };
+fn dtiAdd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const new_ts = applyIntervalTz(ts, args[0].object, 1, objTzName(obj, ctx.vm.default_tz_name));
     const new_obj = try ctx.createObject("DateTimeImmutable");
     try new_obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
     if (obj.get("__timezone") == .string) try new_obj.set(ctx.allocator, "__timezone", obj.get("__timezone"));
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
-fn dtiSub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .{ .object = obj };
+fn dtiSub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const new_ts = applyIntervalTz(ts, args[0].object, -1, objTzName(obj, ctx.vm.default_tz_name));
     const new_obj = try ctx.createObject("DateTimeImmutable");
     try new_obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
     if (obj.get("__timezone") == .string) try new_obj.set(ctx.allocator, "__timezone", obj.get("__timezone"));
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
-fn dtDiff(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .null;
+fn dtDiff(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const other = args[0].object;
     const ts1 = getTimestamp(obj);
     const ts2 = getTimestamp(other);
@@ -1117,12 +1118,12 @@ fn dtDiff(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try interval.set(ctx.allocator, "i", .{ .int = mi });
     try interval.set(ctx.allocator, "s", .{ .int = s });
     try interval.set(ctx.allocator, "invert", .{ .int = invert });
-    return .{ .object = interval };
+    return NativeResult.borrowed(.{ .object = interval });
 }
 
-fn dtSetDate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 3) return .{ .object = obj };
+fn dtSetDate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 3) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const epoch_secs: u64 = @intCast(if (ts < 0) 0 else ts);
     const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
@@ -1132,12 +1133,12 @@ fn dtSetDate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const s: i64 = day_seconds.getSecondsIntoMinute();
     const new_ts = dateToTimestamp(Value.toInt(args[0]), Value.toInt(args[1]), Value.toInt(args[2]), h, m, s);
     try obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2) return .{ .object = obj };
+fn dtSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const epoch_secs: u64 = @intCast(if (ts < 0) 0 else ts);
     const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
@@ -1151,12 +1152,12 @@ fn dtSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // __microseconds. setTime with <4 args resets the sub-second part to 0
     const micros: i64 = if (args.len >= 4) Value.toInt(args[3]) else 0;
     try obj.set(ctx.allocator, "__microseconds", .{ .int = micros });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtiSetDate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 3) return .{ .object = obj };
+fn dtiSetDate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 3) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const epoch_secs: u64 = @intCast(if (ts < 0) 0 else ts);
     const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
@@ -1169,7 +1170,7 @@ fn dtiSetDate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try new_obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
     const tz = obj.get("__timezone");
     if (tz != .null) try new_obj.set(ctx.allocator, "__timezone", tz);
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
 // ISO 8601 week date -> Gregorian date: jan 4 always falls in ISO week 1
@@ -1189,9 +1190,9 @@ fn isoWeekDateToTimestamp(year: i64, week: i64, day_of_week: i64, h: i64, m: i64
     return target_ts + h * 3600 + m * 60 + s;
 }
 
-fn dtSetISODate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2) return .{ .object = obj };
+fn dtSetISODate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.borrowed(.{ .object = obj });
     const year = Value.toInt(args[0]);
     const week = Value.toInt(args[1]);
     const dow = if (args.len >= 3) Value.toInt(args[2]) else 1;
@@ -1203,12 +1204,12 @@ fn dtSetISODate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const m: i64 = day_seconds.getMinutesIntoHour();
     const s: i64 = day_seconds.getSecondsIntoMinute();
     try obj.set(ctx.allocator, "timestamp", .{ .int = isoWeekDateToTimestamp(year, week, dow, h, m, s) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtiSetISODate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2) return .{ .object = obj };
+fn dtiSetISODate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.borrowed(.{ .object = obj });
     const year = Value.toInt(args[0]);
     const week = Value.toInt(args[1]);
     const dow = if (args.len >= 3) Value.toInt(args[2]) else 1;
@@ -1223,12 +1224,12 @@ fn dtiSetISODate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try new_obj.set(ctx.allocator, "timestamp", .{ .int = isoWeekDateToTimestamp(year, week, dow, h, m, s) });
     const tz = obj.get("__timezone");
     if (tz != .null) try new_obj.set(ctx.allocator, "__timezone", tz);
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
-fn dtiSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2) return .{ .object = obj };
+fn dtiSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const epoch_secs: u64 = @intCast(if (ts < 0) 0 else ts);
     const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
@@ -1241,68 +1242,68 @@ fn dtiSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try new_obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
     const tz = obj.get("__timezone");
     if (tz != .null) try new_obj.set(ctx.allocator, "__timezone", tz);
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
-fn dtiSetTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .{ .object = obj };
+fn dtiSetTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.borrowed(.{ .object = obj });
     const new_obj = try ctx.createObject("DateTimeImmutable");
     try new_obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(args[0]) });
     const tz = obj.get("__timezone");
     if (tz != .null) try new_obj.set(ctx.allocator, "__timezone", tz);
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
-fn dtCreateFromTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn dtCreateFromTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("DateTime");
     try obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(args[0]) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtCreateFromFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn dtCreateFromFormat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return createFromFormatImpl(ctx, args, "DateTime");
 }
 
-fn dtCreateFromImmutable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .null;
+fn dtCreateFromImmutable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const src = args[0].object;
     const obj = try ctx.createObject("DateTime");
     try obj.set(ctx.allocator, "timestamp", src.get("timestamp"));
     if (src.get("__timezone") == .string) try obj.set(ctx.allocator, "__timezone", src.get("__timezone"));
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtiCreateFromMutable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .null;
+fn dtiCreateFromMutable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const src = args[0].object;
     const obj = try ctx.createObject("DateTimeImmutable");
     try obj.set(ctx.allocator, "timestamp", src.get("timestamp"));
     if (src.get("__timezone") == .string) try obj.set(ctx.allocator, "__timezone", src.get("__timezone"));
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 // createFromInterface accepts either DateTime or DateTimeImmutable and produces
 // the corresponding target type (called as DateTime::createFromInterface or
 // DateTimeImmutable::createFromInterface)
-fn dtCreateFromInterface(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn dtCreateFromInterface(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return dtCreateFromImmutable(ctx, args);
 }
 
-fn dtiCreateFromInterface(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn dtiCreateFromInterface(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return dtiCreateFromMutable(ctx, args);
 }
 
-fn native_date_create_from_format(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_date_create_from_format(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return createFromFormatImpl(ctx, args, "DateTime");
 }
 
-fn native_date_create_immutable_from_format(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_date_create_immutable_from_format(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return createFromFormatImpl(ctx, args, "DateTimeImmutable");
 }
 
-fn createBareDt(ctx: *NativeContext, class_name: []const u8, args: []const Value) RuntimeError!Value {
+fn createBareDt(ctx: *NativeContext, class_name: []const u8, args: []const Value) RuntimeError!NativeResult {
     const tz_name = if (args.len >= 2) extractTimezoneName(args[1..]) else ctx.vm.default_tz_name;
     var ts: i64 = std.time.timestamp();
     if (args.len >= 1 and args[0] == .string) {
@@ -1333,14 +1334,14 @@ fn createBareDt(ctx: *NativeContext, class_name: []const u8, args: []const Value
     const obj = try ctx.createObject(class_name);
     try obj.set(ctx.allocator, "__timezone", .{ .string = Value.String.borrowed(tz_name) });
     try obj.set(ctx.allocator, "timestamp", .{ .int = ts });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_date_create(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_date_create(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return createBareDt(ctx, "DateTime", args);
 }
 
-fn native_date_create_immutable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_date_create_immutable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return createBareDt(ctx, "DateTimeImmutable", args);
 }
 
@@ -1353,9 +1354,9 @@ fn isImmutable(obj: *PhpObject) bool {
     return std.mem.eql(u8, obj.class_name, "DateTimeImmutable");
 }
 
-fn native_date_format(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = argObj(args) orelse return .{ .bool = false };
-    if (args.len < 2 or args[1] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_date_format(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = argObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2 or args[1] != .string) return NativeResult.literal("");
     const ts = getTimestamp(obj);
     const tz_val = obj.get("__timezone");
     const tz_name = if (tz_val == .string) tz_val.string.bytes() else ctx.vm.default_tz_name;
@@ -1364,60 +1365,60 @@ fn native_date_format(ctx: *NativeContext, args: []const Value) RuntimeError!Val
 }
 
 // procedural alias for DateInterval::createFromDateString
-fn native_date_interval_create_from_date_string(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_date_interval_create_from_date_string(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return diCreateFromDateString(ctx, args);
 }
 
 // procedural alias for DateInterval::format($interval, $format)
-fn native_date_interval_format(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .string) return .{ .bool = false };
+fn native_date_interval_format(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const saved = ctx.vm.currentFrame().vars.get("$this");
     try ctx.vm.currentFrame().vars.put(ctx.allocator, "$this", args[0]);
     defer if (saved) |s| (ctx.vm.currentFrame().vars.put(ctx.allocator, "$this", s) catch {});
     return diFormat(ctx, args[1..]);
 }
 
-fn native_date_modify(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = argObj(args) orelse return .{ .bool = false };
-    if (args.len < 2 or args[1] != .string) return .{ .object = obj };
+fn native_date_modify(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = argObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2 or args[1] != .string) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const result = parseRelativeTime(args[1].string.bytes(), ts);
-    if (result != .int) return .{ .bool = false };
+    if (result != .int) return NativeResult.scalar(.{ .bool = false });
     if (isImmutable(obj)) {
         const new_obj = try ctx.createObject("DateTimeImmutable");
         try new_obj.set(ctx.allocator, "timestamp", result);
         if (obj.get("__timezone") == .string) try new_obj.set(ctx.allocator, "__timezone", obj.get("__timezone"));
-        return .{ .object = new_obj };
+        return NativeResult.borrowed(.{ .object = new_obj });
     }
     try obj.set(ctx.allocator, "timestamp", result);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn applyIntervalProc(ctx: *NativeContext, args: []const Value, sign: i64) RuntimeError!Value {
-    const obj = argObj(args) orelse return .{ .bool = false };
-    if (args.len < 2 or args[1] != .object) return .{ .object = obj };
+fn applyIntervalProc(ctx: *NativeContext, args: []const Value, sign: i64) RuntimeError!NativeResult {
+    const obj = argObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2 or args[1] != .object) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const new_ts = applyInterval(ts, args[1].object, sign);
     if (isImmutable(obj)) {
         const new_obj = try ctx.createObject("DateTimeImmutable");
         try new_obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
         if (obj.get("__timezone") == .string) try new_obj.set(ctx.allocator, "__timezone", obj.get("__timezone"));
-        return .{ .object = new_obj };
+        return NativeResult.borrowed(.{ .object = new_obj });
     }
     try obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_date_add(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_date_add(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return applyIntervalProc(ctx, args, 1);
 }
 
-fn native_date_sub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_date_sub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return applyIntervalProc(ctx, args, -1);
 }
 
-fn native_date_diff(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .object) return .{ .bool = false };
+fn native_date_diff(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .object) return NativeResult.scalar(.{ .bool = false });
     const synth = [_]Value{args[1]};
     const saved_this = ctx.vm.currentFrame().vars.get("$this");
     try ctx.vm.currentFrame().vars.put(ctx.allocator, "$this", args[0]);
@@ -1431,21 +1432,21 @@ fn native_date_diff(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     return dtDiff(ctx, &synth);
 }
 
-fn native_date_timestamp_get(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = argObj(args) orelse return .{ .bool = false };
-    return .{ .int = getTimestamp(obj) };
+fn native_date_timestamp_get(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = argObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = getTimestamp(obj) });
 }
 
-fn native_date_timestamp_set(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = argObj(args) orelse return .{ .bool = false };
-    if (args.len < 2) return .{ .object = obj };
+fn native_date_timestamp_set(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = argObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2) return NativeResult.borrowed(.{ .object = obj });
     try obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(args[1]) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_date_date_set(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = argObj(args) orelse return .{ .bool = false };
-    if (args.len < 4) return .{ .object = obj };
+fn native_date_date_set(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = argObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 4) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const epoch_secs: u64 = @intCast(if (ts < 0) 0 else ts);
     const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
@@ -1455,12 +1456,12 @@ fn native_date_date_set(ctx: *NativeContext, args: []const Value) RuntimeError!V
     const s: i64 = day_seconds.getSecondsIntoMinute();
     const new_ts = dateToTimestamp(Value.toInt(args[1]), Value.toInt(args[2]), Value.toInt(args[3]), h, m, s);
     try obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_date_time_set(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = argObj(args) orelse return .{ .bool = false };
-    if (args.len < 3) return .{ .object = obj };
+fn native_date_time_set(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = argObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3) return NativeResult.borrowed(.{ .object = obj });
     const ts = getTimestamp(obj);
     const epoch_secs: u64 = @intCast(if (ts < 0) 0 else ts);
     const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
@@ -1470,15 +1471,15 @@ fn native_date_time_set(ctx: *NativeContext, args: []const Value) RuntimeError!V
     const sec: i64 = if (args.len >= 4) Value.toInt(args[3]) else 0;
     const new_ts = dateToTimestamp(@intCast(year_day.year), month_day.month.numeric(), month_day.day_index + 1, Value.toInt(args[1]), Value.toInt(args[2]), sec);
     try obj.set(ctx.allocator, "timestamp", .{ .int = new_ts });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtiCreateFromFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn dtiCreateFromFormat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return createFromFormatImpl(ctx, args, "DateTimeImmutable");
 }
 
-fn createFromFormatImpl(ctx: *NativeContext, args: []const Value, default_class: []const u8) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn createFromFormatImpl(ctx: *NativeContext, args: []const Value, default_class: []const u8) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const format = args[0].string.bytes();
     const datetime = args[1].string.bytes();
 
@@ -1499,7 +1500,7 @@ fn createFromFormatImpl(ctx: *NativeContext, args: []const Value, default_class:
         ctx.vm.last_dt_error_count = 3;
         ctx.vm.last_dt_error_text = "Not enough data available to satisfy format";
         ctx.vm.last_dt_error_pos = @intCast(datetime.len);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     ctx.vm.last_dt_parse_failed = false;
     const obj = try ctx.createObject(class_name);
@@ -1509,19 +1510,20 @@ fn createFromFormatImpl(ctx: *NativeContext, args: []const Value, default_class:
     // tz arg to createFromFormat was ignored and DST/regional offsets were
     // wrong (everything treated as UTC)
     var final_ts = res.ts;
-    var tz_name_opt: ?[]const u8 = null;
+    var timezone: ?Value.String = null;
+    defer if (timezone) |name| name.release();
     if (res.tz_offset_seconds) |off| {
         const sign: u8 = if (off < 0) '-' else '+';
         const abs: u32 = @intCast(if (off < 0) -off else off);
         const hh = abs / 3600;
         const mm = (abs % 3600) / 60;
         const n = try std.fmt.allocPrint(ctx.allocator, "{c}{d:0>2}:{d:0>2}", .{ sign, hh, mm });
-        try ctx.strings.append(ctx.allocator, n);
-        tz_name_opt = n;
+        timezone = try Value.String.adopt(ctx.allocator, n);
     } else if (args.len >= 3 and args[2] == .object and std.mem.eql(u8, args[2].object.class_name, "DateTimeZone")) {
         const nv = args[2].object.get("timezone");
         if (nv == .string) {
-            tz_name_opt = nv.string.bytes();
+            nv.string.retain();
+            timezone = nv.string;
             // adjust timestamp: parseDateTimeFormat returned a UTC-interpreted
             // ts but the user meant the wall clock in the explicit zone.
             // subtract the zone's offset at that moment to get the real UTC ts
@@ -1530,9 +1532,9 @@ fn createFromFormatImpl(ctx: *NativeContext, args: []const Value, default_class:
         }
     }
     try obj.set(ctx.allocator, "timestamp", .{ .int = final_ts });
-    if (tz_name_opt) |n| try obj.set(ctx.allocator, "__timezone", .{ .string = Value.String.borrowed(n) });
+    if (timezone) |name| try obj.set(ctx.allocator, "__timezone", .{ .string = name });
     if (res.microseconds != 0) try obj.set(ctx.allocator, "__microseconds", .{ .int = res.microseconds });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 const ParsedDateTime = struct { ts: i64, tz_offset_seconds: ?i32, microseconds: i64 = 0 };
@@ -1821,60 +1823,61 @@ fn weekdayNameLen(s: []const u8) ?usize {
     return null;
 }
 
-fn dtiCreateFromTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn dtiCreateFromTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("DateTimeImmutable");
     try obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(args[0]) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtGetMicrosecond(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
+fn dtGetMicrosecond(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const v = obj.get("__microseconds");
-    if (v == .int) return v;
-    return .{ .int = 0 };
+    if (v == .int) return NativeResult.scalar(v);
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn dtSetMicrosecond(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dtSetMicrosecond(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and args[0] == .int) {
         try obj.set(ctx.allocator, "__microseconds", .{ .int = args[0].int });
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtGetTimezone(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dtGetTimezone(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const tz_val = obj.get("__timezone");
-    const tz_name = if (tz_val == .string) tz_val.string.bytes() else "UTC";
     const tz_obj = try ctx.createObject("DateTimeZone");
-    try tz_obj.set(ctx.allocator, "timezone", .{ .string = Value.String.borrowed(tz_name) });
-    return .{ .object = tz_obj };
+    try tz_obj.set(ctx.allocator, "timezone", if (tz_val == .string) tz_val else .{ .string = Value.String.borrowed("UTC") });
+    return NativeResult.borrowed(.{ .object = tz_obj });
 }
 
-fn dtGetOffset(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
+fn dtGetOffset(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const tz_val = obj.get("__timezone");
     const tz_name = if (tz_val == .string) tz_val.string.bytes() else "UTC";
     const ts = getTimestamp(obj);
-    return .{ .int = @intCast(tzOffsetForName(ctx.allocator, tz_name, ts)) };
+    return NativeResult.scalar(.{ .int = @intCast(tzOffsetForName(ctx.allocator, tz_name, ts)) });
 }
 
-fn dtSetTimezone(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const tz_name = extractTimezoneName(args);
-    try obj.set(ctx.allocator, "__timezone", .{ .string = Value.String.borrowed(tz_name) });
-    return .{ .object = obj };
+fn dtSetTimezone(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const timezone = try Value.String.create(ctx.allocator, extractTimezoneName(args));
+    defer timezone.release();
+    try obj.set(ctx.allocator, "__timezone", .{ .string = timezone });
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dtiSetTimezone(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const tz_name = extractTimezoneName(args);
+fn dtiSetTimezone(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const timezone = try Value.String.create(ctx.allocator, extractTimezoneName(args));
+    defer timezone.release();
     const new_obj = try ctx.createObject("DateTimeImmutable");
     const ts = obj.get("timestamp");
     try new_obj.set(ctx.allocator, "timestamp", if (ts == .null) .{ .int = 0 } else ts);
-    try new_obj.set(ctx.allocator, "__timezone", .{ .string = Value.String.borrowed(tz_name) });
-    return .{ .object = new_obj };
+    try new_obj.set(ctx.allocator, "__timezone", .{ .string = timezone });
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
 fn extractTimezoneName(args: []const Value) []const u8 {
@@ -1887,14 +1890,16 @@ fn extractTimezoneName(args: []const Value) []const u8 {
     return "UTC";
 }
 
-fn dtzConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dtzConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and args[0] == .string) {
         const name = args[0].string.bytes();
         // accept fixed-offset forms (+HH, +HH:MM, UTC, GMT) or known zones.
         // PHP normalizes fixed-offset input to '+HH:MM' / '-HH:MM' (e.g.
         // 'GMT+5' -> '+05:00'). zone names + 'UTC' / 'GMT' alone pass through
-        var stored: []const u8 = name;
+        var stored = args[0].string;
+        stored.retain();
+        defer stored.release();
         var is_named_passthrough = false;
         if (std.mem.eql(u8, name, "UTC") or std.mem.eql(u8, name, "GMT")) {
             is_named_passthrough = true;
@@ -1908,8 +1913,9 @@ fn dtzConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 const hh = abs / 3600;
                 const mm = (abs % 3600) / 60;
                 const n = try std.fmt.allocPrint(ctx.allocator, "{c}{d:0>2}:{d:0>2}", .{ sign, hh, mm });
-                try ctx.strings.append(ctx.allocator, n);
-                stored = n;
+                const normalized = try Value.String.adopt(ctx.allocator, n);
+                stored.release();
+                stored = normalized;
             } else {
                 const msg = try std.fmt.allocPrint(ctx.allocator, "DateTimeZone::__construct(): Unknown or bad timezone ({s})", .{name});
                 try ctx.strings.append(ctx.allocator, msg);
@@ -1917,12 +1923,12 @@ fn dtzConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 return error.RuntimeError;
             }
         }
-        try obj.set(ctx.allocator, "timezone", .{ .string = Value.String.borrowed(try ctx.createString(stored)) });
+        try obj.set(ctx.allocator, "timezone", .{ .string = stored });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dtzListIdentifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn dtzListIdentifiers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // full IANA zone list (419 entries) matching PHP 8.4's tzdb snapshot. used
     // for membership checks in user code that whitelists allowed zones; the
     // names themselves are also valid `DateTimeZone` constructor inputs
@@ -2070,10 +2076,10 @@ fn dtzListIdentifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value 
     };
     var arr = try ctx.createArray();
     for (ids) |id| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(id) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn dtzListAbbreviations(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn dtzListAbbreviations(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     // PHP keys are lowercase abbreviation strings; each value is a list of
     // {dst, offset, timezone_id} entries. iterate our tz_table and emit one
@@ -2086,17 +2092,19 @@ fn dtzListAbbreviations(ctx: *NativeContext, _: []const Value) RuntimeError!Valu
         // emit std side
         if (z.std_abbrev.len > 0 and z.std_abbrev.len < key_buf.len) {
             for (z.std_abbrev, 0..) |c, i| key_buf[i] = std.ascii.toLower(c);
-            const key = try ctx.allocator.dupe(u8, key_buf[0..z.std_abbrev.len]);
-            try ctx.vm.strings.append(ctx.allocator, key);
+            const key = try Value.String.create(ctx.allocator, key_buf[0..z.std_abbrev.len]);
+            defer key.release();
             const canonical = try canonicalizeZoneName(ctx, z.name);
+            defer canonical.release();
             try appendAbbrevEntry(ctx, arr, key, false, z.std_offset, canonical);
         }
         // emit dst side only when distinct
         if (z.dst_rule != .none and z.dst_abbrev.len > 0 and !std.mem.eql(u8, z.std_abbrev, z.dst_abbrev) and z.dst_abbrev.len < key_buf.len) {
             for (z.dst_abbrev, 0..) |c, i| key_buf[i] = std.ascii.toLower(c);
-            const key = try ctx.allocator.dupe(u8, key_buf[0..z.dst_abbrev.len]);
-            try ctx.vm.strings.append(ctx.allocator, key);
+            const key = try Value.String.create(ctx.allocator, key_buf[0..z.dst_abbrev.len]);
+            defer key.release();
             const canonical = try canonicalizeZoneName(ctx, z.name);
+            defer canonical.release();
             try appendAbbrevEntry(ctx, arr, key, true, z.dst_offset, canonical);
         }
     }
@@ -2121,20 +2129,20 @@ fn dtzListAbbreviations(ctx: *NativeContext, _: []const Value) RuntimeError!Valu
     };
     for (military) |m| {
         if (arr.get(.{ .string = Value.String.borrowed(&[_]u8{m.c}) }) != .null) continue;
-        const key = try ctx.allocator.dupe(u8, &[_]u8{m.c});
-        try ctx.vm.strings.append(ctx.allocator, key);
+        const key = try Value.String.create(ctx.allocator, &[_]u8{m.c});
+        defer key.release();
         const list = try ctx.createArray();
         const entry = try ctx.createArray();
         try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("dst") }, .{ .bool = false });
         try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("offset") }, .{ .int = @as(i64, m.off) });
         try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("timezone_id") }, .null);
         try list.append(ctx.allocator, .{ .array = entry });
-        try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(key) }, .{ .array = list });
+        try arr.set(ctx.allocator, .{ .string = key }, .{ .array = list });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn canonicalizeZoneName(ctx: *NativeContext, lower_name: []const u8) ![]const u8 {
+fn canonicalizeZoneName(ctx: *NativeContext, lower_name: []const u8) !Value.String {
     // turn "america/new_york" into "America/New_York"
     const out = try ctx.allocator.dupe(u8, lower_name);
     var capitalize_next = true;
@@ -2146,35 +2154,34 @@ fn canonicalizeZoneName(ctx: *NativeContext, lower_name: []const u8) ![]const u8
             capitalize_next = false;
         }
     }
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return out;
+    return Value.String.adopt(ctx.allocator, out);
 }
 
-fn appendAbbrevEntry(ctx: *NativeContext, outer: *@import("../runtime/value.zig").PhpArray, key: []const u8, dst: bool, offset: i32, tz_id: []const u8) !void {
+fn appendAbbrevEntry(ctx: *NativeContext, outer: *@import("../runtime/value.zig").PhpArray, key: Value.String, dst: bool, offset: i32, tz_id: Value.String) !void {
     const PA = @import("../runtime/value.zig").PhpArray;
     var list: *PA = undefined;
-    const existing = outer.get(.{ .string = Value.String.borrowed(key) });
+    const existing = outer.get(.{ .string = key });
     if (existing == .array) {
         list = existing.array;
     } else {
         list = try ctx.createArray();
-        try outer.set(ctx.allocator, .{ .string = Value.String.borrowed(key) }, .{ .array = list });
+        try outer.set(ctx.allocator, .{ .string = key }, .{ .array = list });
     }
     const entry = try ctx.createArray();
     try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("dst") }, .{ .bool = dst });
     try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("offset") }, .{ .int = @as(i64, offset) });
-    try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("timezone_id") }, .{ .string = Value.String.borrowed(tz_id) });
+    try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("timezone_id") }, .{ .string = tz_id });
     try list.append(ctx.allocator, .{ .array = entry });
 }
 
-fn dtzGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("UTC") };
+fn dtzGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("UTC");
     const tz_val = obj.get("timezone");
-    return if (tz_val == .string) tz_val else .{ .string = Value.String.borrowed("UTC") };
+    return if (tz_val == .string) NativeResult.shareString(tz_val.string) else NativeResult.literal("UTC");
 }
 
-fn dtzGetOffset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
+fn dtzGetOffset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const tz_val = obj.get("timezone");
     const tz_name = if (tz_val == .string) tz_val.string.bytes() else "UTC";
 
@@ -2184,29 +2191,29 @@ fn dtzGetOffset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         ref_ts = getTimestamp(args[0].object);
     }
 
-    return .{ .int = @intCast(tzOffsetForName(ctx.allocator, tz_name, ref_ts)) };
+    return NativeResult.scalar(.{ .int = @intCast(tzOffsetForName(ctx.allocator, tz_name, ref_ts)) });
 }
 
 // PHP's getLocation returns {country_code, latitude, longitude, comments}
 // for named tz, and false for offset-only zones. zphp doesn't ship the IANA
 // tzdata, so named zones return placeholder data with the right structure
-fn dtzGetLocation(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn dtzGetLocation(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const tz_val = obj.get("timezone");
     const tz_name = if (tz_val == .string) tz_val.string.bytes() else "UTC";
     // offset-only zones report false
-    if (tz_name.len > 0 and (tz_name[0] == '+' or tz_name[0] == '-')) return .{ .bool = false };
+    if (tz_name.len > 0 and (tz_name[0] == '+' or tz_name[0] == '-')) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("country_code") }, .{ .string = Value.String.borrowed("??") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("latitude") }, .{ .float = 0.0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("longitude") }, .{ .float = 0.0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("comments") }, .{ .string = Value.String.borrowed("") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // stub that returns an empty list - we don't track historical transitions
-fn dtzGetTransitions(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .array = try ctx.createArray() };
+fn dtzGetTransitions(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
 // standalone PHP functions: date(), mktime(), strtotime(), time(), microtime()
@@ -2237,14 +2244,14 @@ fn appendOffsetCompact(buf: *std.ArrayListUnmanaged(u8), a: Allocator, offset: i
     try buf.appendSlice(a, s);
 }
 
-fn native_date(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_date(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const format = args[0].string.bytes();
     const timestamp: i64 = if (args.len >= 2) Value.toInt(args[1]) else std.time.timestamp();
     return formatTimestamp(ctx, timestamp, format);
 }
 
-fn native_mktime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_mktime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const hour: i64 = if (args.len > 0) Value.toInt(args[0]) else 0;
     const min: i64 = if (args.len > 1) Value.toInt(args[1]) else 0;
     const sec: i64 = if (args.len > 2) Value.toInt(args[2]) else 0;
@@ -2253,46 +2260,46 @@ fn native_mktime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const year: i64 = if (args.len > 5) Value.toInt(args[5]) else 1970;
     var ts = dateToTimestamp(year, month, day, hour, min, sec);
     ts -= @as(i64, tzOffsetForWallByName(ctx.allocator, ctx.vm.default_tz_name, ts));
-    return .{ .int = ts };
+    return NativeResult.scalar(.{ .int = ts });
 }
 
-fn native_gmmktime(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_gmmktime(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const hour: i64 = if (args.len > 0) Value.toInt(args[0]) else 0;
     const min: i64 = if (args.len > 1) Value.toInt(args[1]) else 0;
     const sec: i64 = if (args.len > 2) Value.toInt(args[2]) else 0;
     const month: i64 = if (args.len > 3) Value.toInt(args[3]) else 1;
     const day: i64 = if (args.len > 4) Value.toInt(args[4]) else 1;
     const year: i64 = if (args.len > 5) Value.toInt(args[5]) else 1970;
-    return .{ .int = dateToTimestamp(year, month, day, hour, min, sec) };
+    return NativeResult.scalar(.{ .int = dateToTimestamp(year, month, day, hour, min, sec) });
 }
 
-fn native_strtotime(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_strtotime(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const input = args[0].string.bytes();
     const base: i64 = if (args.len >= 2) Value.toInt(args[1]) else std.time.timestamp();
 
     // @timestamp - unix timestamp literal
     if (input.len >= 2 and input[0] == '@') {
-        const ts = std.fmt.parseInt(i64, input[1..], 10) catch return Value{ .bool = false };
-        return .{ .int = ts };
+        const ts = std.fmt.parseInt(i64, input[1..], 10) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .int = ts });
     }
 
     // ISO 8601 week date: YYYY-Www-D (e.g. 2024-W10-1) or YYYY-Www (Monday)
     if (input.len >= 8 and input[4] == '-' and (input[5] == 'W' or input[5] == 'w') and input[6] >= '0' and input[6] <= '9' and input[7] >= '0' and input[7] <= '9') {
-        const year = std.fmt.parseInt(i64, input[0..4], 10) catch return Value{ .bool = false };
-        const week = std.fmt.parseInt(i64, input[6..8], 10) catch return Value{ .bool = false };
+        const year = std.fmt.parseInt(i64, input[0..4], 10) catch return NativeResult.scalar(.{ .bool = false });
+        const week = std.fmt.parseInt(i64, input[6..8], 10) catch return NativeResult.scalar(.{ .bool = false });
         var dow: i64 = 1;
         if (input.len >= 10 and input[8] == '-' and input[9] >= '1' and input[9] <= '7') {
             dow = input[9] - '0';
         }
-        return .{ .int = isoWeekDateToTimestamp(year, week, dow, 0, 0, 0) };
+        return NativeResult.scalar(.{ .int = isoWeekDateToTimestamp(year, week, dow, 0, 0, 0) });
     }
 
     // YYYY-MM-DD with optional time (space or T separator) and optional timezone
     if (input.len >= 10 and input[4] == '-' and input[7] == '-') {
-        const year = std.fmt.parseInt(i64, input[0..4], 10) catch return Value{ .bool = false };
-        const month = std.fmt.parseInt(i64, input[5..7], 10) catch return Value{ .bool = false };
-        const day = std.fmt.parseInt(i64, input[8..10], 10) catch return Value{ .bool = false };
+        const year = std.fmt.parseInt(i64, input[0..4], 10) catch return NativeResult.scalar(.{ .bool = false });
+        const month = std.fmt.parseInt(i64, input[5..7], 10) catch return NativeResult.scalar(.{ .bool = false });
+        const day = std.fmt.parseInt(i64, input[8..10], 10) catch return NativeResult.scalar(.{ .bool = false });
         var hour: i64 = 0;
         var min: i64 = 0;
         var sec: i64 = 0;
@@ -2338,14 +2345,14 @@ fn native_strtotime(_: *NativeContext, args: []const Value) RuntimeError!Value {
             const rel = parseRelativeTime(trailing, base_ts);
             if (rel == .int) base_ts = rel.int;
         }
-        return .{ .int = base_ts };
+        return NativeResult.scalar(.{ .int = base_ts });
     }
 
     // YYYY/MM/DD slash date (PHP accepts this alongside YYYY-MM-DD)
     if (input.len >= 10 and input[4] == '/' and input[7] == '/') {
-        const year = std.fmt.parseInt(i64, input[0..4], 10) catch return Value{ .bool = false };
-        const month = std.fmt.parseInt(i64, input[5..7], 10) catch return Value{ .bool = false };
-        const day = std.fmt.parseInt(i64, input[8..10], 10) catch return Value{ .bool = false };
+        const year = std.fmt.parseInt(i64, input[0..4], 10) catch return NativeResult.scalar(.{ .bool = false });
+        const month = std.fmt.parseInt(i64, input[5..7], 10) catch return NativeResult.scalar(.{ .bool = false });
+        const day = std.fmt.parseInt(i64, input[8..10], 10) catch return NativeResult.scalar(.{ .bool = false });
         var hour: i64 = 0;
         var min: i64 = 0;
         var sec: i64 = 0;
@@ -2354,14 +2361,14 @@ fn native_strtotime(_: *NativeContext, args: []const Value) RuntimeError!Value {
             min = std.fmt.parseInt(i64, input[14..16], 10) catch 0;
             sec = std.fmt.parseInt(i64, input[17..19], 10) catch 0;
         }
-        return .{ .int = dateToTimestamp(year, month, day, hour, min, sec) };
+        return NativeResult.scalar(.{ .int = dateToTimestamp(year, month, day, hour, min, sec) });
     }
 
     // MM/DD/YYYY US date format with optional timezone
     if (input.len >= 10 and input[2] == '/' and input[5] == '/') {
-        const month = std.fmt.parseInt(i64, input[0..2], 10) catch return Value{ .bool = false };
-        const day = std.fmt.parseInt(i64, input[3..5], 10) catch return Value{ .bool = false };
-        const year = std.fmt.parseInt(i64, input[6..10], 10) catch return Value{ .bool = false };
+        const month = std.fmt.parseInt(i64, input[0..2], 10) catch return NativeResult.scalar(.{ .bool = false });
+        const day = std.fmt.parseInt(i64, input[3..5], 10) catch return NativeResult.scalar(.{ .bool = false });
+        const year = std.fmt.parseInt(i64, input[6..10], 10) catch return NativeResult.scalar(.{ .bool = false });
         var hour: i64 = 0;
         var min: i64 = 0;
         var sec: i64 = 0;
@@ -2376,7 +2383,7 @@ fn native_strtotime(_: *NativeContext, args: []const Value) RuntimeError!Value {
                 if (parseTimezoneOffset(rest)) |off| tz_offset = off;
             }
         }
-        return .{ .int = dateToTimestamp(year, month, day, hour, min, sec) - tz_offset };
+        return NativeResult.scalar(.{ .int = dateToTimestamp(year, month, day, hour, min, sec) - tz_offset });
     }
 
     // DD.MM.YYYY EU date format
@@ -2393,7 +2400,7 @@ fn native_strtotime(_: *NativeContext, args: []const Value) RuntimeError!Value {
                 min = std.fmt.parseInt(i64, input[14..16], 10) catch 0;
                 sec = std.fmt.parseInt(i64, input[17..19], 10) catch 0;
             }
-            return .{ .int = dateToTimestamp(year.?, month.?, day.?, hour, min, sec) };
+            return NativeResult.scalar(.{ .int = dateToTimestamp(year.?, month.?, day.?, hour, min, sec) });
         }
     }
 
@@ -2415,24 +2422,24 @@ fn native_strtotime(_: *NativeContext, args: []const Value) RuntimeError!Value {
                 min = std.fmt.parseInt(i64, input[14..16], 10) catch 0;
                 sec = std.fmt.parseInt(i64, input[17..19], 10) catch 0;
             }
-            return .{ .int = dateToTimestamp(year.?, month.?, day.?, hour, min, sec) };
+            return NativeResult.scalar(.{ .int = dateToTimestamp(year.?, month.?, day.?, hour, min, sec) });
         }
     }
 
     // RFC 2822: "Mon, 15 Jan 2025 10:30:45 +0000" or "15 Jan 2025 10:30:45 GMT"
-    if (tryParseRfc2822(input)) |ts| return .{ .int = ts };
+    if (tryParseRfc2822(input)) |ts| return NativeResult.scalar(.{ .int = ts });
 
     // textual month dates: "January 15, 2025", "Jan 15, 2025", "Jan 15 2025", "15 Jan 2025"
-    if (tryParseTextualDate(input)) |ts| return .{ .int = ts };
+    if (tryParseTextualDate(input)) |ts| return NativeResult.scalar(.{ .int = ts });
 
     // bare time-of-day ("14:30", "2:30pm", "09:15:00") - PHP keeps base's
     // calendar date and replaces the time
     if (tryParseBareTime(input)) |tod| {
         const dc = baseComponents(base);
-        return .{ .int = dateToTimestamp(dc.year, dc.month, dc.day, tod.hour, tod.min, tod.sec) };
+        return NativeResult.scalar(.{ .int = dateToTimestamp(dc.year, dc.month, dc.day, tod.hour, tod.min, tod.sec) });
     }
 
-    return parseRelativeTime(input, base);
+    return NativeResult.scalar(parseRelativeTime(input, base));
 }
 
 // returns a TimeOfDay only when the whole input is a standalone time, i.e.
@@ -2541,39 +2548,39 @@ fn parseTrailingTime(rest: []const u8) TimeOfDay {
     return parseTimeOfDay(s) orelse TimeOfDay{ .hour = 0, .min = 0, .sec = 0 };
 }
 
-fn native_time(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = std.time.timestamp() };
+fn native_time(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = std.time.timestamp() });
 }
 
-fn native_checkdate(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .{ .bool = false };
+fn native_checkdate(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.{ .bool = false });
     const month = Value.toInt(args[0]);
     const day = Value.toInt(args[1]);
     const year = Value.toInt(args[2]);
-    if (year < 1 or year > 32767 or month < 1 or month > 12 or day < 1) return .{ .bool = false };
+    if (year < 1 or year > 32767 or month < 1 or month > 12 or day < 1) return NativeResult.scalar(.{ .bool = false });
     const days_in_month = [_]i64{ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
     var max_day = days_in_month[@intCast(month - 1)];
     if (month == 2) {
         const y: u32 = @intCast(year);
         if (y % 4 == 0 and (y % 100 != 0 or y % 400 == 0)) max_day = 29;
     }
-    return .{ .bool = day <= max_day };
+    return NativeResult.scalar(.{ .bool = day <= max_day });
 }
 
-fn native_cal_days_in_month(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_cal_days_in_month(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // cal_days_in_month($calendar, $month, $year). only CAL_GREGORIAN (0) is
     // commonly used; zphp treats every calendar id as Gregorian
-    if (args.len < 3) return .{ .bool = false };
+    if (args.len < 3) return NativeResult.scalar(.{ .bool = false });
     const month = Value.toInt(args[1]);
     const year = Value.toInt(args[2]);
     if (month < 1 or month > 12) {
         try ctx.vm.setPendingException("ValueError", "Invalid date");
         return error.RuntimeError;
     }
-    return .{ .int = daysInMonth(month, year) };
+    return NativeResult.scalar(.{ .int = daysInMonth(month, year) });
 }
 
-fn buildDateParseResult(ctx: *NativeContext, year: ?i64, month: ?i64, day: ?i64, hour: ?i64, minute: ?i64, second: ?i64, fraction: f64, errors: []const []const u8) !Value {
+fn buildDateParseResult(ctx: *NativeContext, year: ?i64, month: ?i64, day: ?i64, hour: ?i64, minute: ?i64, second: ?i64, fraction: f64, errors: []const []const u8) RuntimeError!NativeResult {
     const PhpArray = @import("../runtime/value.zig").PhpArray;
     var arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("year") }, if (year) |y| .{ .int = y } else .{ .bool = false });
@@ -2595,11 +2602,11 @@ fn buildDateParseResult(ctx: *NativeContext, year: ?i64, month: ?i64, day: ?i64,
     for (errors, 0..) |e, i| try errs.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .string = Value.String.borrowed(e) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("errors") }, .{ .array = errs });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("is_localtime") }, .{ .bool = false });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_date_parse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_date_parse(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     var year: ?i64 = null;
     var month: ?i64 = null;
@@ -2624,8 +2631,8 @@ fn native_date_parse(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     return buildDateParseResult(ctx, year, month, day, hour, minute, second, 0.0, &.{});
 }
 
-fn native_date_parse_from_format(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_date_parse_from_format(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const format = args[0].string.bytes();
     const datetime = args[1].string.bytes();
 
@@ -2852,7 +2859,7 @@ fn native_date_parse_from_format(ctx: *NativeContext, args: []const Value) Runti
     return buildDateParseResultOpt(ctx, year, month, day, hour, minute, second, fraction, errors_buf[0..n_errors]);
 }
 
-fn buildDateParseResultOpt(ctx: *NativeContext, year: ?i64, month: ?i64, day: ?i64, hour: ?i64, minute: ?i64, second: ?i64, fraction: ?f64, errors: []const []const u8) !Value {
+fn buildDateParseResultOpt(ctx: *NativeContext, year: ?i64, month: ?i64, day: ?i64, hour: ?i64, minute: ?i64, second: ?i64, fraction: ?f64, errors: []const []const u8) RuntimeError!NativeResult {
     const PhpArray = @import("../runtime/value.zig").PhpArray;
     var arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("year") }, if (year) |y| .{ .int = y } else .{ .bool = false });
@@ -2874,10 +2881,10 @@ fn buildDateParseResultOpt(ctx: *NativeContext, year: ?i64, month: ?i64, day: ?i
     for (errors, 0..) |e, i| try errs.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .string = Value.String.borrowed(e) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("errors") }, .{ .array = errs });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("is_localtime") }, .{ .bool = false });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_getdate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_getdate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const timestamp: i64 = if (args.len >= 1) Value.toInt(args[0]) else std.time.timestamp();
     const epoch_secs: u64 = @intCast(if (timestamp < 0) 0 else timestamp);
     const es = std.time.epoch.EpochSeconds{ .secs = epoch_secs };
@@ -2904,33 +2911,34 @@ fn native_getdate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("weekday") }, .{ .string = Value.String.borrowed(([_][]const u8{ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" })[@intCast(dow)]) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("month") }, .{ .string = Value.String.borrowed(([_][]const u8{ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" })[@intCast(month_day.month.numeric() - 1)]) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("0") }, .{ .int = timestamp });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_hrtime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_hrtime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const as_int = args.len >= 1 and args[0].isTruthy();
     const ns = std.time.nanoTimestamp();
     if (as_int) {
-        return .{ .int = @intCast(ns) };
+        return NativeResult.scalar(.{ .int = @intCast(ns) });
     }
     const secs: i64 = @intCast(@divTrunc(ns, 1_000_000_000));
     const remainder: i64 = @intCast(@mod(ns, 1_000_000_000));
     var arr = try ctx.createArray();
     try arr.append(ctx.allocator, .{ .int = secs });
     try arr.append(ctx.allocator, .{ .int = remainder });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_microtime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_microtime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const as_float = args.len >= 1 and args[0].isTruthy();
     const ns = std.time.nanoTimestamp();
     if (as_float) {
         const secs: f64 = @as(f64, @floatFromInt(ns)) / 1_000_000_000.0;
-        return .{ .float = secs };
+        return NativeResult.scalar(.{ .float = secs });
     }
     const ts: i64 = @intCast(@divTrunc(ns, 1_000_000_000));
     const usec: i64 = @intCast(@divTrunc(@mod(ns, 1_000_000_000), 1_000));
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var tmp: [32]u8 = undefined;
     try buf.appendSlice(ctx.allocator, "0.");
     const usec_str = std.fmt.bufPrint(&tmp, "{d:0>6}", .{@as(u64, @intCast(if (usec < 0) -usec else usec))}) catch "000000";
@@ -2939,8 +2947,7 @@ fn native_microtime(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     const ts_str = std.fmt.bufPrint(&tmp, "{d}", .{ts}) catch "0";
     try buf.appendSlice(ctx.allocator, ts_str);
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 // date/time utilities
@@ -4324,42 +4331,42 @@ fn startsWith(s: []const u8, prefix: []const u8) bool {
 }
 
 // gmdate is identical to date since zphp timestamps are always UTC
-fn native_gmdate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_gmdate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const format = args[0].string.bytes();
     const timestamp: i64 = if (args.len >= 2) Value.toInt(args[1]) else std.time.timestamp();
     return formatTimestampTz(ctx, timestamp, format, 0, "UTC");
 }
 
-fn native_tz_set(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_tz_set(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     if (lookupTimezone(name)) |_| {
         ctx.vm.default_tz_name = name;
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_timezone_name_get(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
+fn native_timezone_name_get(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].object.get("timezone");
-    if (name == .string) return name;
-    return .{ .string = Value.String.borrowed("UTC") };
+    if (name == .string) return NativeResult.shareString(name.string);
+    return NativeResult.literal("UTC");
 }
 
-fn native_timezone_offset_get(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .object) return .{ .bool = false };
+fn native_timezone_offset_get(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .object) return NativeResult.scalar(.{ .bool = false });
     const tz_obj = args[0].object;
     const dt_obj = args[1].object;
     const tz_name = if (tz_obj.get("timezone") == .string) tz_obj.get("timezone").string.bytes() else "UTC";
     const ts = getTimestamp(dt_obj);
-    if (lookupTimezone(tz_name)) |tz| return .{ .int = @intCast(tzOffsetAt(tz, ts)) };
-    return .{ .int = 0 };
+    if (lookupTimezone(tz_name)) |tz| return NativeResult.scalar(.{ .int = @intCast(tzOffsetAt(tz, ts)) });
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_timezone_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_timezone_open(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     // validate against the same rules as DateTimeZone::__construct: accept
     // fixed-offset forms (+HH, +HH:MM, UTC, GMT) and known IANA zones. on
@@ -4371,39 +4378,39 @@ fn native_timezone_open(ctx: *NativeContext, args: []const Value) RuntimeError!V
         break :blk false;
     };
     if (!valid) {
-        const msg = std.fmt.allocPrint(ctx.allocator, "timezone_open(): Unknown or bad timezone ({s})", .{name}) catch return .{ .bool = false };
+        const msg = std.fmt.allocPrint(ctx.allocator, "timezone_open(): Unknown or bad timezone ({s})", .{name}) catch return NativeResult.scalar(.{ .bool = false });
         ctx.vm.strings.append(ctx.allocator, msg) catch {};
         ctx.vm.emitWarning(msg);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const obj = try ctx.createObject("DateTimeZone");
     try obj.set(ctx.allocator, "timezone", args[0]);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_date_timezone_get(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
+fn native_date_timezone_get(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const tz_v = args[0].object.get("__timezone");
-    if (tz_v != .string) return .{ .bool = false };
+    if (tz_v != .string) return NativeResult.scalar(.{ .bool = false });
     const tz_obj = try ctx.createObject("DateTimeZone");
     try tz_obj.set(ctx.allocator, "timezone", tz_v);
-    return .{ .object = tz_obj };
+    return NativeResult.borrowed(.{ .object = tz_obj });
 }
 
-fn native_date_timezone_set(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .object) return .{ .bool = false };
+fn native_date_timezone_set(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .object) return NativeResult.scalar(.{ .bool = false });
     const tz_name = args[1].object.get("timezone");
     if (tz_name == .string) {
         try args[0].object.set(ctx.allocator, "__timezone", tz_name);
     }
-    return args[0];
+    return NativeResult.share(args[0]);
 }
 
-fn native_tz_get(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed(ctx.vm.default_tz_name) };
+fn native_tz_get(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return try NativeResult.copyString(ctx.allocator, ctx.vm.default_tz_name);
 }
 
-fn native_localtime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_localtime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const timestamp: i64 = if (args.len >= 1) Value.toInt(args[0]) else std.time.timestamp();
     const assoc = args.len >= 2 and args[1].isTruthy();
     const epoch_secs: u64 = @intCast(if (timestamp < 0) 0 else timestamp);
@@ -4442,11 +4449,11 @@ fn native_localtime(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         try arr.append(ctx.allocator, .{ .int = yday });
         try arr.append(ctx.allocator, .{ .int = 0 });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_idate(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string or args[0].string.bytes().len == 0) return .{ .bool = false };
+fn native_idate(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string or args[0].string.bytes().len == 0) return NativeResult.scalar(.{ .bool = false });
     const fmt = args[0].string.bytes()[0];
     const timestamp: i64 = if (args.len >= 2) Value.toInt(args[1]) else std.time.timestamp();
     const epoch_secs: u64 = @intCast(if (timestamp < 0) 0 else timestamp);
@@ -4479,9 +4486,9 @@ fn native_idate(_: *NativeContext, args: []const Value) RuntimeError!Value {
         'N' => if (dow == 0) @as(i64, 7) else dow, // ISO 8601 day of week, Monday=1..Sunday=7
         'B' => @intCast(@mod(@divTrunc(day_seconds.secs, 86), 1000)), // Swatch internet time (rough)
         'Z' => 0, // timezone offset in seconds; without TZ context, default to UTC
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
-    return .{ .int = v };
+    return NativeResult.scalar(.{ .int = v });
 }
 
 fn isLeapYear(y: u16) bool {
@@ -4534,8 +4541,8 @@ fn parseIsoDuration(spec: []const u8) IsoDuration {
     return result;
 }
 
-fn diConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn diConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0 and args[0] == .string) {
         const dur = parseIsoDuration(args[0].string.bytes());
         try obj.set(ctx.allocator, "y", .{ .int = dur.y });
@@ -4548,11 +4555,11 @@ fn diConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     try obj.set(ctx.allocator, "invert", .{ .int = 0 });
     try obj.set(ctx.allocator, "days", .{ .bool = false });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn diCreateFromDateString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn diCreateFromDateString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const dur = parseRelativeDuration(args[0].string.bytes());
     const obj = try ctx.createObject("DateInterval");
     try obj.set(ctx.allocator, "y", .{ .int = dur.y });
@@ -4564,7 +4571,7 @@ fn diCreateFromDateString(ctx: *NativeContext, args: []const Value) RuntimeError
     try obj.set(ctx.allocator, "f", .{ .float = 0 });
     try obj.set(ctx.allocator, "invert", .{ .int = 0 });
     try obj.set(ctx.allocator, "days", .{ .bool = false });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 const RelDuration = struct { y: i64 = 0, m: i64 = 0, d: i64 = 0, h: i64 = 0, mi: i64 = 0, s: i64 = 0 };
@@ -4622,9 +4629,9 @@ fn matchUnit(actual: []const u8, base: []const u8) bool {
     return false;
 }
 
-fn diFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn diFormat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const fmt = args[0].string.bytes();
 
     // raw signed values (PHP's lowercase %d/%h/etc print signed values for
@@ -4692,16 +4699,14 @@ fn diFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
 
-    const dup = try ctx.allocator.dupe(u8, buf.items);
-    try ctx.strings.append(ctx.allocator, dup);
-    return .{ .string = Value.String.borrowed(dup) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice()));
 }
 
-fn diInvert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn diInvert(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0) {
         const invert = if (args[0] == .bool) (if (args[0].bool) @as(i64, 1) else @as(i64, 0)) else if (args[0] == .int) (if (args[0].int != 0) @as(i64, 1) else @as(i64, 0)) else @as(i64, 0);
         try obj.set(ctx.allocator, "invert", .{ .int = invert });
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }

--- a/src/stdlib/dom.zig
+++ b/src/stdlib/dom.zig
@@ -3,12 +3,13 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
-const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!Value;
+const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!NativeResult;
 
 const c = @cImport({
     @cInclude("libxml/parser.h");
@@ -152,10 +153,10 @@ fn cstrLen(p: [*c]const u8) usize {
     return std.mem.len(p);
 }
 
-fn cstrToValue(ctx: *NativeContext, p: [*c]const u8) !Value {
-    if (p == null) return .null;
+fn cstrToValue(ctx: *NativeContext, p: [*c]const u8) RuntimeError!NativeResult {
+    if (p == null) return NativeResult.scalar(.null);
     const slice = p[0..cstrLen(p)];
-    return .{ .string = Value.String.borrowed(try dupString(ctx, slice)) };
+    return try NativeResult.copyString(ctx.allocator, slice);
 }
 
 // ---------------- class name dispatch by xmlElementType ----------------
@@ -197,9 +198,9 @@ fn getOwnerDocObj(obj: *PhpObject) ?*PhpObject {
 
 // ---------------- DOMDocument methods ----------------
 
-fn domDocConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn domDocConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureGlobalInit();
-    const obj = getThis(ctx) orelse return .null;
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     var version: []const u8 = "1.0";
     var encoding: []const u8 = "";
@@ -207,7 +208,7 @@ fn domDocConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     if (args.len > 1 and args[1] == .string) encoding = args[1].string.bytes();
 
     const version_z = try dupZ(ctx, version);
-    const doc = c.xmlNewDoc(@ptrCast(version_z.ptr)) orelse return .null;
+    const doc = c.xmlNewDoc(@ptrCast(version_z.ptr)) orelse return NativeResult.scalar(.null);
     if (encoding.len > 0) {
         const enc_z = try dupZ(ctx, encoding);
         doc.*.encoding = c.xmlStrdup(@ptrCast(enc_z.ptr));
@@ -221,7 +222,7 @@ fn domDocConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     try obj.set(ctx.allocator, "substituteEntities", .{ .bool = false });
     try obj.set(ctx.allocator, "strictErrorChecking", .{ .bool = true });
     try obj.set(ctx.allocator, "recover", .{ .bool = false });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn parseOptions(args: []const Value, idx: usize) c_int {
@@ -229,9 +230,9 @@ fn parseOptions(args: []const Value, idx: usize) c_int {
     return 0;
 }
 
-fn domDocLoadXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domDocLoadXML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const src = args[0].string.bytes();
     const opts = parseOptions(args, 1);
 
@@ -242,28 +243,28 @@ fn domDocLoadXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     const doc = c.xmlReadMemory(src.ptr, @intCast(src.len), null, null, opts);
-    if (doc == null) return .{ .bool = false };
+    if (doc == null) return NativeResult.scalar(.{ .bool = false });
     try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn domDocSchemaValidateSource(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocSchemaValidateSource(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const source = args[0].string.bytes();
-    const parser_ctx = c.xmlSchemaNewMemParserCtxt(source.ptr, @intCast(source.len)) orelse return .{ .bool = false };
+    const parser_ctx = c.xmlSchemaNewMemParserCtxt(source.ptr, @intCast(source.len)) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.xmlSchemaFreeParserCtxt(parser_ctx);
-    const schema = c.xmlSchemaParse(parser_ctx) orelse return .{ .bool = false };
+    const schema = c.xmlSchemaParse(parser_ctx) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.xmlSchemaFree(schema);
-    const valid_ctx = c.xmlSchemaNewValidCtxt(schema) orelse return .{ .bool = false };
+    const valid_ctx = c.xmlSchemaNewValidCtxt(schema) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.xmlSchemaFreeValidCtxt(valid_ctx);
-    return .{ .bool = c.xmlSchemaValidateDoc(valid_ctx, doc) == 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlSchemaValidateDoc(valid_ctx, doc) == 0 });
 }
 
-fn domDocLoad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domDocLoad(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
     const opts = parseOptions(args, 1);
 
@@ -273,14 +274,14 @@ fn domDocLoad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     const doc = c.xmlReadFile(path_z.ptr, null, opts);
-    if (doc == null) return .{ .bool = false };
+    if (doc == null) return NativeResult.scalar(.{ .bool = false });
     try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn domDocLoadHTML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domDocLoadHTML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const src = args[0].string.bytes();
     const opts = parseOptions(args, 1);
 
@@ -290,14 +291,14 @@ fn domDocLoadHTML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     const doc = c.htmlReadMemory(src.ptr, @intCast(src.len), null, null, opts);
-    if (doc == null) return .{ .bool = false };
+    if (doc == null) return NativeResult.scalar(.{ .bool = false });
     try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn domDocLoadHTMLFile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domDocLoadHTMLFile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
     const opts = parseOptions(args, 1);
 
@@ -307,9 +308,9 @@ fn domDocLoadHTMLFile(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     }
 
     const doc = c.htmlReadFile(path_z.ptr, null, opts);
-    if (doc == null) return .{ .bool = false };
+    if (doc == null) return NativeResult.scalar(.{ .bool = false });
     try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn formatOutputOn(obj: *PhpObject) bool {
@@ -317,9 +318,9 @@ fn formatOutputOn(obj: *PhpObject) bool {
     return v == .bool and v.bool;
 }
 
-fn domDocSaveXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocSaveXML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     var node: ?*c.xmlNode = null;
     if (args.len > 0 and args[0] == .object) {
@@ -333,9 +334,9 @@ fn domDocSaveXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const fmt: c_int = if (formatOutputOn(obj)) 1 else 0;
         _ = c.xmlNodeDump(buf, doc, n, 0, fmt);
         const out = c.xmlBufferContent(buf);
-        if (out == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        if (out == null) return try NativeResult.copyString(ctx.allocator, "");
         const slice = out[0..cstrLen(out)];
-        return .{ .string = Value.String.borrowed(try dupString(ctx, slice)) };
+        return try NativeResult.copyString(ctx.allocator, slice);
     }
 
     // full doc. pass NULL encoding when the document doesn't have one so libxml2
@@ -344,102 +345,102 @@ fn domDocSaveXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var size: c_int = 0;
     const fmt: c_int = if (formatOutputOn(obj)) 1 else 0;
     c.xmlDocDumpFormatMemoryEnc(doc, &out, &size, doc.*.encoding, fmt);
-    if (out == null) return .{ .bool = false };
+    if (out == null) return NativeResult.scalar(.{ .bool = false });
     defer c.xmlFree.?(out);
     const slice = out[0..@intCast(size)];
-    return .{ .string = Value.String.borrowed(try dupString(ctx, slice)) };
+    return try NativeResult.copyString(ctx.allocator, slice);
 }
 
-fn domDocSaveHTML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocSaveHTML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     if (args.len > 0 and args[0] == .object) {
-        const n = getNodePtr(args[0].object) orelse return .{ .bool = false };
+        const n = getNodePtr(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
         const buf = c.xmlBufferCreate();
         defer c.xmlBufferFree(buf);
         _ = c.htmlNodeDump(buf, doc, n);
         const out = c.xmlBufferContent(buf);
-        if (out == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        if (out == null) return try NativeResult.copyString(ctx.allocator, "");
         const slice = out[0..cstrLen(out)];
-        return .{ .string = Value.String.borrowed(try dupString(ctx, slice)) };
+        return try NativeResult.copyString(ctx.allocator, slice);
     }
 
     var out: [*c]u8 = null;
     var size: c_int = 0;
     c.htmlDocDumpMemory(doc, &out, &size);
-    if (out == null) return .{ .bool = false };
+    if (out == null) return NativeResult.scalar(.{ .bool = false });
     defer c.xmlFree.?(out);
     const slice = out[0..@intCast(size)];
-    return .{ .string = Value.String.borrowed(try dupString(ctx, slice)) };
+    return try NativeResult.copyString(ctx.allocator, slice);
 }
 
-fn domDocSave(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocSave(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
     const fmt: c_int = if (formatOutputOn(obj)) 1 else 0;
     const written = c.xmlSaveFormatFile(path_z.ptr, doc, fmt);
-    if (written < 0) return .{ .bool = false };
-    return .{ .int = @intCast(written) };
+    if (written < 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(written) });
 }
 
-fn domDocCreateElement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocCreateElement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
-    const node = c.xmlNewDocNode(doc, null, @ptrCast(name_z.ptr), null) orelse return .{ .bool = false };
+    const node = c.xmlNewDocNode(doc, null, @ptrCast(name_z.ptr), null) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len > 1 and args[1] == .string and args[1].string.bytes().len > 0) {
         const text_z = try dupZ(ctx, args[1].string.bytes());
         const tn = c.xmlNewDocText(doc, @ptrCast(text_z.ptr));
         _ = c.xmlAddChild(node, tn);
     }
-    return wrapNode(ctx, node, obj);
+    return NativeResult.borrowed(try wrapNode(ctx, node, obj));
 }
 
-fn domDocCreateTextNode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocCreateTextNode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const text_z = try dupZ(ctx, args[0].string.bytes());
-    const node = c.xmlNewDocText(doc, @ptrCast(text_z.ptr)) orelse return .{ .bool = false };
-    return wrapNode(ctx, node, obj);
+    const node = c.xmlNewDocText(doc, @ptrCast(text_z.ptr)) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, node, obj));
 }
 
-fn domDocCreateComment(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocCreateComment(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const text_z = try dupZ(ctx, args[0].string.bytes());
-    const node = c.xmlNewDocComment(doc, @ptrCast(text_z.ptr)) orelse return .{ .bool = false };
-    return wrapNode(ctx, node, obj);
+    const node = c.xmlNewDocComment(doc, @ptrCast(text_z.ptr)) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, node, obj));
 }
 
-fn domDocCreateCDATASection(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocCreateCDATASection(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const text = args[0].string.bytes();
-    const node = c.xmlNewCDataBlock(doc, @ptrCast(text.ptr), @intCast(text.len)) orelse return .{ .bool = false };
-    return wrapNode(ctx, node, obj);
+    const node = c.xmlNewCDataBlock(doc, @ptrCast(text.ptr), @intCast(text.len)) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, node, obj));
 }
 
-fn domDocCreateAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocCreateAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
     // detached attribute: create via xmlNewDocProp on null parent
-    const attr = c.xmlNewDocProp(doc, @ptrCast(name_z.ptr), null) orelse return .{ .bool = false };
-    return wrapNode(ctx, @ptrCast(attr), obj);
+    const attr = c.xmlNewDocProp(doc, @ptrCast(name_z.ptr), null) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, @ptrCast(attr), obj));
 }
 
-fn domDocCreateElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocCreateElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     const ns_uri: ?[]const u8 = if (args[0] == .string) args[0].string.bytes() else null;
     const qname = args[1].string.bytes();
@@ -454,7 +455,7 @@ fn domDocCreateElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!
         local_buf = try dupZ(ctx, qname);
     }
 
-    const node = c.xmlNewDocNode(doc, null, @ptrCast(local_buf.ptr), null) orelse return .{ .bool = false };
+    const node = c.xmlNewDocNode(doc, null, @ptrCast(local_buf.ptr), null) orelse return NativeResult.scalar(.{ .bool = false });
     if (ns_uri) |uri| {
         const uri_z = try dupZ(ctx, uri);
         const prefix_ptr: [*c]const u8 = if (prefix_buf) |p| @ptrCast(p.ptr) else null;
@@ -466,31 +467,31 @@ fn domDocCreateElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!
         const tn = c.xmlNewDocText(doc, @ptrCast(text_z.ptr));
         _ = c.xmlAddChild(node, tn);
     }
-    return wrapNode(ctx, node, obj);
+    return NativeResult.borrowed(try wrapNode(ctx, node, obj));
 }
 
-fn domDocCreateDocumentFragment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
-    const node = c.xmlNewDocFragment(doc) orelse return .{ .bool = false };
-    return wrapNode(ctx, node, obj);
+fn domDocCreateDocumentFragment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = c.xmlNewDocFragment(doc) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, node, obj));
 }
 
-fn domDocImportNode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
-    const src = getNodePtr(args[0].object) orelse return .{ .bool = false };
+fn domDocImportNode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const src = getNodePtr(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     const deep: c_int = if (args.len > 1 and args[1] == .bool and args[1].bool) 1 else 0;
     const copy = c.xmlDocCopyNode(src, doc, if (deep != 0) 1 else 2);
-    if (copy == null) return .{ .bool = false };
-    return wrapNode(ctx, copy, obj);
+    if (copy == null) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, copy, obj));
 }
 
-fn domDocGetElementsByTagName(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn domDocGetElementsByTagName(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
 
     const root = c.xmlDocGetRootElement(doc);
@@ -502,21 +503,21 @@ fn domDocGetElementsByTagName(ctx: *NativeContext, args: []const Value) RuntimeE
     return try makeNodeList(ctx, obj, list.items);
 }
 
-fn domDocGetElementById(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const doc = getDocPtr(obj) orelse return .null;
+fn domDocGetElementById(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const id_z = try dupZ(ctx, args[0].string.bytes());
     const attr = c.xmlGetID(doc, @ptrCast(id_z.ptr));
     if (attr == null) {
         // fall back to scanning for any attribute named "id" with this value
         const root = c.xmlDocGetRootElement(doc);
         if (root) |r| {
-            if (findById(r, args[0].string.bytes())) |n| return wrapNode(ctx, n, obj);
+            if (findById(r, args[0].string.bytes())) |n| return NativeResult.borrowed(try wrapNode(ctx, n, obj));
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
-    return wrapNode(ctx, @ptrCast(attr.*.parent), obj);
+    return NativeResult.borrowed(try wrapNode(ctx, @ptrCast(attr.*.parent), obj));
 }
 
 fn findById(node: *c.xmlNode, id: []const u8) ?*c.xmlNode {
@@ -584,33 +585,28 @@ fn collectByNameNS(allocator: Allocator, node: *c.xmlNode, ns: []const u8, name:
     }
 }
 
-fn domDocNormalizeDocument(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn domDocNormalizeDocument(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     _ = ctx;
     // PHP's normalizeDocument coalesces adjacent text nodes; libxml2 does this on saveXML.
     // no-op here is observably equivalent for the common path
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ---------------- DOMNode read-only accessors ----------------
 
-fn domNodeProp(prop: []const u8) ?(*const fn (ctx: *NativeContext, args: []const Value) RuntimeError!Value) {
-    _ = prop;
-    return null;
-}
-
 // magic getter dispatched via __get for read-only properties on DOM* objects.
 // register native __get on each DOM* class and route by property name
-fn domGenericGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn domGenericGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const prop = args[0].string.bytes();
     return try readProperty(ctx, obj, prop);
 }
 
-fn domGenericSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn domGenericSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const prop = args[0].string.bytes();
     const val = args[1];
 
@@ -619,27 +615,27 @@ fn domGenericSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const s_z = try dupZ(ctx, s);
         // wipe existing content and set fresh
         _ = c.xmlNodeSetContent(node, @ptrCast(s_z.ptr));
-        return .null;
+        return NativeResult.scalar(.null);
     }
     if (std.mem.eql(u8, prop, "data") and (node.type == c.XML_TEXT_NODE or node.type == c.XML_CDATA_SECTION_NODE or node.type == c.XML_COMMENT_NODE)) {
         const s = if (val == .string) val.string.bytes() else "";
         const s_z = try dupZ(ctx, s);
         _ = c.xmlNodeSetContent(node, @ptrCast(s_z.ptr));
-        return .null;
+        return NativeResult.scalar(.null);
     }
     if (std.mem.eql(u8, prop, "value") and node.type == c.XML_ATTRIBUTE_NODE) {
         const s = if (val == .string) val.string.bytes() else "";
         const s_z = try dupZ(ctx, s);
         _ = c.xmlNodeSetContent(node, @ptrCast(s_z.ptr));
-        return .null;
+        return NativeResult.scalar(.null);
     }
     // unrecognized property: fall back to stashing in PhpObject (matches the
     // legacy dynamic-property behavior so tests aren't surprised)
     try obj.set(ctx.allocator, prop, val);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn readProperty(ctx: *NativeContext, obj: *PhpObject, prop: []const u8) RuntimeError!Value {
+fn readProperty(ctx: *NativeContext, obj: *PhpObject, prop: []const u8) RuntimeError!NativeResult {
     // namespace pseudo-nodes are stored as standalone PhpObjects with their
     // prefix+href captured as properties (not via __node, since the underlying
     // xmlNs is freed when the XPath result is). short-circuit before any
@@ -649,34 +645,33 @@ fn readProperty(ctx: *NativeContext, obj: *PhpObject, prop: []const u8) RuntimeE
             const px = obj.get("__ns_prefix");
             if (px == .string and px.string.bytes().len > 0) {
                 const out = try std.fmt.allocPrint(ctx.allocator, "xmlns:{s}", .{px.string.bytes()});
-                try ctx.strings.append(ctx.allocator, out);
-                return .{ .string = Value.String.borrowed(out) };
+                return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
             }
-            return .{ .string = Value.String.borrowed(try dupString(ctx, "xmlns")) };
+            return try NativeResult.copyString(ctx.allocator, "xmlns");
         }
         if (std.mem.eql(u8, prop, "nodeValue") or std.mem.eql(u8, prop, "value")) {
             const href = obj.get("__ns_href");
-            if (href == .string) return href;
-            return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+            if (href == .string) return NativeResult.share(href);
+            return try NativeResult.copyString(ctx.allocator, "");
         }
-        if (std.mem.eql(u8, prop, "nodeType")) return .{ .int = @intCast(c.XML_NAMESPACE_DECL) };
-        return .null;
+        if (std.mem.eql(u8, prop, "nodeType")) return NativeResult.scalar(.{ .int = @intCast(c.XML_NAMESPACE_DECL) });
+        return NativeResult.scalar(.null);
     }
 
     const owner = getOwnerDocObj(obj) orelse obj;
     const node_opt = getNodePtr(obj);
-    if (node_opt == null) return .null;
+    if (node_opt == null) return NativeResult.scalar(.null);
     const node = node_opt.?;
 
     if (std.mem.eql(u8, prop, "nodeName")) {
         // for documents, return "#document"
         if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE) {
-            return .{ .string = Value.String.borrowed(try dupString(ctx, "#document")) };
+            return try NativeResult.copyString(ctx.allocator, "#document");
         }
-        if (node.type == c.XML_TEXT_NODE) return .{ .string = Value.String.borrowed(try dupString(ctx, "#text")) };
-        if (node.type == c.XML_CDATA_SECTION_NODE) return .{ .string = Value.String.borrowed(try dupString(ctx, "#cdata-section")) };
-        if (node.type == c.XML_COMMENT_NODE) return .{ .string = Value.String.borrowed(try dupString(ctx, "#comment")) };
-        if (node.type == c.XML_DOCUMENT_FRAG_NODE) return .{ .string = Value.String.borrowed(try dupString(ctx, "#document-fragment")) };
+        if (node.type == c.XML_TEXT_NODE) return try NativeResult.copyString(ctx.allocator, "#text");
+        if (node.type == c.XML_CDATA_SECTION_NODE) return try NativeResult.copyString(ctx.allocator, "#cdata-section");
+        if (node.type == c.XML_COMMENT_NODE) return try NativeResult.copyString(ctx.allocator, "#comment");
+        if (node.type == c.XML_DOCUMENT_FRAG_NODE) return try NativeResult.copyString(ctx.allocator, "#document-fragment");
         // for elements, include prefix if namespaced
         if (node.type == c.XML_ELEMENT_NODE and node.ns != null and node.ns.*.prefix != null) {
             const prefix = node.ns.*.prefix;
@@ -685,66 +680,65 @@ fn readProperty(ctx: *NativeContext, obj: *PhpObject, prop: []const u8) RuntimeE
                 prefix[0..cstrLen(prefix)],
                 name[0..cstrLen(name)],
             });
-            try ctx.strings.append(ctx.allocator, out);
-            return .{ .string = Value.String.borrowed(out) };
+            return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
         }
         return try cstrToValue(ctx, node.name);
     }
     if (std.mem.eql(u8, prop, "nodeValue")) {
         // PHP returns concatenated text content for elements; null for documents
         if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE or node.type == c.XML_DOCUMENT_TYPE_NODE) {
-            return .null;
+            return NativeResult.scalar(.null);
         }
         const content = c.xmlNodeGetContent(node);
-        if (content == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        if (content == null) return try NativeResult.copyString(ctx.allocator, "");
         defer c.xmlFree.?(content);
         const slice = content[0..cstrLen(content)];
-        return .{ .string = Value.String.borrowed(try dupString(ctx, slice)) };
+        return try NativeResult.copyString(ctx.allocator, slice);
     }
     if (std.mem.eql(u8, prop, "textContent")) {
         const content = c.xmlNodeGetContent(node);
-        if (content == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        if (content == null) return try NativeResult.copyString(ctx.allocator, "");
         defer c.xmlFree.?(content);
         const slice = content[0..cstrLen(content)];
-        return .{ .string = Value.String.borrowed(try dupString(ctx, slice)) };
+        return try NativeResult.copyString(ctx.allocator, slice);
     }
     if (std.mem.eql(u8, prop, "nodeType")) {
-        return .{ .int = @intCast(node.type) };
+        return NativeResult.scalar(.{ .int = @intCast(node.type) });
     }
     if (std.mem.eql(u8, prop, "parentNode")) {
-        return wrapNode(ctx, node.parent, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, node.parent, owner));
     }
     if (std.mem.eql(u8, prop, "firstChild")) {
-        return wrapNode(ctx, node.children, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, node.children, owner));
     }
     if (std.mem.eql(u8, prop, "lastChild")) {
-        return wrapNode(ctx, node.last, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, node.last, owner));
     }
     if (std.mem.eql(u8, prop, "previousSibling")) {
-        return wrapNode(ctx, node.prev, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, node.prev, owner));
     }
     if (std.mem.eql(u8, prop, "nextSibling")) {
-        return wrapNode(ctx, node.next, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, node.next, owner));
     }
     if (std.mem.eql(u8, prop, "previousElementSibling")) {
         var p = node.prev;
         while (p != null and p.*.type != c.XML_ELEMENT_NODE) : (p = p.*.prev) {}
-        return wrapNode(ctx, p, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, p, owner));
     }
     if (std.mem.eql(u8, prop, "nextElementSibling")) {
         var n = node.next;
         while (n != null and n.*.type != c.XML_ELEMENT_NODE) : (n = n.*.next) {}
-        return wrapNode(ctx, n, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, n, owner));
     }
     if (std.mem.eql(u8, prop, "firstElementChild")) {
         var k = node.children;
         while (k != null and k.*.type != c.XML_ELEMENT_NODE) : (k = k.*.next) {}
-        return wrapNode(ctx, k, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, k, owner));
     }
     if (std.mem.eql(u8, prop, "lastElementChild")) {
         var k = node.last;
         while (k != null and k.*.type != c.XML_ELEMENT_NODE) : (k = k.*.prev) {}
-        return wrapNode(ctx, k, owner);
+        return NativeResult.borrowed(try wrapNode(ctx, k, owner));
     }
     if (std.mem.eql(u8, prop, "childElementCount")) {
         var k = node.children;
@@ -752,7 +746,7 @@ fn readProperty(ctx: *NativeContext, obj: *PhpObject, prop: []const u8) RuntimeE
         while (k != null) : (k = k.*.next) {
             if (k.*.type == c.XML_ELEMENT_NODE) count += 1;
         }
-        return .{ .int = count };
+        return NativeResult.scalar(.{ .int = count });
     }
     if (std.mem.eql(u8, prop, "childNodes")) {
         var list = std.ArrayList(*c.xmlNode){};
@@ -762,33 +756,33 @@ fn readProperty(ctx: *NativeContext, obj: *PhpObject, prop: []const u8) RuntimeE
         return try makeNodeList(ctx, owner, list.items);
     }
     if (std.mem.eql(u8, prop, "ownerDocument")) {
-        if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE) return .null;
-        return .{ .object = owner };
+        if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE) return NativeResult.scalar(.null);
+        return NativeResult.borrowed(.{ .object = owner });
     }
     if (std.mem.eql(u8, prop, "documentElement")) {
-        if (node.type != c.XML_DOCUMENT_NODE and node.type != c.XML_HTML_DOCUMENT_NODE) return .null;
+        if (node.type != c.XML_DOCUMENT_NODE and node.type != c.XML_HTML_DOCUMENT_NODE) return NativeResult.scalar(.null);
         const doc: *c.xmlDoc = @ptrCast(node);
-        return wrapNode(ctx, c.xmlDocGetRootElement(doc), owner);
+        return NativeResult.borrowed(try wrapNode(ctx, c.xmlDocGetRootElement(doc), owner));
     }
     if (std.mem.eql(u8, prop, "namespaceURI")) {
         if (node.ns != null and node.ns.*.href != null) return try cstrToValue(ctx, node.ns.*.href);
-        return .null;
+        return NativeResult.scalar(.null);
     }
     if (std.mem.eql(u8, prop, "prefix")) {
         if (node.ns != null and node.ns.*.prefix != null) return try cstrToValue(ctx, node.ns.*.prefix);
-        return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        return try NativeResult.copyString(ctx.allocator, "");
     }
     if (std.mem.eql(u8, prop, "localName")) {
         if (node.type == c.XML_ELEMENT_NODE or node.type == c.XML_ATTRIBUTE_NODE) {
             return try cstrToValue(ctx, node.name);
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
     if (std.mem.eql(u8, prop, "baseURI")) {
         const u = c.xmlNodeGetBase(@ptrCast(node.doc), node);
-        if (u == null) return .null;
+        if (u == null) return NativeResult.scalar(.null);
         defer c.xmlFree.?(u);
-        return .{ .string = Value.String.borrowed(try dupString(ctx, u[0..cstrLen(u)])) };
+        return try NativeResult.copyString(ctx.allocator, u[0..cstrLen(u)]);
     }
     if (std.mem.eql(u8, prop, "tagName")) {
         if (node.type == c.XML_ELEMENT_NODE) {
@@ -799,71 +793,70 @@ fn readProperty(ctx: *NativeContext, obj: *PhpObject, prop: []const u8) RuntimeE
                     prefix[0..cstrLen(prefix)],
                     name[0..cstrLen(name)],
                 });
-                try ctx.strings.append(ctx.allocator, out);
-                return .{ .string = Value.String.borrowed(out) };
+                return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
             }
             return try cstrToValue(ctx, node.name);
         }
     }
     if (std.mem.eql(u8, prop, "attributes")) {
-        if (node.type != c.XML_ELEMENT_NODE) return .null;
+        if (node.type != c.XML_ELEMENT_NODE) return NativeResult.scalar(.null);
         return try makeNamedNodeMap(ctx, owner, node);
     }
     if (std.mem.eql(u8, prop, "data") or std.mem.eql(u8, prop, "value")) {
         const content = c.xmlNodeGetContent(node);
-        if (content == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        if (content == null) return try NativeResult.copyString(ctx.allocator, "");
         defer c.xmlFree.?(content);
-        return .{ .string = Value.String.borrowed(try dupString(ctx, content[0..cstrLen(content)])) };
+        return try NativeResult.copyString(ctx.allocator, content[0..cstrLen(content)]);
     }
     if (std.mem.eql(u8, prop, "length")) {
         const content = c.xmlNodeGetContent(node);
-        if (content == null) return .{ .int = 0 };
+        if (content == null) return NativeResult.scalar(.{ .int = 0 });
         defer c.xmlFree.?(content);
-        return .{ .int = @intCast(cstrLen(content)) };
+        return NativeResult.scalar(.{ .int = @intCast(cstrLen(content)) });
     }
     if (std.mem.eql(u8, prop, "name")) {
         if (node.type == c.XML_ATTRIBUTE_NODE) return try cstrToValue(ctx, node.name);
     }
     if (std.mem.eql(u8, prop, "ownerElement")) {
-        if (node.type == c.XML_ATTRIBUTE_NODE) return wrapNode(ctx, node.parent, owner);
+        if (node.type == c.XML_ATTRIBUTE_NODE) return NativeResult.borrowed(try wrapNode(ctx, node.parent, owner));
     }
     if (std.mem.eql(u8, prop, "encoding")) {
         if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE) {
             const doc: *c.xmlDoc = @ptrCast(node);
             if (doc.*.encoding != null) return try cstrToValue(ctx, doc.*.encoding);
-            return .null;
+            return NativeResult.scalar(.null);
         }
     }
     if (std.mem.eql(u8, prop, "version") or std.mem.eql(u8, prop, "xmlVersion")) {
         if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE) {
             const doc: *c.xmlDoc = @ptrCast(node);
             if (doc.*.version != null) return try cstrToValue(ctx, doc.*.version);
-            return .null;
+            return NativeResult.scalar(.null);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ---------------- DOMNode write methods ----------------
 
-fn domNodeAppendChild(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const parent = getNodePtr(obj) orelse return .{ .bool = false };
-    const child = getNodePtr(args[0].object) orelse return .{ .bool = false };
+fn domNodeAppendChild(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const parent = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const child = getNodePtr(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
 
     // unlink first if attached
     c.xmlUnlinkNode(child);
     const added = c.xmlAddChild(parent, child);
-    if (added == null) return .{ .bool = false };
-    return wrapNode(ctx, added, getOwnerDocObj(obj) orelse obj);
+    if (added == null) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, added, getOwnerDocObj(obj) orelse obj));
 }
 
-fn domNodeRemoveChild(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    _ = getNodePtr(obj) orelse return .{ .bool = false };
-    const child = getNodePtr(args[0].object) orelse return .{ .bool = false };
+fn domNodeRemoveChild(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    _ = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const child = getNodePtr(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
 
     c.xmlUnlinkNode(child);
     // PHP returns the removed node; we keep it alive (libxml2 won't free unless we xmlFreeNode).
@@ -871,164 +864,164 @@ fn domNodeRemoveChild(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     // would leak across requests. attach it to a per-doc orphans list so xmlFreeDoc still
     // catches it: simplest is to keep wrapping and rely on the test runner's request lifetime
     // freeing the whole VM. for now wrap and return
-    return wrapNode(ctx, child, getOwnerDocObj(obj) orelse obj);
+    return NativeResult.borrowed(try wrapNode(ctx, child, getOwnerDocObj(obj) orelse obj));
 }
 
-fn domNodeReplaceChild(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .object) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    _ = getNodePtr(obj) orelse return .{ .bool = false };
-    const new_node = getNodePtr(args[0].object) orelse return .{ .bool = false };
-    const old_node = getNodePtr(args[1].object) orelse return .{ .bool = false };
+fn domNodeReplaceChild(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .object) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    _ = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const new_node = getNodePtr(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
+    const old_node = getNodePtr(args[1].object) orelse return NativeResult.scalar(.{ .bool = false });
 
     c.xmlUnlinkNode(new_node);
     const replaced = c.xmlReplaceNode(old_node, new_node);
-    if (replaced == null) return .{ .bool = false };
-    return wrapNode(ctx, replaced, getOwnerDocObj(obj) orelse obj);
+    if (replaced == null) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, replaced, getOwnerDocObj(obj) orelse obj));
 }
 
-fn domNodeInsertBefore(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const parent = getNodePtr(obj) orelse return .{ .bool = false };
-    const new_node = getNodePtr(args[0].object) orelse return .{ .bool = false };
+fn domNodeInsertBefore(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const parent = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const new_node = getNodePtr(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
 
     var ref: ?*c.xmlNode = null;
     if (args.len > 1 and args[1] == .object) ref = getNodePtr(args[1].object);
 
     c.xmlUnlinkNode(new_node);
     const added = if (ref) |r| c.xmlAddPrevSibling(r, new_node) else c.xmlAddChild(parent, new_node);
-    if (added == null) return .{ .bool = false };
-    return wrapNode(ctx, added, getOwnerDocObj(obj) orelse obj);
+    if (added == null) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, added, getOwnerDocObj(obj) orelse obj));
 }
 
-fn domNodeCloneNode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domNodeCloneNode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const deep: c_int = if (args.len > 0 and args[0] == .bool and args[0].bool) 1 else 2;
     const copy = c.xmlDocCopyNode(node, node.doc, deep);
-    return wrapNode(ctx, copy, getOwnerDocObj(obj) orelse obj);
+    return NativeResult.borrowed(try wrapNode(ctx, copy, getOwnerDocObj(obj) orelse obj));
 }
 
-fn domNodeHasChildNodes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
-    return .{ .bool = node.children != null };
+fn domNodeHasChildNodes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = node.children != null });
 }
 
-fn domNodeHasAttributes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
-    if (node.type != c.XML_ELEMENT_NODE) return .{ .bool = false };
-    return .{ .bool = node.properties != null };
+fn domNodeHasAttributes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (node.type != c.XML_ELEMENT_NODE) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = node.properties != null });
 }
 
-fn domNodeIsSameNode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const a = getNodePtr(obj) orelse return .{ .bool = false };
-    const b = getNodePtr(args[0].object) orelse return .{ .bool = false };
-    return .{ .bool = a == b };
+fn domNodeIsSameNode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const a = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const b = getNodePtr(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = a == b });
 }
 
-fn domNodeGetNodePath(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn domNodeGetNodePath(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const p = c.xmlGetNodePath(node);
-    if (p == null) return .null;
+    if (p == null) return NativeResult.scalar(.null);
     defer c.xmlFree.?(p);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, p[0..cstrLen(p)])) };
+    return try NativeResult.copyString(ctx.allocator, p[0..cstrLen(p)]);
 }
 
-fn domNodeGetLineNo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const node = getNodePtr(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(c.xmlGetLineNo(node)) };
+fn domNodeGetLineNo(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(c.xmlGetLineNo(node)) });
 }
 
-fn domNodeLookupPrefix(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn domNodeLookupPrefix(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const uri_z = try dupZ(ctx, args[0].string.bytes());
     const ns = c.xmlSearchNsByHref(node.doc, node, @ptrCast(uri_z.ptr));
-    if (ns == null or ns.*.prefix == null) return .null;
+    if (ns == null or ns.*.prefix == null) return NativeResult.scalar(.null);
     return try cstrToValue(ctx, ns.*.prefix);
 }
 
-fn domNodeLookupNamespaceURI(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn domNodeLookupNamespaceURI(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const prefix_ptr: [*c]const u8 = if (args[0] == .string and args[0].string.bytes().len > 0)
         @ptrCast((try dupZ(ctx, args[0].string.bytes())).ptr)
     else
         null;
     const ns = c.xmlSearchNs(node.doc, node, prefix_ptr);
-    if (ns == null or ns.*.href == null) return .null;
+    if (ns == null or ns.*.href == null) return NativeResult.scalar(.null);
     return try cstrToValue(ctx, ns.*.href);
 }
 
 // ---------------- DOMElement methods ----------------
 
-fn domElementGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    const node = getNodePtr(obj) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+fn domElementGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return try NativeResult.copyString(ctx.allocator, "");
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
+    const node = getNodePtr(obj) orelse return try NativeResult.copyString(ctx.allocator, "");
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const v = c.xmlGetProp(node, @ptrCast(name_z.ptr));
-    if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == null) return try NativeResult.copyString(ctx.allocator, "");
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn domElementSetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domElementSetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const val_z = try dupZ(ctx, args[1].string.bytes());
     const attr = c.xmlSetProp(node, @ptrCast(name_z.ptr), @ptrCast(val_z.ptr));
-    if (attr == null) return .{ .bool = false };
-    return wrapNode(ctx, @ptrCast(attr), getOwnerDocObj(obj) orelse obj);
+    if (attr == null) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try wrapNode(ctx, @ptrCast(attr), getOwnerDocObj(obj) orelse obj));
 }
 
-fn domElementHasAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domElementHasAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
-    return .{ .bool = c.xmlHasProp(node, @ptrCast(name_z.ptr)) != null };
+    return NativeResult.scalar(.{ .bool = c.xmlHasProp(node, @ptrCast(name_z.ptr)) != null });
 }
 
-fn domElementRemoveAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domElementRemoveAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const rc = c.xmlUnsetProp(node, @ptrCast(name_z.ptr));
-    return .{ .bool = rc == 0 };
+    return NativeResult.scalar(.{ .bool = rc == 0 });
 }
 
-fn domElementGetAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    const node = getNodePtr(obj) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+fn domElementGetAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return try NativeResult.copyString(ctx.allocator, "");
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
+    const node = getNodePtr(obj) orelse return try NativeResult.copyString(ctx.allocator, "");
     const ns_ptr: [*c]const u8 = if (args[0] == .string and args[0].string.bytes().len > 0)
         @ptrCast((try dupZ(ctx, args[0].string.bytes())).ptr)
     else
         null;
     const name_z = try dupZ(ctx, args[1].string.bytes());
     const v = c.xmlGetNsProp(node, @ptrCast(name_z.ptr), ns_ptr);
-    if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == null) return try NativeResult.copyString(ctx.allocator, "");
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn domElementSetAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[1] != .string or args[2] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domElementSetAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const qname = args[1].string.bytes();
     const val_z = try dupZ(ctx, args[2].string.bytes());
 
@@ -1052,28 +1045,28 @@ fn domElementSetAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeErr
     const local = if (std.mem.indexOfScalar(u8, qname, ':')) |i| qname[i + 1 ..] else qname;
     const local_z = try dupZ(ctx, local);
     _ = c.xmlSetNsProp(node, ns_ptr, @ptrCast(local_z.ptr), @ptrCast(val_z.ptr));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn domElementHasAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domElementHasAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const ns_ptr: [*c]const u8 = if (args[0] == .string and args[0].string.bytes().len > 0)
         @ptrCast((try dupZ(ctx, args[0].string.bytes())).ptr)
     else
         null;
     const name_z = try dupZ(ctx, args[1].string.bytes());
     const v = c.xmlGetNsProp(node, @ptrCast(name_z.ptr), ns_ptr);
-    if (v == null) return .{ .bool = false };
+    if (v == null) return NativeResult.scalar(.{ .bool = false });
     c.xmlFree.?(v);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn domElementRemoveAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domElementRemoveAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const ns_ptr: [*c]const u8 = if (args[0] == .string and args[0].string.bytes().len > 0)
         @ptrCast((try dupZ(ctx, args[0].string.bytes())).ptr)
     else
@@ -1081,13 +1074,13 @@ fn domElementRemoveAttributeNS(ctx: *NativeContext, args: []const Value) Runtime
     _ = ns_ptr;
     const name_z = try dupZ(ctx, args[1].string.bytes());
     _ = c.xmlUnsetNsProp(node, null, @ptrCast(name_z.ptr));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn domElementGetElementsByTagName(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domElementGetElementsByTagName(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var list = std.ArrayList(*c.xmlNode){};
     defer list.deinit(ctx.allocator);
     var child = node.children;
@@ -1095,12 +1088,12 @@ fn domElementGetElementsByTagName(ctx: *NativeContext, args: []const Value) Runt
     return try makeNodeList(ctx, getOwnerDocObj(obj) orelse obj, list.items);
 }
 
-fn domGetElementsByTagNameNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domGetElementsByTagNameNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const ns = if (args[0] == .string) args[0].string.bytes() else "*";
     const name = args[1].string.bytes();
-    var node = getNodePtr(obj) orelse return .{ .bool = false };
+    var node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     // for DOMDocument, the wrapping node may not have children walking the doc;
     // start at the root element
     if (node.type == c.XML_DOCUMENT_NODE) {
@@ -1114,45 +1107,45 @@ fn domGetElementsByTagNameNS(ctx: *NativeContext, args: []const Value) RuntimeEr
     return try makeNodeList(ctx, getOwnerDocObj(obj) orelse obj, list.items);
 }
 
-fn domElementGetAttributeNode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn domElementGetAttributeNode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const attr = c.xmlHasProp(node, @ptrCast(name_z.ptr));
-    if (attr == null) return .null;
-    return wrapNode(ctx, @ptrCast(attr), getOwnerDocObj(obj) orelse obj);
+    if (attr == null) return NativeResult.scalar(.null);
+    return NativeResult.borrowed(try wrapNode(ctx, @ptrCast(attr), getOwnerDocObj(obj) orelse obj));
 }
 
 // ---------------- DOMCharacterData methods ----------------
 
-fn domCdAppendData(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn domCdAppendData(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const text_z = try dupZ(ctx, args[0].string.bytes());
     _ = c.xmlNodeAddContent(node, @ptrCast(text_z.ptr));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn domCdSubstringData(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int or args[1] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn domCdSubstringData(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const content = c.xmlNodeGetContent(node);
-    if (content == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (content == null) return try NativeResult.copyString(ctx.allocator, "");
     defer c.xmlFree.?(content);
     const slice = content[0..cstrLen(content)];
     const off: usize = if (args[0].int < 0) 0 else @intCast(args[0].int);
-    if (off >= slice.len) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (off >= slice.len) return try NativeResult.copyString(ctx.allocator, "");
     const cnt: usize = if (args[1].int < 0) 0 else @intCast(args[1].int);
     const end = @min(off + cnt, slice.len);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, slice[off..end])) };
+    return try NativeResult.copyString(ctx.allocator, slice[off..end]);
 }
 
 // ---------------- DOMNodeList ----------------
 
-fn makeNodeList(ctx: *NativeContext, owner_doc: *PhpObject, nodes: []*c.xmlNode) !Value {
+fn makeNodeList(ctx: *NativeContext, owner_doc: *PhpObject, nodes: []*c.xmlNode) RuntimeError!NativeResult {
     const list_obj = try ctx.createObject("DOMNodeList");
     const arr = try ctx.createArray();
     for (nodes, 0..) |n, i| {
@@ -1162,7 +1155,7 @@ fn makeNodeList(ctx: *NativeContext, owner_doc: *PhpObject, nodes: []*c.xmlNode)
     try list_obj.set(ctx.allocator, "__items", .{ .array = arr });
     try list_obj.set(ctx.allocator, "__pos", .{ .int = 0 });
     try list_obj.set(ctx.allocator, "length", .{ .int = @intCast(nodes.len) });
-    return .{ .object = list_obj };
+    return NativeResult.borrowed(.{ .object = list_obj });
 }
 
 fn nlItems(obj: *PhpObject) ?*PhpArray {
@@ -1171,62 +1164,62 @@ fn nlItems(obj: *PhpObject) ?*PhpArray {
     return v.array;
 }
 
-fn domNodeListLength(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn domNodeListLength(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     _ = ctx;
-    const obj = getThisGlobal() orelse return .{ .int = 0 };
-    const arr = nlItems(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(arr.entries.items.len) };
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = nlItems(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(arr.entries.items.len) });
 }
 
-fn domNodeListItem(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn domNodeListItem(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     _ = ctx;
-    if (args.len < 1 or args[0] != .int) return .null;
-    const obj = getThisGlobal() orelse return .null;
-    const arr = nlItems(obj) orelse return .null;
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.null);
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.null);
+    const arr = nlItems(obj) orelse return NativeResult.scalar(.null);
     const idx = args[0].int;
-    if (idx < 0 or idx >= @as(i64, @intCast(arr.entries.items.len))) return .null;
-    return arr.entries.items[@intCast(idx)].value;
+    if (idx < 0 or idx >= @as(i64, @intCast(arr.entries.items.len))) return NativeResult.scalar(.null);
+    return NativeResult.share(arr.entries.items[@intCast(idx)].value);
 }
 
-fn domNodeListCount(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn domNodeListCount(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return domNodeListLength(ctx, args);
 }
 
-fn domNodeListRewind(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThisGlobal() orelse return .null;
+fn domNodeListRewind(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.null);
     obj.properties.put(std.heap.page_allocator, "__pos", .{ .int = 0 }) catch {};
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn domNodeListValid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThisGlobal() orelse return .{ .bool = false };
-    const arr = nlItems(obj) orelse return .{ .bool = false };
+fn domNodeListValid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = nlItems(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const pos = obj.get("__pos");
     const p: i64 = if (pos == .int) pos.int else 0;
-    return .{ .bool = p >= 0 and p < @as(i64, @intCast(arr.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = p >= 0 and p < @as(i64, @intCast(arr.entries.items.len)) });
 }
 
-fn domNodeListCurrent(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThisGlobal() orelse return .null;
-    const arr = nlItems(obj) orelse return .null;
+fn domNodeListCurrent(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.null);
+    const arr = nlItems(obj) orelse return NativeResult.scalar(.null);
     const pos = obj.get("__pos");
     const p: i64 = if (pos == .int) pos.int else 0;
-    if (p < 0 or p >= @as(i64, @intCast(arr.entries.items.len))) return .null;
-    return arr.entries.items[@intCast(p)].value;
+    if (p < 0 or p >= @as(i64, @intCast(arr.entries.items.len))) return NativeResult.scalar(.null);
+    return NativeResult.share(arr.entries.items[@intCast(p)].value);
 }
 
-fn domNodeListKey(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThisGlobal() orelse return .{ .int = 0 };
+fn domNodeListKey(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.{ .int = 0 });
     const pos = obj.get("__pos");
-    return if (pos == .int) pos else .{ .int = 0 };
+    return if (pos == .int) NativeResult.share(pos) else NativeResult.scalar(.{ .int = 0 });
 }
 
-fn domNodeListNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThisGlobal() orelse return .null;
+fn domNodeListNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.null);
     const pos = obj.get("__pos");
     const p: i64 = if (pos == .int) pos.int else 0;
     obj.set(ctx.allocator, "__pos", .{ .int = p + 1 }) catch {};
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn getThisGlobal() ?*PhpObject {
@@ -1242,7 +1235,7 @@ var vm_singleton: ?*VM = null;
 
 // ---------------- DOMNamedNodeMap ----------------
 
-fn makeNamedNodeMap(ctx: *NativeContext, owner_doc: *PhpObject, element: *c.xmlNode) !Value {
+fn makeNamedNodeMap(ctx: *NativeContext, owner_doc: *PhpObject, element: *c.xmlNode) RuntimeError!NativeResult {
     const map_obj = try ctx.createObject("DOMNamedNodeMap");
     const arr = try ctx.createArray();
     const named = try ctx.createArray();
@@ -1262,46 +1255,46 @@ fn makeNamedNodeMap(ctx: *NativeContext, owner_doc: *PhpObject, element: *c.xmlN
     try map_obj.set(ctx.allocator, "__named", .{ .array = named });
     try map_obj.set(ctx.allocator, "__pos", .{ .int = 0 });
     try map_obj.set(ctx.allocator, "length", .{ .int = @intCast(i) });
-    return .{ .object = map_obj };
+    return NativeResult.borrowed(.{ .object = map_obj });
 }
 
-fn domNNMGetNamedItem(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThisGlobal() orelse return .null;
+fn domNNMGetNamedItem(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.null);
     const named = obj.get("__named");
-    if (named != .array) return .null;
-    return named.array.get(.{ .string = args[0].string });
+    if (named != .array) return NativeResult.scalar(.null);
+    return NativeResult.share(named.array.get(.{ .string = args[0].string }));
 }
 
-fn domNNMItem(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .null;
-    const obj = getThisGlobal() orelse return .null;
+fn domNNMItem(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.null);
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.null);
     const items = obj.get("__items");
-    if (items != .array) return .null;
+    if (items != .array) return NativeResult.scalar(.null);
     const idx = args[0].int;
-    if (idx < 0 or idx >= @as(i64, @intCast(items.array.entries.items.len))) return .null;
-    return items.array.entries.items[@intCast(idx)].value;
+    if (idx < 0 or idx >= @as(i64, @intCast(items.array.entries.items.len))) return NativeResult.scalar(.null);
+    return NativeResult.share(items.array.entries.items[@intCast(idx)].value);
 }
 
-fn domNNMCount(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThisGlobal() orelse return .{ .int = 0 };
+fn domNNMCount(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.{ .int = 0 });
     const items = obj.get("__items");
-    if (items != .array) return .{ .int = 0 };
-    return .{ .int = @intCast(items.array.entries.items.len) };
+    if (items != .array) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(items.array.entries.items.len) });
 }
 
 // ---------------- DOMXPath ----------------
 
-fn domXpathConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn domXpathConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__doc", args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn domXpathRegisterNamespace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domXpathRegisterNamespace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     var ns_map = obj.get("__namespaces");
     if (ns_map != .array) {
         const arr = try ctx.createArray();
@@ -1311,22 +1304,22 @@ fn domXpathRegisterNamespace(ctx: *NativeContext, args: []const Value) RuntimeEr
     const key = try dupString(ctx, args[0].string.bytes());
     const val = try dupString(ctx, args[1].string.bytes());
     try ns_map.array.set(ctx.allocator, .{ .string = Value.String.borrowed(key) }, .{ .string = Value.String.borrowed(val) });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn domXpathQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domXpathQuery(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const doc_v = obj.get("__doc");
-    if (doc_v != .object) return .{ .bool = false };
-    const doc = getDocPtr(doc_v.object) orelse return .{ .bool = false };
+    if (doc_v != .object) return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(doc_v.object) orelse return NativeResult.scalar(.{ .bool = false });
 
     var context_node: ?*c.xmlNode = null;
     if (args.len > 1 and args[1] == .object) {
         context_node = getNodePtr(args[1].object);
     }
 
-    const xctx = c.xmlXPathNewContext(doc) orelse return .{ .bool = false };
+    const xctx = c.xmlXPathNewContext(doc) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.xmlXPathFreeContext(xctx);
     if (context_node) |cn| xctx.*.node = cn;
 
@@ -1343,7 +1336,7 @@ fn domXpathQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     const expr_z = try dupZ(ctx, args[0].string.bytes());
     const result = c.xmlXPathEvalExpression(@ptrCast(expr_z.ptr), xctx);
-    if (result == null) return .{ .bool = false };
+    if (result == null) return NativeResult.scalar(.{ .bool = false });
     defer c.xmlXPathFreeObject(result);
 
     if (result.*.type != c.XPATH_NODESET) {
@@ -1358,7 +1351,7 @@ fn domXpathQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 // build a DOMNodeList from an xmlXPath nodeset. namespace pseudo-nodes get
 // converted into standalone PhpObjects right away because the underlying
 // xmlNs entries are freed when xmlXPathFreeObject runs on this result
-fn buildXpathNodeList(ctx: *NativeContext, owner_doc: *PhpObject, xset: *c.xmlNodeSet) !Value {
+fn buildXpathNodeList(ctx: *NativeContext, owner_doc: *PhpObject, xset: *c.xmlNodeSet) RuntimeError!NativeResult {
     const list_obj = try ctx.createObject("DOMNodeList");
     const arr = try ctx.createArray();
     var i: usize = 0;
@@ -1374,7 +1367,7 @@ fn buildXpathNodeList(ctx: *NativeContext, owner_doc: *PhpObject, xset: *c.xmlNo
     try list_obj.set(ctx.allocator, "__items", .{ .array = arr });
     try list_obj.set(ctx.allocator, "__pos", .{ .int = 0 });
     try list_obj.set(ctx.allocator, "length", .{ .int = @intCast(xset.nodeNr) });
-    return .{ .object = list_obj };
+    return NativeResult.borrowed(.{ .object = list_obj });
 }
 
 fn wrapNamespaceNode(ctx: *NativeContext, owner_doc: *PhpObject, ns: *c.xmlNs) !Value {
@@ -1396,17 +1389,17 @@ fn wrapNamespaceNode(ctx: *NativeContext, owner_doc: *PhpObject, ns: *c.xmlNs) !
     return .{ .object = obj };
 }
 
-fn domXpathEvaluate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn domXpathEvaluate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const doc_v = obj.get("__doc");
-    if (doc_v != .object) return .{ .bool = false };
-    const doc = getDocPtr(doc_v.object) orelse return .{ .bool = false };
+    if (doc_v != .object) return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(doc_v.object) orelse return NativeResult.scalar(.{ .bool = false });
 
     var context_node: ?*c.xmlNode = null;
     if (args.len > 1 and args[1] == .object) context_node = getNodePtr(args[1].object);
 
-    const xctx = c.xmlXPathNewContext(doc) orelse return .{ .bool = false };
+    const xctx = c.xmlXPathNewContext(doc) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.xmlXPathFreeContext(xctx);
     if (context_node) |cn| xctx.*.node = cn;
 
@@ -1422,7 +1415,7 @@ fn domXpathEvaluate(ctx: *NativeContext, args: []const Value) RuntimeError!Value
 
     const expr_z = try dupZ(ctx, args[0].string.bytes());
     const result = c.xmlXPathEvalExpression(@ptrCast(expr_z.ptr), xctx);
-    if (result == null) return .{ .bool = false };
+    if (result == null) return NativeResult.scalar(.{ .bool = false });
     defer c.xmlXPathFreeObject(result);
 
     switch (result.*.type) {
@@ -1431,14 +1424,14 @@ fn domXpathEvaluate(ctx: *NativeContext, args: []const Value) RuntimeError!Value
             if (xs == null) return try makeNodeList(ctx, doc_v.object, &.{});
             return try buildXpathNodeList(ctx, doc_v.object, xs);
         },
-        c.XPATH_BOOLEAN => return .{ .bool = result.*.boolval != 0 },
-        c.XPATH_NUMBER => return .{ .float = result.*.floatval },
+        c.XPATH_BOOLEAN => return NativeResult.scalar(.{ .bool = result.*.boolval != 0 }),
+        c.XPATH_NUMBER => return NativeResult.scalar(.{ .float = result.*.floatval }),
         c.XPATH_STRING => {
-            if (result.*.stringval == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+            if (result.*.stringval == null) return try NativeResult.copyString(ctx.allocator, "");
             const s = result.*.stringval;
-            return .{ .string = Value.String.borrowed(try dupString(ctx, s[0..cstrLen(s)])) };
+            return try NativeResult.copyString(ctx.allocator, s[0..cstrLen(s)]);
         },
-        else => return .null,
+        else => return NativeResult.scalar(.null),
     }
 }
 
@@ -1688,54 +1681,54 @@ fn registerNodeListClass(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "DOMNodeList::offsetUnset", domNodeListReadOnly);
 }
 
-fn domNodeListOffsetExists(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    const obj = getThisGlobal() orelse return .{ .bool = false };
-    const arr = nlItems(obj) orelse return .{ .bool = false };
+fn domNodeListOffsetExists(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThisGlobal() orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = nlItems(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const idx = Value.toInt(args[0]);
-    return .{ .bool = idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len)) });
 }
 
-fn domNodeListReadOnly(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn domNodeListReadOnly(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP's DOMNodeList ArrayAccess is read-only; offsetSet/offsetUnset are
     // no-ops in practice (they throw on some builds but the result is the
     // same: the list isn't mutated). matching that is enough for compat
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn domNodeListGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn domNodeListGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (std.mem.eql(u8, args[0].string.bytes(), "length")) {
         const items = obj.get("__items");
-        if (items != .array) return .{ .int = 0 };
-        return .{ .int = @intCast(items.array.entries.items.len) };
+        if (items != .array) return NativeResult.scalar(.{ .int = 0 });
+        return NativeResult.scalar(.{ .int = @intCast(items.array.entries.items.len) });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // DOMNamedNodeMap iterates with the attribute name as key (PHP semantics)
 // rather than the numeric index used for NodeList
-fn domNNMGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn domNNMGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const named = obj.get("__named");
-    if (named != .array) return .null;
+    if (named != .array) return NativeResult.scalar(.null);
     const iter_obj = try ctx.createObject("ArrayIterator");
     try iter_obj.set(ctx.allocator, "__data", named);
     try iter_obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try iter_obj.set(ctx.allocator, "__flags", .{ .int = 0 });
-    return .{ .object = iter_obj };
+    return NativeResult.borrowed(.{ .object = iter_obj });
 }
 
-fn domNodeListGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn domNodeListGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const items = obj.get("__items");
-    if (items != .array) return .null;
+    if (items != .array) return NativeResult.scalar(.null);
     const iter_obj = try ctx.createObject("ArrayIterator");
     try iter_obj.set(ctx.allocator, "__data", items);
     try iter_obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try iter_obj.set(ctx.allocator, "__flags", .{ .int = 0 });
-    return .{ .object = iter_obj };
+    return NativeResult.borrowed(.{ .object = iter_obj });
 }
 
 fn registerNamedNodeMapClass(vm: *VM, a: Allocator) !void {
@@ -1839,7 +1832,7 @@ pub const libxml_entries = .{
     .{ "libxml_set_external_entity_loader", libxmlSetExternalEntityLoader },
 };
 
-fn libxmlUseInternalErrors(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn libxmlUseInternalErrors(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const prev = libxml_internal_errors_enabled;
     if (args.len > 0) {
         switch (args[0]) {
@@ -1848,13 +1841,13 @@ fn libxmlUseInternalErrors(_: *NativeContext, args: []const Value) RuntimeError!
             else => {},
         }
     }
-    return .{ .bool = prev };
+    return NativeResult.scalar(.{ .bool = prev });
 }
 
-fn libxmlClearErrors(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn libxmlClearErrors(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     for (captured_errors.items) |*e| freeCapturedError(e);
     captured_errors.clearRetainingCapacity();
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn buildLibXMLError(ctx: *NativeContext, e: CapturedError) RuntimeError!Value {
@@ -1879,27 +1872,27 @@ fn buildLibXMLError(ctx: *NativeContext, e: CapturedError) RuntimeError!Value {
     return .{ .object = obj };
 }
 
-fn libxmlGetErrors(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn libxmlGetErrors(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     for (captured_errors.items) |e| {
         try arr.append(ctx.allocator, try buildLibXMLError(ctx, e));
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn libxmlGetLastError(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (captured_errors.items.len == 0) return .{ .bool = false };
-    return try buildLibXMLError(ctx, captured_errors.items[captured_errors.items.len - 1]);
+fn libxmlGetLastError(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    if (captured_errors.items.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(try buildLibXMLError(ctx, captured_errors.items[captured_errors.items.len - 1]));
 }
 
-fn libxmlDisableEntityLoader(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn libxmlDisableEntityLoader(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // deprecated in PHP 8.0+ and a noop on modern libxml. accept and return true
     _ = args;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn libxmlSetExternalEntityLoader(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn libxmlSetExternalEntityLoader(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {

--- a/src/stdlib/enums.zig
+++ b/src/stdlib/enums.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
@@ -9,7 +10,7 @@ fn enumClassFromCallName(ctx: *NativeContext) ?[]const u8 {
     return null;
 }
 
-pub fn enumCases(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+pub fn enumCases(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const enum_name = enumClassFromCallName(ctx) orelse return error.RuntimeError;
     const def = ctx.vm.classes.get(enum_name) orelse return error.RuntimeError;
     var arr = try ctx.createArray();
@@ -18,7 +19,7 @@ pub fn enumCases(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             try arr.append(ctx.allocator, val);
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn coerceForLookup(ctx: *NativeContext, def_backed: anytype, arg: Value) !Value {
@@ -124,37 +125,38 @@ fn checkEnumArgType(ctx: *NativeContext, backed: anytype, enum_name: []const u8,
     return null;
 }
 
-pub fn enumFrom(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+pub fn enumFrom(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) return error.RuntimeError;
     const enum_name = enumClassFromCallName(ctx) orelse return error.RuntimeError;
     const def = ctx.vm.classes.get(enum_name) orelse return error.RuntimeError;
-    if (try checkEnumArgType(ctx, def.backed_type, enum_name, "from", args[0])) |err_val| return err_val;
+    if (try checkEnumArgType(ctx, def.backed_type, enum_name, "from", args[0])) |err_val| return NativeResult.borrowed(err_val);
     const lookup = try coerceForLookup(ctx, def.backed_type, args[0]);
     var iter = def.static_props.iterator();
     while (iter.next()) |entry| {
         if (entry.value_ptr.* == .object) {
             const case_val = entry.value_ptr.*.object.get("value");
-            if (Value.identical(case_val, lookup)) return entry.value_ptr.*;
+            if (Value.identical(case_val, lookup)) return NativeResult.borrowed(entry.value_ptr.*);
         }
     }
     const arg_str = try argDisplayString(ctx, lookup);
     const msg = try std.fmt.allocPrint(ctx.allocator, "{s} is not a valid backing value for enum {s}", .{ arg_str, enum_name });
     try ctx.vm.strings.append(ctx.allocator, msg);
-    return throwBuiltin(ctx, "ValueError", msg);
+    _ = try throwBuiltin(ctx, "ValueError", msg);
+    unreachable;
 }
 
-pub fn enumTryFrom(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const enum_name = enumClassFromCallName(ctx) orelse return .null;
-    const def = ctx.vm.classes.get(enum_name) orelse return .null;
-    if (try checkEnumArgType(ctx, def.backed_type, enum_name, "tryFrom", args[0])) |err_val| return err_val;
+pub fn enumTryFrom(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const enum_name = enumClassFromCallName(ctx) orelse return NativeResult.scalar(.null);
+    const def = ctx.vm.classes.get(enum_name) orelse return NativeResult.scalar(.null);
+    if (try checkEnumArgType(ctx, def.backed_type, enum_name, "tryFrom", args[0])) |err_val| return NativeResult.borrowed(err_val);
     const lookup = try coerceForLookup(ctx, def.backed_type, args[0]);
     var iter = def.static_props.iterator();
     while (iter.next()) |entry| {
         if (entry.value_ptr.* == .object) {
             const case_val = entry.value_ptr.*.object.get("value");
-            if (Value.identical(case_val, lookup)) return entry.value_ptr.*;
+            if (Value.identical(case_val, lookup)) return NativeResult.borrowed(entry.value_ptr.*);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }

--- a/src/stdlib/exceptions.zig
+++ b/src/stdlib/exceptions.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
@@ -140,9 +141,9 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ErrorException::getSeverity", errorExceptionGetSeverity);
 }
 
-fn errorExceptionConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this_val != .object) return .null;
+fn errorExceptionConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this_val != .object) return NativeResult.scalar(.null);
     const obj = this_val.object;
     if (args.len >= 1) try obj.set(ctx.allocator, "message", args[0]);
     if (args.len >= 2) try obj.set(ctx.allocator, "code", args[1]);
@@ -150,19 +151,19 @@ fn errorExceptionConstruct(ctx: *NativeContext, args: []const Value) RuntimeErro
     if (args.len >= 4) try obj.set(ctx.allocator, "file", args[3]);
     if (args.len >= 5) try obj.set(ctx.allocator, "line", args[4]);
     if (args.len >= 6) try obj.set(ctx.allocator, "previous", args[5]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn errorExceptionGetSeverity(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .{ .int = 0 };
-    if (this_val != .object) return .{ .int = 0 };
+fn errorExceptionGetSeverity(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.{ .int = 0 });
+    if (this_val != .object) return NativeResult.scalar(.{ .int = 0 });
     const sev = this_val.object.get("severity");
-    return if (sev == .int) sev else .{ .int = 0 };
+    return NativeResult.scalar(if (sev == .int) sev else .{ .int = 0 });
 }
 
-fn exceptionConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this_val != .object) return .null;
+fn exceptionConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this_val != .object) return NativeResult.scalar(.null);
     const obj = this_val.object;
     if (args.len >= 1) try obj.set(ctx.allocator, "message", args[0]);
     if (args.len >= 2) try obj.set(ctx.allocator, "code", args[1]);
@@ -181,7 +182,7 @@ fn exceptionConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         }
     }
     try buildAndAttachTrace(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // read a still-live frame's bound parameter value by name, checking the
@@ -248,17 +249,16 @@ fn buildAndAttachTrace(ctx: *NativeContext, obj: *@import("../runtime/value.zig"
     try obj.setForScope(ctx.vm.allocator, "trace", .{ .array = arr }, ctx.vm.exceptionTraceScope(obj));
 }
 
-fn exceptionGetMessage(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this_val != .object) return .null;
+fn exceptionGetMessage(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this_val != .object) return NativeResult.scalar(.null);
     const message = this_val.object.get("message");
-    if (message == .string) message.string.retain();
-    return message;
+    return if (message == .string) NativeResult.shareString(message.string) else NativeResult.borrowed(message);
 }
 
-fn exceptionToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .{ .string = Value.String.borrowed("") };
-    if (this_val != .object) return .{ .string = Value.String.borrowed("") };
+fn exceptionToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.literal("");
+    if (this_val != .object) return NativeResult.literal("");
     const obj = this_val.object;
     const msg = obj.get("message");
     const msg_str = if (msg == .string) msg.string.bytes() else "";
@@ -267,52 +267,52 @@ fn exceptionToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const line = obj.get("line");
     const line_int = if (line == .int) line.int else 0;
     const s = try std.fmt.allocPrint(ctx.allocator, "{s}: {s} in {s}:{d}\nStack trace:\n#0 {{main}}", .{ obj.class_name, msg_str, file_str, line_int });
-    try ctx.vm.strings.append(ctx.allocator, s);
-    return .{ .string = Value.String.borrowed(s) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
 }
 
-fn exceptionGetCode(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this_val != .object) return .null;
-    return this_val.object.get("code");
+fn exceptionGetCode(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this_val != .object) return NativeResult.scalar(.null);
+    const value = this_val.object.get("code");
+    return if (value == .string) NativeResult.shareString(value.string) else NativeResult.borrowed(value);
 }
 
-fn exceptionGetPrevious(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this_val != .object) return .null;
-    return this_val.object.get("previous");
+fn exceptionGetPrevious(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this_val != .object) return NativeResult.scalar(.null);
+    return NativeResult.borrowed(this_val.object.get("previous"));
 }
 
-fn exceptionGetFile(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this_val != .object) return .null;
+fn exceptionGetFile(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this_val != .object) return NativeResult.scalar(.null);
     const v = this_val.object.get("file");
-    return if (v == .string) v else .{ .string = Value.String.borrowed("") };
+    return if (v == .string) NativeResult.shareString(v.string) else NativeResult.literal("");
 }
 
-fn exceptionGetLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this_val != .object) return .null;
+fn exceptionGetLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this_val != .object) return NativeResult.scalar(.null);
     const v = this_val.object.get("line");
-    return if (v == .int) v else .{ .int = 0 };
+    return NativeResult.scalar(if (v == .int) v else .{ .int = 0 });
 }
 
-fn exceptionGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn exceptionGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const PhpArray = @import("../runtime/value.zig").PhpArray;
     const this_val = ctx.vm.currentFrame().vars.get("$this") orelse {
         const arr = try ctx.vm.allocator.create(PhpArray);
         arr.* = .{};
         try ctx.vm.arrays.append(ctx.vm.allocator, arr);
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     };
     if (this_val == .object) {
         const t = this_val.object.getForScope("trace", ctx.vm.exceptionTraceScope(this_val.object));
-        if (t == .array) return t;
+        if (t == .array) return NativeResult.borrowed(t);
     }
     const arr = try ctx.vm.allocator.create(PhpArray);
     arr.* = .{};
     try ctx.vm.arrays.append(ctx.vm.allocator, arr);
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // render a single call argument the way PHP's exception trace does: quoted
@@ -344,9 +344,9 @@ fn formatTraceArg(buf: *std.ArrayListUnmanaged(u8), alloc: std.mem.Allocator, v:
     }
 }
 
-fn exceptionGetTraceAsString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return .{ .string = Value.String.borrowed("") };
-    if (this_val != .object) return .{ .string = Value.String.borrowed("") };
+fn exceptionGetTraceAsString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.literal("");
+    if (this_val != .object) return NativeResult.literal("");
     const t = this_val.object.getForScope("trace", ctx.vm.exceptionTraceScope(this_val.object));
     var buf: std.ArrayListUnmanaged(u8) = .{};
     defer buf.deinit(ctx.allocator);
@@ -386,7 +386,5 @@ fn exceptionGetTraceAsString(ctx: *NativeContext, _: []const Value) RuntimeError
     } else {
         try buf.appendSlice(ctx.allocator, "#0 {main}");
     }
-    const owned = try ctx.allocator.dupe(u8, buf.items);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator)));
 }

--- a/src/stdlib/filesystem.zig
+++ b/src/stdlib/filesystem.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -461,7 +462,7 @@ fn curlHeaderCallback(data: [*]u8, size: usize, nmemb: usize, userdata: *anyopaq
     return total;
 }
 
-fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
+fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!NativeResult {
     if (ctx.vm.last_http_response_headers) |previous| ctx.vm.arrayRelease(previous);
     ctx.vm.last_http_response_headers = null;
 
@@ -471,11 +472,11 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
         curl_global_init_done = true;
     }
 
-    const handle = c_curl.curl_easy_init() orelse return .{ .bool = false };
+    const handle = c_curl.curl_easy_init() orelse return NativeResult.scalar(.{ .bool = false });
     defer c_curl.curl_easy_cleanup(handle);
 
     var url_buf: [8192]u8 = undefined;
-    if (url.len >= url_buf.len) return .{ .bool = false };
+    if (url.len >= url_buf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(url_buf[0..url.len], url);
     url_buf[url.len] = 0;
 
@@ -489,7 +490,7 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
     };
     defer wd.buffer.deinit(wd.allocator);
 
-    const headers_arr = ctx.createArray() catch return .{ .bool = false };
+    const headers_arr = ctx.createArray() catch return NativeResult.scalar(.{ .bool = false });
     @import("../runtime/vm.zig").VM.arrayRetain(headers_arr);
     defer ctx.vm.arrayRelease(headers_arr);
     var hd = CurlHeaderData{
@@ -507,19 +508,21 @@ fn fetchUrl(ctx: *NativeContext, url: []const u8) RuntimeError!Value {
         @import("../runtime/vm.zig").VM.arrayRetain(headers_arr);
         ctx.vm.last_http_response_headers = headers_arr;
     }
-    if (result != c_curl.CURLE_OK) return .{ .bool = false };
+    if (result != c_curl.CURLE_OK) return NativeResult.scalar(.{ .bool = false });
 
-    return .{ .string = Value.String.borrowed(try ctx.createString(wd.buffer.items)) };
+    const body = try wd.buffer.toOwnedSlice(wd.allocator);
+    errdefer wd.allocator.free(body);
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, body));
 }
 
-fn native_file_get_contents(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_file_get_contents(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     var path = args[0].string.bytes();
     if (std.mem.startsWith(u8, path, "file://")) path = path[7..];
     if (userWrapperFor(ctx.vm, path)) |class_name| {
-        const opened = (try dispatchUserOpen(ctx, class_name, path, "rb")) orelse return Value{ .bool = false };
+        const opened = (try dispatchUserOpen(ctx, class_name, path, "rb")) orelse return NativeResult.scalar(.{ .bool = false });
         const fh = opened.object;
-        const wrapper = fileHandleWrapper(fh) orelse return .{ .bool = false };
+        const wrapper = fileHandleWrapper(fh) orelse return NativeResult.scalar(.{ .bool = false });
         var buf = std.ArrayListUnmanaged(u8){};
         defer buf.deinit(ctx.allocator);
         while (true) {
@@ -531,50 +534,45 @@ fn native_file_get_contents(ctx: *NativeContext, args: []const Value) RuntimeErr
             _ = try ctx.callMethod(wrapper, "stream_close", &.{});
         }
         const owned = try buf.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, owned);
-        return .{ .string = Value.String.borrowed(owned) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
     }
     if (extractScheme(path)) |s| {
-        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return .{ .bool = false };
+        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return NativeResult.scalar(.{ .bool = false });
     }
     if (std.mem.eql(u8, path, "php://input")) {
-        const body_val = ctx.vm.request_vars.get("__raw_body") orelse return .{ .string = Value.String.borrowed("") };
-        if (body_val == .string) return body_val;
-        return .{ .string = Value.String.borrowed("") };
+        const body_val = ctx.vm.request_vars.get("__raw_body") orelse return NativeResult.literal("");
+        if (body_val == .string) return NativeResult.share(body_val);
+        return NativeResult.literal("");
     }
     if (std.mem.eql(u8, path, "php://stdin")) {
         const stdin = std.fs.File{ .handle = 0 };
-        const data = stdin.readToEndAlloc(ctx.allocator, 1024 * 1024 * 64) catch return Value{ .bool = false };
-        try ctx.strings.append(ctx.allocator, data);
-        return .{ .string = Value.String.borrowed(data) };
+        const data = stdin.readToEndAlloc(ctx.allocator, 1024 * 1024 * 64) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, data));
     }
     if (std.mem.eql(u8, path, "php://stdout") or std.mem.eql(u8, path, "php://output") or std.mem.eql(u8, path, "php://stderr")) {
-        return .{ .string = Value.String.borrowed("") };
+        return NativeResult.literal("");
     }
     if (std.mem.startsWith(u8, path, "data:")) {
-        const payload = (parseDataUri(ctx.allocator, path) catch return Value{ .bool = false }) orelse return Value{ .bool = false };
-        try ctx.strings.append(ctx.allocator, payload);
-        return .{ .string = Value.String.borrowed(payload) };
+        const payload = (parseDataUri(ctx.allocator, path) catch return NativeResult.scalar(.{ .bool = false })) orelse return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, payload));
     }
     if (std.mem.startsWith(u8, path, "phar://")) {
-        const r = resolvePharPathWithCtx(path, ctx) orelse return .{ .bool = false };
-        const payload = (readPharEntry(ctx.allocator, r.archive_path, r.internal_path) catch return Value{ .bool = false }) orelse return Value{ .bool = false };
-        try ctx.strings.append(ctx.allocator, payload);
-        return .{ .string = Value.String.borrowed(payload) };
+        const r = resolvePharPathWithCtx(path, ctx) orelse return NativeResult.scalar(.{ .bool = false });
+        const payload = (readPharEntry(ctx.allocator, r.archive_path, r.internal_path) catch return NativeResult.scalar(.{ .bool = false })) orelse return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, payload));
     }
     if (std.mem.startsWith(u8, path, ZLIB_PREFIX)) {
-        const decoded = readZlibFile(ctx.allocator, path) catch return Value{ .bool = false };
-        try ctx.strings.append(ctx.allocator, decoded);
-        return .{ .string = Value.String.borrowed(decoded) };
+        const decoded = readZlibFile(ctx.allocator, path) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, decoded));
     }
     if (path.len > 7 and (std.mem.startsWith(u8, path, "http://") or std.mem.startsWith(u8, path, "https://"))) {
         return fetchUrl(ctx, path);
     }
-    const content = std.fs.cwd().readFileAlloc(ctx.allocator, path, 1024 * 1024 * 64) catch return Value{ .bool = false };
-    try ctx.strings.append(ctx.allocator, content);
+    const content = std.fs.cwd().readFileAlloc(ctx.allocator, path, 1024 * 1024 * 64) catch return NativeResult.scalar(.{ .bool = false });
 
     // optional offset (4th arg) and length (5th arg)
     if (args.len >= 4 and args[3] != .null) {
+        defer ctx.allocator.free(content);
         const total_i: i64 = @intCast(content.len);
         var offset = Value.toInt(args[3]);
         if (offset < 0) offset = @max(0, total_i + offset);
@@ -582,18 +580,20 @@ fn native_file_get_contents(ctx: *NativeContext, args: []const Value) RuntimeErr
         const ustart: usize = @intCast(offset);
         const have_len = args.len >= 5 and args[4] != .null;
         const length: i64 = if (have_len) Value.toInt(args[4]) else total_i - offset;
-        if (length < 0) return .{ .bool = false };
+        if (length < 0) return NativeResult.scalar(.{ .bool = false });
         const finish = @min(content.len, ustart + @as(usize, @intCast(length)));
-        const slice = try ctx.allocator.dupe(u8, content[ustart..finish]);
-        try ctx.strings.append(ctx.allocator, slice);
-        return .{ .string = Value.String.borrowed(slice) };
+        return try NativeResult.copyString(ctx.allocator, content[ustart..finish]);
     }
 
-    return .{ .string = Value.String.borrowed(content) };
+    const owned = Value.String.adopt(ctx.allocator, content) catch |err| {
+        ctx.allocator.free(content);
+        return err;
+    };
+    return NativeResult.takeString(owned);
 }
 
-fn native_file_put_contents(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
+fn native_file_put_contents(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     const data = if (args[1] == .string) args[1].string.bytes() else if (args[1] == .array) blk: {
         // PHP writes an array argument as its elements concatenated, like
@@ -613,21 +613,21 @@ fn native_file_put_contents(ctx: *NativeContext, args: []const Value) RuntimeErr
         break :blk s;
     };
     if (userWrapperFor(ctx.vm, path)) |class_name| {
-        const opened = (try dispatchUserOpen(ctx, class_name, path, "wb")) orelse return Value{ .bool = false };
-        const wrapper = fileHandleWrapper(opened.object) orelse return .{ .bool = false };
+        const opened = (try dispatchUserOpen(ctx, class_name, path, "wb")) orelse return NativeResult.scalar(.{ .bool = false });
+        const wrapper = fileHandleWrapper(opened.object) orelse return NativeResult.scalar(.{ .bool = false });
         const written = try ctx.callMethod(wrapper, "stream_write", &[_]Value{.{ .string = Value.String.borrowed(data) }});
         if (ctx.vm.hasMethod(wrapper.class_name, "stream_close")) {
             _ = try ctx.callMethod(wrapper, "stream_close", &.{});
         }
-        if (written != .int) return .{ .bool = false };
-        return .{ .int = written.int };
+        if (written != .int) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .int = written.int });
     }
     if (extractScheme(path)) |s| {
-        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return .{ .bool = false };
+        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return NativeResult.scalar(.{ .bool = false });
     }
     if (std.mem.eql(u8, path, "php://stdout") or std.mem.eql(u8, path, "php://output")) {
         try ctx.vm.output.appendSlice(ctx.allocator, data);
-        return .{ .int = @intCast(data.len) };
+        return NativeResult.scalar(.{ .int = @intCast(data.len) });
     }
     if (std.mem.eql(u8, path, "php://stderr")) {
         if (ctx.vm.output.items.len > 0) {
@@ -636,112 +636,112 @@ fn native_file_put_contents(ctx: *NativeContext, args: []const Value) RuntimeErr
             ctx.vm.output.clearRetainingCapacity();
         }
         const stderr = std.fs.File{ .handle = 2 };
-        const n = stderr.write(data) catch return Value{ .bool = false };
-        return .{ .int = @intCast(n) };
+        const n = stderr.write(data) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .int = @intCast(n) });
     }
     if (std.mem.startsWith(u8, path, ZLIB_PREFIX)) {
-        writeZlibFile(ctx.allocator, path, data) catch return Value{ .bool = false };
-        return .{ .int = @intCast(data.len) };
+        writeZlibFile(ctx.allocator, path, data) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .int = @intCast(data.len) });
     }
     const flags: i64 = if (args.len >= 3) Value.toInt(args[2]) else 0;
     const append = (flags & 8) != 0; // FILE_APPEND = 8
     if (append) {
         const file = std.fs.cwd().openFile(path, .{ .mode = .write_only }) catch {
-            std.fs.cwd().writeFile(.{ .sub_path = path, .data = data }) catch return Value{ .bool = false };
-            return .{ .int = @intCast(data.len) };
+            std.fs.cwd().writeFile(.{ .sub_path = path, .data = data }) catch return NativeResult.scalar(.{ .bool = false });
+            return NativeResult.scalar(.{ .int = @intCast(data.len) });
         };
         defer file.close();
-        file.seekFromEnd(0) catch return Value{ .bool = false };
-        _ = file.write(data) catch return Value{ .bool = false };
+        file.seekFromEnd(0) catch return NativeResult.scalar(.{ .bool = false });
+        _ = file.write(data) catch return NativeResult.scalar(.{ .bool = false });
     } else {
-        std.fs.cwd().writeFile(.{ .sub_path = path, .data = data }) catch return Value{ .bool = false };
+        std.fs.cwd().writeFile(.{ .sub_path = path, .data = data }) catch return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .int = @intCast(data.len) };
+    return NativeResult.scalar(.{ .int = @intCast(data.len) });
 }
 
-fn native_file_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_file_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     if (userWrapperFor(ctx.vm, path)) |class_name| {
         const arr = try dispatchUserStat(ctx, class_name, path, 0);
-        return .{ .bool = arr != null };
+        return NativeResult.scalar(.{ .bool = arr != null });
     }
     if (extractScheme(path)) |s| {
-        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return .{ .bool = false };
+        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return NativeResult.scalar(.{ .bool = false });
     }
     if (std.mem.startsWith(u8, path, "phar://")) {
-        const r = resolvePharPathWithCtx(path, ctx) orelse return .{ .bool = false };
-        if (r.internal_path.len == 0) return .{ .bool = true }; // archive itself
-        var loaded = loadPhar(ctx.allocator, r.archive_path) catch return Value{ .bool = false };
+        const r = resolvePharPathWithCtx(path, ctx) orelse return NativeResult.scalar(.{ .bool = false });
+        if (r.internal_path.len == 0) return NativeResult.scalar(.{ .bool = true }); // archive itself
+        var loaded = loadPhar(ctx.allocator, r.archive_path) catch return NativeResult.scalar(Value{ .bool = false });
         defer freePhar(ctx.allocator, &loaded);
-        const normalized = normalizePharInternalPath(ctx.allocator, r.internal_path) catch return .{ .bool = false };
+        const normalized = normalizePharInternalPath(ctx.allocator, r.internal_path) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(normalized);
-        if (loaded.parsed.lookup(normalized) != null) return .{ .bool = true };
-        return .{ .bool = loaded.parsed.isDir(normalized) };
+        if (loaded.parsed.lookup(normalized) != null) return NativeResult.scalar(.{ .bool = true });
+        return NativeResult.scalar(.{ .bool = loaded.parsed.isDir(normalized) });
     }
     if (std.mem.startsWith(u8, path, ZLIB_PREFIX)) {
-        std.fs.cwd().access(path[ZLIB_PREFIX.len..], .{}) catch return Value{ .bool = false };
-        return .{ .bool = true };
+        std.fs.cwd().access(path[ZLIB_PREFIX.len..], .{}) catch return NativeResult.scalar(Value{ .bool = false });
+        return NativeResult.scalar(.{ .bool = true });
     }
-    std.fs.cwd().access(path, .{}) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    std.fs.cwd().access(path, .{}) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_is_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    const path = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return .{ .bool = false };
+fn native_is_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const path = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return NativeResult.scalar(.{ .bool = false });
     if (userWrapperFor(ctx.vm, path)) |class_name| {
-        const arr = (try dispatchUserStat(ctx, class_name, path, 0)) orelse return .{ .bool = false };
+        const arr = (try dispatchUserStat(ctx, class_name, path, 0)) orelse return NativeResult.scalar(.{ .bool = false });
         const mode_v = arr.get(.{ .string = Value.String.borrowed("mode") });
-        if (mode_v != .int) return .{ .bool = false };
-        return .{ .bool = (mode_v.int & 0o170000) == 0o100000 };
+        if (mode_v != .int) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .bool = (mode_v.int & 0o170000) == 0o100000 });
     }
     if (extractScheme(path)) |s| {
-        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return .{ .bool = false };
+        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return NativeResult.scalar(.{ .bool = false });
     }
     if (std.mem.startsWith(u8, path, "phar://")) {
-        const r = resolvePharPathWithCtx(path, ctx) orelse return .{ .bool = false };
-        if (r.internal_path.len == 0) return .{ .bool = true };
-        var loaded = loadPhar(ctx.allocator, r.archive_path) catch return Value{ .bool = false };
+        const r = resolvePharPathWithCtx(path, ctx) orelse return NativeResult.scalar(.{ .bool = false });
+        if (r.internal_path.len == 0) return NativeResult.scalar(.{ .bool = true });
+        var loaded = loadPhar(ctx.allocator, r.archive_path) catch return NativeResult.scalar(Value{ .bool = false });
         defer freePhar(ctx.allocator, &loaded);
-        const normalized = normalizePharInternalPath(ctx.allocator, r.internal_path) catch return .{ .bool = false };
+        const normalized = normalizePharInternalPath(ctx.allocator, r.internal_path) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(normalized);
-        return .{ .bool = loaded.parsed.lookup(normalized) != null };
+        return NativeResult.scalar(.{ .bool = loaded.parsed.lookup(normalized) != null });
     }
     if (std.mem.startsWith(u8, path, ZLIB_PREFIX)) {
-        const stat = std.fs.cwd().statFile(path[ZLIB_PREFIX.len..]) catch return Value{ .bool = false };
-        return .{ .bool = stat.kind == .file };
+        const stat = std.fs.cwd().statFile(path[ZLIB_PREFIX.len..]) catch return NativeResult.scalar(Value{ .bool = false });
+        return NativeResult.scalar(.{ .bool = stat.kind == .file });
     }
-    const stat = std.fs.cwd().statFile(path) catch return Value{ .bool = false };
-    return .{ .bool = stat.kind == .file };
+    const stat = std.fs.cwd().statFile(path) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .bool = stat.kind == .file });
 }
 
-fn native_is_dir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    const path = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return .{ .bool = false };
+fn native_is_dir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const path = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return NativeResult.scalar(.{ .bool = false });
     if (userWrapperFor(ctx.vm, path)) |class_name| {
-        const arr = (try dispatchUserStat(ctx, class_name, path, 0)) orelse return .{ .bool = false };
+        const arr = (try dispatchUserStat(ctx, class_name, path, 0)) orelse return NativeResult.scalar(.{ .bool = false });
         const mode_v = arr.get(.{ .string = Value.String.borrowed("mode") });
-        if (mode_v != .int) return .{ .bool = false };
-        return .{ .bool = (mode_v.int & 0o170000) == 0o040000 };
+        if (mode_v != .int) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .bool = (mode_v.int & 0o170000) == 0o040000 });
     }
     if (extractScheme(path)) |s| {
-        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return .{ .bool = false };
+        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return NativeResult.scalar(.{ .bool = false });
     }
     if (std.mem.startsWith(u8, path, "phar://")) {
-        const r = resolvePharPathWithCtx(path, ctx) orelse return .{ .bool = false };
-        if (r.internal_path.len == 0) return .{ .bool = false }; // the archive is a file, not a dir
-        var loaded = loadPhar(ctx.allocator, r.archive_path) catch return Value{ .bool = false };
+        const r = resolvePharPathWithCtx(path, ctx) orelse return NativeResult.scalar(.{ .bool = false });
+        if (r.internal_path.len == 0) return NativeResult.scalar(.{ .bool = false }); // the archive is a file, not a dir
+        var loaded = loadPhar(ctx.allocator, r.archive_path) catch return NativeResult.scalar(Value{ .bool = false });
         defer freePhar(ctx.allocator, &loaded);
-        return .{ .bool = loaded.parsed.isDir(r.internal_path) };
+        return NativeResult.scalar(.{ .bool = loaded.parsed.isDir(r.internal_path) });
     }
-    var dir = std.fs.cwd().openDir(path, .{}) catch return Value{ .bool = false };
+    var dir = std.fs.cwd().openDir(path, .{}) catch return NativeResult.scalar(Value{ .bool = false });
     dir.close();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_basename(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_basename(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     var path = args[0].string.bytes();
     const suffix = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "";
     // PHP strips trailing slashes before extracting the last segment
@@ -753,15 +753,15 @@ fn native_basename(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     if (suffix.len > 0 and name.len > suffix.len and std.mem.endsWith(u8, name, suffix)) {
         name = name[0 .. name.len - suffix.len];
     }
-    return .{ .string = Value.String.borrowed(try ctx.createString(name)) };
+    return NativeResult.copyString(ctx.allocator, name);
 }
 
-fn native_dirname(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_dirname(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     var path = args[0].string.bytes();
-    if (path.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (path.len == 0) return NativeResult.literal("");
     var levels: i64 = if (args.len >= 2) Value.toInt(args[1]) else 1;
-    if (levels <= 0) return .{ .string = Value.String.borrowed(try ctx.createString(path)) };
+    if (levels <= 0) return NativeResult.copyString(ctx.allocator, path);
     while (levels > 0) : (levels -= 1) {
         while (path.len > 1 and path[path.len - 1] == '/') path = path[0 .. path.len - 1];
         if (std.mem.lastIndexOf(u8, path, "/")) |pos| {
@@ -775,11 +775,11 @@ fn native_dirname(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             break;
         }
     }
-    return .{ .string = Value.String.borrowed(try ctx.createString(path)) };
+    return NativeResult.copyString(ctx.allocator, path);
 }
 
-fn native_pathinfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .null;
+fn native_pathinfo(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.null);
     // PHP strips trailing slashes from the input before splitting (so
     // pathinfo("/a/b/") yields dirname=/a, basename=b, matching basename())
     var path = args[0].string.bytes();
@@ -798,11 +798,11 @@ fn native_pathinfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     if (args.len >= 2 and args[1] == .int) {
         const flag = args[1].int;
         return switch (flag) {
-            1 => .{ .string = Value.String.borrowed(try ctx.createString(dir)) },
-            2 => .{ .string = Value.String.borrowed(try ctx.createString(base)) },
-            4 => .{ .string = Value.String.borrowed(try ctx.createString(ext)) },
-            8 => .{ .string = Value.String.borrowed(try ctx.createString(filename)) },
-            else => .null,
+            1 => try NativeResult.copyString(ctx.allocator, dir),
+            2 => try NativeResult.copyString(ctx.allocator, base),
+            4 => try NativeResult.copyString(ctx.allocator, ext),
+            8 => try NativeResult.copyString(ctx.allocator, filename),
+            else => NativeResult.scalar(.null),
         };
     }
 
@@ -813,75 +813,75 @@ fn native_pathinfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("extension") }, .{ .string = Value.String.borrowed(try ctx.createString(ext)) });
     }
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("filename") }, .{ .string = Value.String.borrowed(try ctx.createString(filename)) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_realpath(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_realpath(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const resolved = std.fs.cwd().realpath(args[0].string.bytes(), &buf) catch return Value{ .bool = false };
-    return .{ .string = Value.String.borrowed(try ctx.createString(resolved)) };
+    const resolved = std.fs.cwd().realpath(args[0].string.bytes(), &buf) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.copyString(ctx.allocator, resolved);
 }
 
 // directory operations
 
-fn native_mkdir(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_mkdir(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     const recursive = args.len >= 3 and args[2].isTruthy();
     if (recursive) {
-        std.fs.cwd().makePath(path) catch return Value{ .bool = false };
+        std.fs.cwd().makePath(path) catch return NativeResult.scalar(Value{ .bool = false });
     } else {
-        std.fs.cwd().makeDir(path) catch return Value{ .bool = false };
+        std.fs.cwd().makeDir(path) catch return NativeResult.scalar(Value{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_rmdir(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    std.fs.cwd().deleteDir(args[0].string.bytes()) catch return Value{ .bool = false };
-    return .{ .bool = true };
+fn native_rmdir(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    std.fs.cwd().deleteDir(args[0].string.bytes()) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_unlink(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_unlink(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     if (userWrapperFor(ctx.vm, path)) |class_name| {
-        if (!ctx.vm.hasMethod(class_name, "unlink")) return .{ .bool = false };
+        if (!ctx.vm.hasMethod(class_name, "unlink")) return NativeResult.scalar(.{ .bool = false });
         const wrapper = try ctx.createObject(class_name);
         if (ctx.vm.hasMethod(class_name, "__construct")) {
             _ = try ctx.callMethod(wrapper, "__construct", &.{});
         }
-        const result = try ctx.callMethod(wrapper, "unlink", &[_]Value{.{ .string = Value.String.borrowed(path) }});
-        return .{ .bool = result.isTruthy() };
+        const result = try ctx.callMethod(wrapper, "unlink", &[_]Value{args[0]});
+        return NativeResult.scalar(.{ .bool = result.isTruthy() });
     }
     if (extractScheme(path)) |s| {
-        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return .{ .bool = false };
+        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return NativeResult.scalar(.{ .bool = false });
     }
-    std.fs.cwd().deleteFile(path) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    std.fs.cwd().deleteFile(path) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_copy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const source = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return .{ .bool = false };
-    std.fs.cwd().copyFile(source, std.fs.cwd(), args[1].string.bytes(), .{}) catch return Value{ .bool = false };
-    return .{ .bool = true };
+fn native_copy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const source = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return NativeResult.scalar(.{ .bool = false });
+    std.fs.cwd().copyFile(source, std.fs.cwd(), args[1].string.bytes(), .{}) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_rename(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    std.fs.cwd().rename(args[0].string.bytes(), args[1].string.bytes()) catch return Value{ .bool = false };
-    return .{ .bool = true };
+fn native_rename(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    std.fs.cwd().rename(args[0].string.bytes(), args[1].string.bytes()) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // directory listing
 
-fn native_scandir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_scandir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     // SCANDIR_SORT_ASCENDING=0, _DESCENDING=1, _NONE=2
     const order: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else 0;
-    var dir = std.fs.cwd().openDir(args[0].string.bytes(), .{ .iterate = true }) catch return Value{ .bool = false };
+    var dir = std.fs.cwd().openDir(args[0].string.bytes(), .{ .iterate = true }) catch return NativeResult.scalar(.{ .bool = false });
     defer dir.close();
 
     var names = std.ArrayListUnmanaged([]const u8){};
@@ -911,49 +911,49 @@ fn native_scandir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     var result = try ctx.createArray();
     for (names.items) |n| try result.append(ctx.allocator, .{ .string = Value.String.borrowed(n) });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 // dir($path) returns a Directory object with path, handle, and read/rewind/
 // close methods that delegate to the underlying DirectoryHandle. PHP's
 // 'Directory' is a thin OO wrapper around opendir/readdir/rewinddir/closedir
-fn native_dir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const handle = try native_opendir(ctx, args);
-    if (handle != .object) return .{ .bool = false };
+fn native_dir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const handle = (try native_opendir(ctx, args)).value;
+    if (handle != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("Directory");
     try obj.set(ctx.allocator, "path", .{ .string = args[0].string });
     try obj.set(ctx.allocator, "handle", handle);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn directoryRead(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = ctx.vm.currentFrame().vars.get("$this") orelse return .{ .bool = false };
-    if (this != .object) return .{ .bool = false };
+fn directoryRead(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.{ .bool = false });
+    if (this != .object) return NativeResult.scalar(.{ .bool = false });
     const h = this.object.get("handle");
-    if (h != .object) return .{ .bool = false };
+    if (h != .object) return NativeResult.scalar(.{ .bool = false });
     return native_readdir(ctx, &.{h});
 }
 
-fn directoryRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this != .object) return .null;
+fn directoryRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this != .object) return NativeResult.scalar(.null);
     const h = this.object.get("handle");
-    if (h != .object) return .null;
+    if (h != .object) return NativeResult.scalar(.null);
     return native_rewinddir(ctx, &.{h});
 }
 
-fn directoryClose(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (this != .object) return .null;
+fn directoryClose(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (this != .object) return NativeResult.scalar(.null);
     const h = this.object.get("handle");
-    if (h != .object) return .null;
+    if (h != .object) return NativeResult.scalar(.null);
     return native_closedir(ctx, &.{h});
 }
 
-fn native_opendir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    var dir = std.fs.cwd().openDir(args[0].string.bytes(), .{ .iterate = true }) catch return Value{ .bool = false };
+fn native_opendir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    var dir = std.fs.cwd().openDir(args[0].string.bytes(), .{ .iterate = true }) catch return NativeResult.scalar(.{ .bool = false });
     defer dir.close();
     const names_arr = try ctx.allocator.create(PhpArray);
     names_arr.* = .{};
@@ -971,45 +971,45 @@ fn native_opendir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try obj.set(ctx.allocator, "__pos", .{ .int = 0 });
     try obj.set(ctx.allocator, "__open", .{ .bool = true });
     try ctx.vm.objects.append(ctx.allocator, obj);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_readdir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_readdir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     const open = obj.get("__open");
-    if (open != .bool or !open.bool) return .{ .bool = false };
+    if (open != .bool or !open.bool) return NativeResult.scalar(.{ .bool = false });
     const dir_entries = obj.get("__entries");
-    if (dir_entries != .array) return .{ .bool = false };
+    if (dir_entries != .array) return NativeResult.scalar(.{ .bool = false });
     const pos = Value.toInt(obj.get("__pos"));
-    if (pos < 0 or pos >= dir_entries.array.length()) return .{ .bool = false };
+    if (pos < 0 or pos >= dir_entries.array.length()) return NativeResult.scalar(.{ .bool = false });
     const entry = dir_entries.array.entries.items[@intCast(pos)].value;
     try obj.set(ctx.allocator, "__pos", .{ .int = pos + 1 });
-    return entry;
+    return NativeResult.share(entry);
 }
 
-fn native_closedir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .null;
+fn native_closedir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const obj = args[0].object;
     try obj.set(ctx.allocator, "__open", .{ .bool = false });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_rewinddir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .null;
+fn native_rewinddir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const obj = args[0].object;
     try obj.set(ctx.allocator, "__pos", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_fnmatch(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_fnmatch(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const flags: i64 = if (args.len >= 3) Value.toInt(args[2]) else 0;
-    return .{ .bool = globMatchFlags(args[0].string.bytes(), args[1].string.bytes(), flags) };
+    return NativeResult.scalar(.{ .bool = globMatchFlags(args[0].string.bytes(), args[1].string.bytes(), flags) });
 }
 
-fn native_glob(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_glob(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const pattern = args[0].string.bytes();
     const flags: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else 0;
     const GLOB_BRACE: i64 = 128;
@@ -1031,7 +1031,7 @@ fn native_glob(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     try globAppend(ctx, result, expanded, flags);
                 }
                 if ((flags & GLOB_NOSORT) == 0) sortArrayValues(result);
-                return .{ .array = result };
+                return NativeResult.borrowed(.{ .array = result });
             }
         }
     }
@@ -1045,7 +1045,7 @@ fn native_glob(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try result.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(pattern)) });
     }
     _ = GLOB_ONLYDIR;
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 fn globAppend(ctx: *NativeContext, result: *PhpArray, pattern: []const u8, flags: i64) !void {
@@ -1175,78 +1175,78 @@ fn globMatchFlags(pattern: []const u8, name: []const u8, flags: i64) bool {
 
 // file info
 
-fn native_is_readable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_is_readable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     if (std.mem.startsWith(u8, args[0].string.bytes(), "phar://")) return native_is_file(ctx, args);
-    std.fs.cwd().access(args[0].string.bytes(), .{ .mode = .read_only }) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    std.fs.cwd().access(args[0].string.bytes(), .{ .mode = .read_only }) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_is_writable(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_is_writable(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
-    std.posix.access(path, std.posix.W_OK) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    std.posix.access(path, std.posix.W_OK) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_is_executable(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_is_executable(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
-    std.posix.access(path, std.posix.X_OK) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    std.posix.access(path, std.posix.X_OK) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_filesize(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return Value{ .bool = false };
-    return .{ .int = @intCast(stat.size) };
+fn native_filesize(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(stat.size) });
 }
 
-fn native_filemtime(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return Value{ .bool = false };
-    return .{ .int = @intCast(@divFloor(stat.mtime, 1_000_000_000)) };
+fn native_filemtime(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(@divFloor(stat.mtime, 1_000_000_000)) });
 }
 
-fn native_fileatime(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return Value{ .bool = false };
-    return .{ .int = @intCast(@divFloor(stat.atime, 1_000_000_000)) };
+fn native_fileatime(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(@divFloor(stat.atime, 1_000_000_000)) });
 }
 
-fn native_filectime(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return Value{ .bool = false };
-    return .{ .int = @intCast(@divFloor(stat.ctime, 1_000_000_000)) };
+fn native_filectime(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(@divFloor(stat.ctime, 1_000_000_000)) });
 }
 
-fn native_fileinode(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return Value{ .bool = false };
-    return .{ .int = @intCast(stat.inode) };
+fn native_fileinode(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return NativeResult.scalar(Value{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(stat.inode) });
 }
 
-fn native_filetype(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_filetype(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch {
         // might be a directory
-        var dir = std.fs.cwd().openDir(args[0].string.bytes(), .{}) catch return Value{ .bool = false };
+        var dir = std.fs.cwd().openDir(args[0].string.bytes(), .{}) catch return NativeResult.scalar(.{ .bool = false });
         dir.close();
-        return .{ .string = Value.String.borrowed("dir") };
+        return NativeResult.literal("dir");
     };
-    return .{ .string = Value.String.borrowed(switch (stat.kind) {
+    return try NativeResult.copyString(ctx.allocator, switch (stat.kind) {
         .file => "file",
         .directory => "dir",
         .sym_link => "link",
         else => "unknown",
-    }) };
+    });
 }
 
 // read file into array of lines
 
-fn native_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const content = std.fs.cwd().readFileAlloc(ctx.allocator, args[0].string.bytes(), 1024 * 1024 * 64) catch return Value{ .bool = false };
+fn native_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const content = std.fs.cwd().readFileAlloc(ctx.allocator, args[0].string.bytes(), 1024 * 1024 * 64) catch return NativeResult.scalar(.{ .bool = false });
     try ctx.strings.append(ctx.allocator, content);
 
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
@@ -1276,24 +1276,24 @@ fn native_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try result.append(ctx.allocator, .{ .string = Value.String.borrowed(line) });
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_readfile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const content = std.fs.cwd().readFileAlloc(ctx.allocator, args[0].string.bytes(), 1024 * 1024 * 64) catch return Value{ .bool = false };
+fn native_readfile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const content = std.fs.cwd().readFileAlloc(ctx.allocator, args[0].string.bytes(), 1024 * 1024 * 64) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(content);
     try ctx.vm.output.appendSlice(ctx.allocator, content);
-    return .{ .int = @intCast(content.len) };
+    return NativeResult.scalar(.{ .int = @intCast(content.len) });
 }
 
 // file handle operations (fopen/fclose/fread/fwrite/fgets/feof/fseek/ftell)
 
-fn native_gzopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_gzopen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // gzopen($path, $mode) opens a gzipped file with transparent compression.
     // route through fopen with the compress.zlib stream wrapper so a single
     // backend handles read/write, seek, eof, etc
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     if (std.mem.startsWith(u8, path, "compress.zlib://")) {
         return native_fopen(ctx, args);
@@ -1307,45 +1307,46 @@ fn native_gzopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return native_fopen(ctx, new_args[0..i]);
 }
 
-fn native_gzfile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn appendOwnedString(ctx: *NativeContext, arr: *PhpArray, bytes: []const u8) !void {
+    const s = try Value.String.create(ctx.allocator, bytes);
+    defer s.release();
+    try arr.append(ctx.allocator, .{ .string = s });
+}
+
+fn native_gzfile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // gzfile($path) reads the whole gzipped file and returns an array of lines
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     const wrapped = try std.fmt.allocPrint(ctx.allocator, "compress.zlib://{s}", .{path});
-    try ctx.strings.append(ctx.allocator, wrapped);
+    defer ctx.allocator.free(wrapped);
     var fgc_args = [_]Value{.{ .string = Value.String.borrowed(wrapped) }};
-    const contents_val = try native_file_get_contents(ctx, &fgc_args);
-    if (contents_val != .string) return .{ .bool = false };
+    const contents_val = (try native_file_get_contents(ctx, &fgc_args)).value;
+    if (contents_val != .string) return NativeResult.scalar(.{ .bool = false });
+    defer contents_val.string.release();
     const arr = try ctx.createArray();
     const contents = contents_val.string.bytes();
     var start: usize = 0;
     var pos: usize = 0;
     while (pos < contents.len) : (pos += 1) {
         if (contents[pos] == '\n') {
-            const slice = try ctx.allocator.dupe(u8, contents[start .. pos + 1]);
-            try ctx.strings.append(ctx.allocator, slice);
-            try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(slice) });
+            try appendOwnedString(ctx, arr, contents[start .. pos + 1]);
             start = pos + 1;
         }
     }
-    if (start < contents.len) {
-        const slice = try ctx.allocator.dupe(u8, contents[start..]);
-        try ctx.strings.append(ctx.allocator, slice);
-        try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(slice) });
-    }
-    return .{ .array = arr };
+    if (start < contents.len) try appendOwnedString(ctx, arr, contents[start..]);
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_fopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const path = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return .{ .bool = false };
+fn native_fopen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const path = if (args[0] == .string) args[0].string.bytes() else if (args[0] == .object and ctx.vm.hasMethod(args[0].object.class_name, "__toString")) try ctx.vm.objectToString(args[0].object) else return NativeResult.scalar(.{ .bool = false });
     const mode = args[1].string.bytes();
 
     if (userWrapperFor(ctx.vm, path)) |class_name| {
-        return (try dispatchUserOpen(ctx, class_name, path, mode)) orelse Value{ .bool = false };
+        return NativeResult.borrowed((try dispatchUserOpen(ctx, class_name, path, mode)) orelse Value{ .bool = false });
     }
     if (extractScheme(path)) |s| {
-        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return .{ .bool = false };
+        if (isBuiltinWrapper(s) and isWrapperUnregistered(ctx.vm, s)) return NativeResult.scalar(.{ .bool = false });
     }
 
     if (std.mem.eql(u8, path, "php://stdout") or std.mem.eql(u8, path, "php://output")) {
@@ -1353,21 +1354,21 @@ fn native_fopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try obj.set(ctx.allocator, "__fd", .{ .int = 1 });
         try obj.set(ctx.allocator, "__open", .{ .bool = true });
         try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("w") });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (std.mem.eql(u8, path, "php://stderr")) {
         const obj = try ctx.createObject("FileHandle");
         try obj.set(ctx.allocator, "__fd", .{ .int = 2 });
         try obj.set(ctx.allocator, "__open", .{ .bool = true });
         try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("w") });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (std.mem.eql(u8, path, "php://stdin")) {
         const obj = try ctx.createObject("FileHandle");
         try obj.set(ctx.allocator, "__fd", .{ .int = 0 });
         try obj.set(ctx.allocator, "__open", .{ .bool = true });
         try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("r") });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (std.mem.eql(u8, path, "php://input")) {
         const body_val = ctx.vm.request_vars.get("__raw_body");
@@ -1377,28 +1378,28 @@ fn native_fopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try obj.set(ctx.allocator, "__pos", .{ .int = 0 });
         try obj.set(ctx.allocator, "__open", .{ .bool = true });
         try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("r") });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (std.mem.startsWith(u8, path, "data:")) {
-        const payload = (parseDataUri(ctx.allocator, path) catch return Value{ .bool = false }) orelse return Value{ .bool = false };
+        const payload = (parseDataUri(ctx.allocator, path) catch return NativeResult.scalar(.{ .bool = false })) orelse return NativeResult.scalar(.{ .bool = false });
         try ctx.strings.append(ctx.allocator, payload);
         const obj = try ctx.createObject("FileHandle");
         try obj.set(ctx.allocator, "__buffer", .{ .string = Value.String.borrowed(payload) });
         try obj.set(ctx.allocator, "__pos", .{ .int = 0 });
         try obj.set(ctx.allocator, "__open", .{ .bool = true });
         try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("r") });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (std.mem.startsWith(u8, path, "phar://")) {
-        const r = resolvePharPathWithCtx(path, ctx) orelse return .{ .bool = false };
-        const payload = (readPharEntry(ctx.allocator, r.archive_path, r.internal_path) catch return Value{ .bool = false }) orelse return Value{ .bool = false };
+        const r = resolvePharPathWithCtx(path, ctx) orelse return NativeResult.scalar(.{ .bool = false });
+        const payload = (readPharEntry(ctx.allocator, r.archive_path, r.internal_path) catch return NativeResult.scalar(.{ .bool = false })) orelse return NativeResult.scalar(.{ .bool = false });
         try ctx.strings.append(ctx.allocator, payload);
         const obj = try ctx.createObject("FileHandle");
         try obj.set(ctx.allocator, "__buffer", .{ .string = Value.String.borrowed(payload) });
         try obj.set(ctx.allocator, "__pos", .{ .int = 0 });
         try obj.set(ctx.allocator, "__open", .{ .bool = true });
         try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("r") });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (std.mem.startsWith(u8, path, ZLIB_PREFIX)) {
         const is_write = mode.len >= 1 and (mode[0] == 'w' or mode[0] == 'a' or mode[0] == 'x');
@@ -1413,28 +1414,28 @@ fn native_fopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         } else {
             const decoded = readZlibFile(ctx.allocator, path) catch {
                 obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-                return .{ .bool = false };
+                return NativeResult.scalar(.{ .bool = false });
             };
             try ctx.strings.append(ctx.allocator, decoded);
             try obj.set(ctx.allocator, "__buffer", .{ .string = Value.String.borrowed(decoded) });
             try obj.set(ctx.allocator, "__pos", .{ .int = 0 });
         }
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
 
     const is_memory_stream = std.mem.startsWith(u8, path, "php://temp") or std.mem.startsWith(u8, path, "php://memory");
     const file = if (is_memory_stream) blk: {
-        const tmp = std.fmt.allocPrint(ctx.allocator, "/tmp/zphp_{d}", .{@as(u64, @truncate(@as(u128, @bitCast(std.time.nanoTimestamp()))))}) catch return Value{ .bool = false };
+        const tmp = std.fmt.allocPrint(ctx.allocator, "/tmp/zphp_{d}", .{@as(u64, @truncate(@as(u128, @bitCast(std.time.nanoTimestamp()))))}) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(tmp);
-        const f = std.fs.cwd().createFile(tmp, .{ .read = true, .truncate = true }) catch return Value{ .bool = false };
+        const f = std.fs.cwd().createFile(tmp, .{ .read = true, .truncate = true }) catch return NativeResult.scalar(.{ .bool = false });
         std.fs.cwd().deleteFile(tmp) catch {};
         break :blk f;
     } else openWithMode(path, mode) catch |err| {
         const reason = openErrorReason(err);
-        const msg = std.fmt.allocPrint(ctx.allocator, "fopen({s}): Failed to open stream: {s}", .{ path, reason }) catch return Value{ .bool = false };
+        const msg = std.fmt.allocPrint(ctx.allocator, "fopen({s}): Failed to open stream: {s}", .{ path, reason }) catch return NativeResult.scalar(.{ .bool = false });
         ctx.vm.strings.append(ctx.allocator, msg) catch {};
         ctx.vm.emitWarning(msg);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
 
     const obj = try ctx.createObject("FileHandle");
@@ -1443,7 +1444,7 @@ fn native_fopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed(mode) });
     try obj.set(ctx.allocator, "__path", .{ .string = Value.String.borrowed(try ctx.createString(path)) });
     if (is_memory_stream) try obj.set(ctx.allocator, "__peek_eof", .{ .bool = true });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 fn openErrorReason(err: anyerror) []const u8 {
@@ -1492,10 +1493,10 @@ fn openWithMode(path: []const u8, mode: []const u8) !std.fs.File {
     };
 }
 
-fn native_fclose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_fclose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
-    if (!std.mem.eql(u8, obj.class_name, "FileHandle")) return .{ .bool = false };
+    if (!std.mem.eql(u8, obj.class_name, "FileHandle")) return NativeResult.scalar(.{ .bool = false });
     const open = obj.get("__open");
     if (open != .bool or !open.bool) {
         try ctx.vm.setPendingException("TypeError", "fclose(): Argument #1 ($stream) must be an open stream resource");
@@ -1506,7 +1507,7 @@ fn native_fclose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             _ = try ctx.callMethod(wrapper, "stream_close", &.{});
         }
         obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
     // closing a proc_open pipe: close our fd and detach it from the live child so
     // proc_close's wait() (cleanupStreams) won't double-close the same fd. closing
@@ -1525,7 +1526,7 @@ fn native_fclose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         obj.set(ctx.allocator, "__fd", .{ .int = -1 }) catch {};
         obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
     const popen_cmd = obj.get("__popen_cmd");
     if (popen_cmd == .string) {
@@ -1537,7 +1538,7 @@ fn native_fclose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         } else |_| {}
         obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
         obj.properties.put(std.heap.page_allocator, "__popen_cmd", .null) catch {};
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
     if (isZlibWriting(obj)) {
         const path_v = obj.get("__zlib_path");
@@ -1545,18 +1546,18 @@ fn native_fclose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (path_v == .string and buf_v == .string) {
             writeZlibFile(ctx.allocator, path_v.string.bytes(), buf_v.string.bytes()) catch {
                 obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-                return .{ .bool = false };
+                return NativeResult.scalar(.{ .bool = false });
             };
         }
         obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
     if (getFileHandle(obj)) |file| {
         // never close stdin/stdout/stderr - they're shared with the host process
         if (file.handle > 2) file.close();
     }
     obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn isZlibWriting(obj: *PhpObject) bool {
@@ -1564,8 +1565,8 @@ fn isZlibWriting(obj: *PhpObject) bool {
     return v == .bool and v.bool;
 }
 
-fn native_fpassthru(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .int = 0 };
+fn native_fpassthru(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .int = 0 });
     var total: i64 = 0;
     const chunk: i64 = 4096;
     while (true) {
@@ -1575,11 +1576,11 @@ fn native_fpassthru(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         total += @intCast(result.string.bytes().len);
         if (result.string.bytes().len < @as(usize, @intCast(chunk))) break;
     }
-    return .{ .int = total };
+    return NativeResult.scalar(.{ .int = total });
 }
 
-fn native_fread(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .int) return .{ .bool = false };
+fn native_fread(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     if (std.mem.eql(u8, obj.class_name, "FileHandle")) {
         const open = obj.get("__open");
@@ -1595,31 +1596,30 @@ fn native_fread(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const length: usize = @intCast(args[1].int);
     if (fileHandleWrapper(obj)) |wrapper| {
         const result = try ctx.callMethod(wrapper, "stream_read", &[_]Value{.{ .int = @intCast(length) }});
-        if (result == .string) return result;
-        return .{ .string = Value.String.borrowed("") };
+        if (result == .string) return NativeResult.share(result);
+        return NativeResult.literal("");
     }
     if (getBufferBacking(obj)) |buffer| {
         const pos = getBufferPos(obj);
-        if (pos >= buffer.len) return .{ .string = Value.String.borrowed("") };
+        if (pos >= buffer.len) return NativeResult.literal("");
         const end = @min(pos + length, buffer.len);
         const slice = try ctx.allocator.dupe(u8, buffer[pos..end]);
-        try ctx.strings.append(ctx.allocator, slice);
         setBufferPos(obj, end);
-        return .{ .string = Value.String.borrowed(slice) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, slice));
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     const buf = try ctx.allocator.alloc(u8, length);
     const n = file.read(buf) catch |err| {
         ctx.allocator.free(buf);
         // non-blocking stream with nothing buffered yet reads as "" in php, not a hard failure
-        if (err == error.WouldBlock) return .{ .string = Value.String.borrowed("") };
-        return .{ .bool = false };
+        if (err == error.WouldBlock) return NativeResult.literal("");
+        return NativeResult.scalar(.{ .bool = false });
     };
     if (n == 0) {
         ctx.allocator.free(buf);
         try obj.set(ctx.allocator, "__eof", .{ .bool = true });
-        return .{ .string = Value.String.borrowed("") };
+        return NativeResult.literal("");
     }
     if (n < length) try obj.set(ctx.allocator, "__eof", .{ .bool = true });
     // shrink to actual read size
@@ -1627,15 +1627,13 @@ fn native_fread(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const exact = try ctx.allocator.alloc(u8, n);
         @memcpy(exact, buf[0..n]);
         ctx.allocator.free(buf);
-        try ctx.strings.append(ctx.allocator, exact);
-        return .{ .string = Value.String.borrowed(exact) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, exact));
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn native_fwrite(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .string) return .{ .bool = false };
+fn native_fwrite(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     if (std.mem.eql(u8, obj.class_name, "FileHandle")) {
         const open = obj.get("__open");
@@ -1651,8 +1649,8 @@ fn native_fwrite(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     if (fileHandleWrapper(obj)) |wrapper| {
         const result = try ctx.callMethod(wrapper, "stream_write", &[_]Value{.{ .string = Value.String.borrowed(data) }});
-        if (result == .int) return result;
-        return .{ .int = 0 };
+        if (result == .int) return NativeResult.scalar(result);
+        return NativeResult.scalar(.{ .int = 0 });
     }
     if (isZlibWriting(obj) or obj.get("__popen_cmd") == .string) {
         const cur = obj.get("__buffer");
@@ -1662,9 +1660,9 @@ fn native_fwrite(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         @memcpy(combined[cur_str.len..], data);
         try ctx.strings.append(ctx.allocator, combined);
         try obj.set(ctx.allocator, "__buffer", .{ .string = Value.String.borrowed(combined) });
-        return .{ .int = @intCast(data.len) };
+        return NativeResult.scalar(.{ .int = @intCast(data.len) });
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
     // 'a' / 'a+' modes: writes always append, regardless of where the read cursor is
     const mode_v = obj.get("__mode");
     if (mode_v == .string and mode_v.string.bytes().len > 0 and mode_v.string.bytes()[0] == 'a') {
@@ -1675,7 +1673,7 @@ fn native_fwrite(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // this call lands before our stderr write
     if (file.handle == 1) {
         try ctx.vm.output.appendSlice(ctx.allocator, data);
-        return .{ .int = @intCast(data.len) };
+        return NativeResult.scalar(.{ .int = @intCast(data.len) });
     }
     if (file.handle == 2) {
         if (ctx.vm.output.items.len > 0) {
@@ -1684,18 +1682,18 @@ fn native_fwrite(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             ctx.vm.output.clearRetainingCapacity();
         }
     }
-    const written = file.write(data) catch return Value{ .bool = false };
-    return .{ .int = @intCast(written) };
+    const written = file.write(data) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(written) });
 }
 
-fn native_fgets(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_fgets(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     // PHP: fgets($f, length) reads up to length-1 bytes
     const max_len: usize = if (args.len >= 2 and args[1] == .int) @intCast(@max(args[1].int - 1, 1)) else 1024;
     if (getBufferBacking(obj)) |buffer| {
         const pos = getBufferPos(obj);
-        if (pos >= buffer.len) return .{ .bool = false };
+        if (pos >= buffer.len) return NativeResult.scalar(.{ .bool = false });
         var end = pos;
         while (end < buffer.len and end - pos < max_len) {
             const c = buffer[end];
@@ -1703,11 +1701,10 @@ fn native_fgets(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             if (c == '\n') break;
         }
         const slice = try ctx.allocator.dupe(u8, buffer[pos..end]);
-        try ctx.strings.append(ctx.allocator, slice);
         setBufferPos(obj, end);
-        return .{ .string = Value.String.borrowed(slice) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, slice));
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     var buf = std.ArrayListUnmanaged(u8){};
     var byte: [1]u8 = undefined;
@@ -1722,16 +1719,15 @@ fn native_fgets(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (byte[0] == '\n') break;
     }
     if (hit_eof) try obj.set(ctx.allocator, "__eof", .{ .bool = true });
-    if (buf.items.len == 0) return .{ .bool = false };
+    if (buf.items.len == 0) return NativeResult.scalar(.{ .bool = false });
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_stream_get_line(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_stream_get_line(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // stream_get_line(handle, length[, ending]) - reads up to length bytes,
     // stopping when `ending` is encountered (consumed but not returned) or EOF
-    if (args.len < 2 or args[0] != .object) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     const max_len: usize = @intCast(@max(Value.toInt(args[1]), 0));
     const ending = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else "";
@@ -1739,7 +1735,7 @@ fn native_stream_get_line(ctx: *NativeContext, args: []const Value) RuntimeError
 
     if (getBufferBacking(obj)) |buffer| {
         const pos = getBufferPos(obj);
-        if (pos >= buffer.len) return .{ .bool = false };
+        if (pos >= buffer.len) return NativeResult.scalar(.{ .bool = false });
         var end = pos;
         var hit_delim_at: ?usize = null;
         while (end < buffer.len and end - pos < cap) {
@@ -1751,12 +1747,11 @@ fn native_stream_get_line(ctx: *NativeContext, args: []const Value) RuntimeError
         }
         const out_end = hit_delim_at orelse end;
         const slice = try ctx.allocator.dupe(u8, buffer[pos..out_end]);
-        try ctx.strings.append(ctx.allocator, slice);
         const new_pos = if (hit_delim_at) |d| d + ending.len else end;
         setBufferPos(obj, new_pos);
-        return .{ .string = Value.String.borrowed(slice) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, slice));
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     var buf = std.ArrayListUnmanaged(u8){};
     var byte: [1]u8 = undefined;
@@ -1782,29 +1777,27 @@ fn native_stream_get_line(ctx: *NativeContext, args: []const Value) RuntimeError
             try buf.append(ctx.allocator, byte[0]);
         }
     }
-    if (buf.items.len == 0 and matched == 0) return .{ .bool = false };
+    if (buf.items.len == 0 and matched == 0) return NativeResult.scalar(.{ .bool = false });
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_fgetc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_fgetc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var byte: [1]u8 = undefined;
-    const n = file.read(&byte) catch return Value{ .bool = false };
+    const n = file.read(&byte) catch return NativeResult.scalar(.{ .bool = false });
     if (n == 0) {
         try obj.set(ctx.allocator, "__eof", .{ .bool = true });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const result = try ctx.allocator.dupe(u8, byte[0..1]);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_feof(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = true };
+fn native_feof(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = true });
     const obj = args[0].object;
     if (std.mem.eql(u8, obj.class_name, "FileHandle")) {
         const open = obj.get("__open");
@@ -1814,30 +1807,30 @@ fn native_feof(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
     if (fileHandleWrapper(obj)) |wrapper| {
-        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_eof")) return .{ .bool = false };
+        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_eof")) return NativeResult.scalar(.{ .bool = false });
         const result = try ctx.callMethod(wrapper, "stream_eof", &.{});
-        return .{ .bool = result.isTruthy() };
+        return NativeResult.scalar(.{ .bool = result.isTruthy() });
     }
     if (getBufferBacking(obj)) |buffer| {
-        return .{ .bool = getBufferPos(obj) >= buffer.len };
+        return NativeResult.scalar(.{ .bool = getBufferPos(obj) >= buffer.len });
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = true };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = true });
     // memory/temp streams use peek-ahead semantics (PHP behavior for those streams)
     const peek_eof = obj.get("__peek_eof");
     if (peek_eof == .bool and peek_eof.bool) {
         var byte: [1]u8 = undefined;
-        const n = file.read(&byte) catch return Value{ .bool = true };
-        if (n == 0) return .{ .bool = true };
+        const n = file.read(&byte) catch return NativeResult.scalar(.{ .bool = true });
+        if (n == 0) return NativeResult.scalar(.{ .bool = true });
         file.seekBy(-1) catch {};
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     // PHP file semantics: feof becomes true only after a read attempt returned 0
     const eof = obj.get("__eof");
-    return .{ .bool = eof == .bool and eof.bool };
+    return NativeResult.scalar(.{ .bool = eof == .bool and eof.bool });
 }
 
-fn native_fseek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .int) return .{ .int = -1 };
+fn native_fseek(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.{ .int = -1 });
     const obj = args[0].object;
     const offset = args[1].int;
     const whence: u2 = if (args.len >= 3 and args[2] == .int) blk: {
@@ -1848,79 +1841,79 @@ fn native_fseek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         };
     } else 0;
     if (fileHandleWrapper(obj)) |wrapper| {
-        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_seek")) return .{ .int = -1 };
+        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_seek")) return NativeResult.scalar(.{ .int = -1 });
         const result = try ctx.callMethod(wrapper, "stream_seek", &[_]Value{ .{ .int = offset }, .{ .int = whence } });
-        return .{ .int = if (result.isTruthy()) 0 else -1 };
+        return NativeResult.scalar(.{ .int = if (result.isTruthy()) 0 else -1 });
     }
     if (getBufferBacking(obj)) |buffer| {
         const new_pos: i64 = switch (whence) {
             0 => offset,
             1 => @as(i64, @intCast(getBufferPos(obj))) + offset,
             2 => @as(i64, @intCast(buffer.len)) + offset,
-            else => return .{ .int = -1 },
+            else => return NativeResult.scalar(.{ .int = -1 }),
         };
-        if (new_pos < 0) return .{ .int = -1 };
+        if (new_pos < 0) return NativeResult.scalar(.{ .int = -1 });
         setBufferPos(obj, @intCast(new_pos));
-        return .{ .int = 0 };
+        return NativeResult.scalar(.{ .int = 0 });
     }
-    const file = getFileHandle(obj) orelse return Value{ .int = -1 };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .int = -1 });
     switch (whence) {
-        0 => file.seekTo(@intCast(offset)) catch return Value{ .int = -1 },
-        1 => file.seekBy(offset) catch return Value{ .int = -1 },
-        2 => file.seekFromEnd(offset) catch return Value{ .int = -1 },
-        else => return .{ .int = -1 },
+        0 => file.seekTo(@intCast(offset)) catch return NativeResult.scalar(.{ .int = -1 }),
+        1 => file.seekBy(offset) catch return NativeResult.scalar(.{ .int = -1 }),
+        2 => file.seekFromEnd(offset) catch return NativeResult.scalar(.{ .int = -1 }),
+        else => return NativeResult.scalar(.{ .int = -1 }),
     }
     try obj.set(ctx.allocator, "__eof", .{ .bool = false });
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_ftell(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_ftell(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     if (fileHandleWrapper(obj)) |wrapper| {
-        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_tell")) return .{ .bool = false };
+        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_tell")) return NativeResult.scalar(.{ .bool = false });
         const result = try ctx.callMethod(wrapper, "stream_tell", &.{});
-        if (result == .int) return result;
-        return .{ .bool = false };
+        if (result == .int) return NativeResult.share(result);
+        return NativeResult.scalar(.{ .bool = false });
     }
     if (getBufferBacking(obj) != null) {
-        return .{ .int = @intCast(getBufferPos(obj)) };
+        return NativeResult.scalar(.{ .int = @intCast(getBufferPos(obj)) });
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
-    const pos = file.getPos() catch return Value{ .bool = false };
-    return .{ .int = @intCast(pos) };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const pos = file.getPos() catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(pos) });
 }
 
-fn native_rewind(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_rewind(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     if (fileHandleWrapper(obj)) |wrapper| {
-        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_seek")) return .{ .bool = false };
+        if (!ctx.vm.hasMethod(wrapper.class_name, "stream_seek")) return NativeResult.scalar(.{ .bool = false });
         const result = try ctx.callMethod(wrapper, "stream_seek", &[_]Value{ .{ .int = 0 }, .{ .int = 0 } });
-        return .{ .bool = result.isTruthy() };
+        return NativeResult.scalar(.{ .bool = result.isTruthy() });
     }
     if (getBufferBacking(obj) != null) {
         setBufferPos(obj, 0);
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
-    file.seekTo(0) catch return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    file.seekTo(0) catch return NativeResult.scalar(.{ .bool = false });
     try obj.set(ctx.allocator, "__eof", .{ .bool = false });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_fflush(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_fflush(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     // zig files are unbuffered at our level, this is a no-op
-    _ = getFileHandle(args[0].object) orelse return Value{ .bool = false };
-    return .{ .bool = true };
+    _ = getFileHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_ftruncate(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .int) return .{ .bool = false };
-    const file = getFileHandle(args[0].object) orelse return Value{ .bool = false };
+fn native_ftruncate(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
+    const file = getFileHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     const size: u64 = @intCast(@max(args[1].int, 0));
-    file.setEndPos(size) catch return Value{ .bool = false };
+    file.setEndPos(size) catch return NativeResult.scalar(.{ .bool = false });
     // for php://memory / php://temp, snap the cursor to the new end rather than
     // leaving it past EOF where subsequent writes would create null-padded holes
     const path = args[0].object.get("__path");
@@ -1928,12 +1921,12 @@ fn native_ftruncate(_: *NativeContext, args: []const Value) RuntimeError!Value {
         const cur = file.getPos() catch 0;
         if (cur > size) file.seekTo(size) catch {};
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_flock(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .int) return .{ .bool = false };
-    const file = getFileHandle(args[0].object) orelse return Value{ .bool = false };
+fn native_flock(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
+    const file = getFileHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     // PHP renumbers the lock op constants: LOCK_SH=1, LOCK_EX=2, LOCK_UN=3,
     // LOCK_NB=4. translate to the OS values (LOCK_SH=1, LOCK_EX=2, LOCK_NB=4,
     // LOCK_UN=8) before handing to flock(2)
@@ -1946,12 +1939,12 @@ fn native_flock(_: *NativeContext, args: []const Value) RuntimeError!Value {
         3 => 8, // LOCK_UN
         else => 0,
     };
-    std.posix.flock(file.handle, os_base | non_block) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    std.posix.flock(file.handle, os_base | non_block) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn stream_get_meta_data(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn stream_get_meta_data(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     const mode_val = obj.get("__mode");
     const mode = if (mode_val == .string) mode_val.string.bytes() else "r";
@@ -1993,7 +1986,7 @@ fn stream_get_meta_data(ctx: *NativeContext, args: []const Value) RuntimeError!V
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("unread_bytes") }, .{ .int = 0 });
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("seekable") }, .{ .bool = true });
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("uri") }, .{ .string = Value.String.borrowed(uri) });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 const builtin_wrappers = [_][]const u8{ "https", "php", "file", "data", "http", "phar", "compress.zlib" };
@@ -2054,46 +2047,40 @@ fn zlibEncodeWindow(a: Allocator, input: []const u8, window_bits: c_int) ![]u8 {
     return try a.realloc(out, stream.total_out);
 }
 
-fn native_gzcompress(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const out = zlibEncodeWindow(ctx.allocator, args[0].string.bytes(), 15) catch return .{ .bool = false };
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_gzcompress(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = zlibEncodeWindow(ctx.allocator, args[0].string.bytes(), 15) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_gzuncompress(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const out = zlibDecodeWindow(ctx.allocator, args[0].string.bytes(), 15) catch return .{ .bool = false };
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_gzuncompress(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = zlibDecodeWindow(ctx.allocator, args[0].string.bytes(), 15) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_gzdeflate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const out = zlibEncodeWindow(ctx.allocator, args[0].string.bytes(), -15) catch return .{ .bool = false };
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_gzdeflate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = zlibEncodeWindow(ctx.allocator, args[0].string.bytes(), -15) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_gzinflate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const out = zlibDecodeWindow(ctx.allocator, args[0].string.bytes(), -15) catch return .{ .bool = false };
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_gzinflate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = zlibDecodeWindow(ctx.allocator, args[0].string.bytes(), -15) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_gzencode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const out = zlibEncodeWindow(ctx.allocator, args[0].string.bytes(), 15 + 16) catch return .{ .bool = false };
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_gzencode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = zlibEncodeWindow(ctx.allocator, args[0].string.bytes(), 15 + 16) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_gzdecode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const out = zlibDecodeWindow(ctx.allocator, args[0].string.bytes(), 15 + 32) catch return .{ .bool = false };
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_gzdecode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = zlibDecodeWindow(ctx.allocator, args[0].string.bytes(), 15 + 32) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
 fn gzipDecode(a: Allocator, input: []const u8) ![]u8 {
@@ -2245,7 +2232,7 @@ fn dispatchUserStat(ctx: *NativeContext, class_name: []const u8, path: []const u
     return result.array;
 }
 
-fn stream_get_wrappers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn stream_get_wrappers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const result = try ctx.createArray();
     for (builtin_wrappers) |w| {
         if (ctx.vm.stream_wrappers_unregistered.contains(w)) continue;
@@ -2253,94 +2240,94 @@ fn stream_get_wrappers(ctx: *NativeContext, _: []const Value) RuntimeError!Value
     }
     var it = ctx.vm.stream_wrappers_user.keyIterator();
     while (it.next()) |k| try result.append(ctx.allocator, .{ .string = Value.String.borrowed(k.*) });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn stream_wrapper_register(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn stream_wrapper_register(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const protocol = args[0].string.bytes();
     const class_name = args[1].string.bytes();
-    if (protocol.len == 0) return .{ .bool = false };
+    if (protocol.len == 0) return NativeResult.scalar(.{ .bool = false });
     // already registered (builtin still active or user wrapper present)
     const builtin_active = isBuiltinWrapper(protocol) and !ctx.vm.stream_wrappers_unregistered.contains(protocol);
-    if (builtin_active or ctx.vm.stream_wrappers_user.contains(protocol)) return .{ .bool = false };
+    if (builtin_active or ctx.vm.stream_wrappers_user.contains(protocol)) return NativeResult.scalar(.{ .bool = false });
     if (!ctx.vm.classes.contains(class_name)) {
-        ctx.vm.tryAutoload(class_name) catch return Value{ .bool = false };
-        if (!ctx.vm.classes.contains(class_name)) return .{ .bool = false };
+        ctx.vm.tryAutoload(class_name) catch return NativeResult.scalar(.{ .bool = false });
+        if (!ctx.vm.classes.contains(class_name)) return NativeResult.scalar(.{ .bool = false });
     }
     const proto_owned = try ctx.createString(protocol);
     const class_owned = try ctx.createString(class_name);
     try ctx.vm.stream_wrappers_user.put(ctx.allocator, proto_owned, class_owned);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn stream_wrapper_unregister(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn stream_wrapper_unregister(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const protocol = args[0].string.bytes();
-    if (ctx.vm.stream_wrappers_user.fetchRemove(protocol) != null) return .{ .bool = true };
-    if (!isBuiltinWrapper(protocol)) return .{ .bool = false };
-    if (ctx.vm.stream_wrappers_unregistered.contains(protocol)) return .{ .bool = false };
+    if (ctx.vm.stream_wrappers_user.fetchRemove(protocol) != null) return NativeResult.scalar(.{ .bool = true });
+    if (!isBuiltinWrapper(protocol)) return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.stream_wrappers_unregistered.contains(protocol)) return NativeResult.scalar(.{ .bool = false });
     const proto_owned = try ctx.createString(protocol);
     try ctx.vm.stream_wrappers_unregistered.put(ctx.allocator, proto_owned, {});
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn stream_wrapper_restore(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn stream_wrapper_restore(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const protocol = args[0].string.bytes();
-    if (!isBuiltinWrapper(protocol)) return .{ .bool = false };
-    if (!ctx.vm.stream_wrappers_unregistered.contains(protocol)) return .{ .bool = true };
+    if (!isBuiltinWrapper(protocol)) return NativeResult.scalar(.{ .bool = false });
+    if (!ctx.vm.stream_wrappers_unregistered.contains(protocol)) return NativeResult.scalar(.{ .bool = true });
     _ = ctx.vm.stream_wrappers_unregistered.remove(protocol);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_noop_true(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_noop_true(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_stream_filter_register(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_stream_filter_register(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // accept the registration silently; user-defined filters aren't dispatched
     // through our stream layer, but returning true lets feature-detection
     // codepaths in libraries proceed
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_stream_filter_append(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_stream_filter_append(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // return a stub resource-like value so the caller can later pass it to
     // stream_filter_remove without erroring
-    return .{ .int = 1 };
+    return NativeResult.scalar(.{ .int = 1 });
 }
 
-fn native_stream_get_filters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_stream_get_filters(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     const names = [_][]const u8{ "string.rot13", "string.toupper", "string.tolower", "convert.base64-encode", "convert.base64-decode", "zlib.deflate", "zlib.inflate" };
     for (names) |n| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(n) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_stream_get_transports(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_stream_get_transports(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     const names = [_][]const u8{ "tcp", "udp", "unix", "udg", "ssl", "tls", "tlsv1.2", "tlsv1.3" };
     for (names) |n| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(n) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn stream_copy_to_stream(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .object) return .{ .bool = false };
+fn stream_copy_to_stream(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .object) return NativeResult.scalar(.{ .bool = false });
     const length: i64 = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else -1;
     const offset: i64 = if (args.len >= 4 and args[3] != .null) Value.toInt(args[3]) else 0;
 
     var src_args: [3]Value = .{ args[0], .{ .int = if (length < 0) -1 else length }, .{ .int = offset } };
-    const data_v = try stream_get_contents(ctx, src_args[0..3]);
-    const data: []const u8 = if (data_v == .string) data_v.string.bytes() else return Value{ .bool = false };
+    const data_v = (try stream_get_contents(ctx, src_args[0..3])).value;
+    if (data_v != .string) return NativeResult.scalar(.{ .bool = false });
+    defer data_v.string.release();
 
-    var write_args: [2]Value = .{ args[1], .{ .string = Value.String.borrowed(data) } };
-    const written = try native_fwrite(ctx, write_args[0..2]);
-    return written;
+    var write_args: [2]Value = .{ args[1], data_v };
+    return native_fwrite(ctx, write_args[0..2]);
 }
 
-fn stream_get_contents(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn stream_get_contents(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     // length: -1 (or null) means read until EOF; non-negative means cap
     const length: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else -1;
@@ -2350,40 +2337,38 @@ fn stream_get_contents(ctx: *NativeContext, args: []const Value) RuntimeError!Va
     if (getBufferBacking(obj)) |buffer| {
         if (offset >= 0) setBufferPos(obj, @intCast(offset));
         const pos = getBufferPos(obj);
-        if (pos >= buffer.len) return .{ .string = Value.String.borrowed("") };
+        if (pos >= buffer.len) return NativeResult.literal("");
         const remaining = buffer[pos..];
         const take = if (length >= 0) @min(@as(usize, @intCast(length)), remaining.len) else remaining.len;
         setBufferPos(obj, pos + take);
-        return .{ .string = Value.String.borrowed(try ctx.createString(remaining[0..take])) };
+        return try NativeResult.copyString(ctx.allocator, remaining[0..take]);
     }
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
     if (offset >= 0) {
-        file.seekTo(@intCast(offset)) catch return Value{ .bool = false };
+        file.seekTo(@intCast(offset)) catch return NativeResult.scalar(.{ .bool = false });
     }
     if (length >= 0) {
         const cap: usize = @intCast(length);
-        const buf = ctx.allocator.alloc(u8, cap) catch return Value{ .bool = false };
+        const buf = ctx.allocator.alloc(u8, cap) catch return NativeResult.scalar(.{ .bool = false });
         const n = file.read(buf) catch {
             ctx.allocator.free(buf);
-            return Value{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         };
         if (n < cap) {
-            const result = try ctx.createString(buf[0..n]);
+            const result = try Value.String.create(ctx.allocator, buf[0..n]);
             ctx.allocator.free(buf);
-            return .{ .string = Value.String.borrowed(result) };
+            return NativeResult.takeString(result);
         }
-        try ctx.strings.append(ctx.allocator, buf);
-        return .{ .string = Value.String.borrowed(buf) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
     }
-    const buf = file.readToEndAlloc(ctx.allocator, 10 * 1024 * 1024) catch return Value{ .bool = false };
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    const buf = file.readToEndAlloc(ctx.allocator, 10 * 1024 * 1024) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn native_fstat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
-    const file = getFileHandle(args[0].object) orelse return Value{ .bool = false };
-    const stat = std.posix.fstat(file.handle) catch return Value{ .bool = false };
+fn native_fstat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const file = getFileHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
+    const stat = std.posix.fstat(file.handle) catch return NativeResult.scalar(.{ .bool = false });
     const result = try ctx.createArray();
     const mode: i64 = @intCast(stat.mode);
     const size: i64 = @intCast(stat.size);
@@ -2391,13 +2376,13 @@ fn native_fstat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("size") }, .{ .int = size });
     try result.set(ctx.allocator, .{ .int = 2 }, .{ .int = mode });
     try result.set(ctx.allocator, .{ .int = 7 }, .{ .int = size });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_fgetcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_fgetcsv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
-    const file = getFileHandle(obj) orelse return Value{ .bool = false };
+    const file = getFileHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const delimiter: u8 = if (args.len >= 3 and args[2] == .string and args[2].string.bytes().len > 0) args[2].string.bytes()[0] else ',';
     const enclosure: u8 = if (args.len >= 4 and args[3] == .string and args[3].string.bytes().len > 0) args[3].string.bytes()[0] else '"';
 
@@ -2437,7 +2422,7 @@ fn native_fgetcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             break;
         }
     }
-    if (!got_any) return .{ .bool = false };
+    if (!got_any) return NativeResult.scalar(.{ .bool = false });
 
     const line_owned = try line.toOwnedSlice(ctx.allocator);
     try ctx.strings.append(ctx.allocator, line_owned);
@@ -2449,7 +2434,7 @@ fn native_fgetcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return parseCsvRecord(ctx, raw, delimiter, enclosure);
 }
 
-fn parseCsvRecord(ctx: *NativeContext, raw: []const u8, delimiter: u8, enclosure: u8) !Value {
+fn parseCsvRecord(ctx: *NativeContext, raw: []const u8, delimiter: u8, enclosure: u8) !NativeResult {
     var result = try ctx.createArray();
     var field = std.ArrayListUnmanaged(u8){};
     var in_quotes = false;
@@ -2486,12 +2471,12 @@ fn parseCsvRecord(ctx: *NativeContext, raw: []const u8, delimiter: u8, enclosure
     const s = try field.toOwnedSlice(ctx.allocator);
     try ctx.strings.append(ctx.allocator, s);
     try result.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_fputcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .array) return .{ .bool = false };
-    const file = getFileHandle(args[0].object) orelse return Value{ .bool = false };
+fn native_fputcsv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .array) return NativeResult.scalar(.{ .bool = false });
+    const file = getFileHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     const arr = args[1].array;
     const delimiter: u8 = if (args.len >= 3 and args[2] == .string and args[2].string.bytes().len > 0) args[2].string.bytes()[0] else ',';
     const enclosure: u8 = if (args.len >= 4 and args[3] == .string and args[3].string.bytes().len > 0) args[3].string.bytes()[0] else '"';
@@ -2526,14 +2511,14 @@ fn native_fputcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     try buf.append(ctx.allocator, '\n');
 
-    const written = file.write(buf.items) catch return Value{ .bool = false };
+    const written = file.write(buf.items) catch return NativeResult.scalar(.{ .bool = false });
     const owned = try buf.toOwnedSlice(ctx.allocator);
     try ctx.strings.append(ctx.allocator, owned);
-    return .{ .int = @intCast(written) };
+    return NativeResult.scalar(.{ .int = @intCast(written) });
 }
 
-fn native_touch(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_touch(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
 
     // create the file if it doesn't already exist, then fall through to the
@@ -2541,11 +2526,11 @@ fn native_touch(_: *NativeContext, args: []const Value) RuntimeError!Value {
     // regardless of whether the file pre-existed
     const created = std.fs.cwd().createFile(path, .{ .exclusive = true }) catch |err| switch (err) {
         error.PathAlreadyExists => null,
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     if (created) |c| c.close();
 
-    const f = std.fs.cwd().openFile(path, .{ .mode = .write_only }) catch return Value{ .bool = false };
+    const f = std.fs.cwd().openFile(path, .{ .mode = .write_only }) catch return NativeResult.scalar(.{ .bool = false });
     defer f.close();
     const now: i128 = std.time.nanoTimestamp();
     const mtime: i128 = if (args.len >= 2 and args[1] != .null)
@@ -2556,59 +2541,59 @@ fn native_touch(_: *NativeContext, args: []const Value) RuntimeError!Value {
         @as(i128, Value.toInt(args[2])) * 1_000_000_000
     else
         mtime;
-    f.updateTimes(atime, mtime) catch return Value{ .bool = true };
-    return .{ .bool = true };
+    f.updateTimes(atime, mtime) catch return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_chmod(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
+fn native_chmod(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     const mode_val = Value.toInt(args[1]);
-    if (mode_val < 0) return .{ .bool = false };
+    if (mode_val < 0) return NativeResult.scalar(.{ .bool = false });
     const mode: std.posix.mode_t = @intCast(mode_val);
 
     const file = std.fs.cwd().openFile(path, .{ .mode = .read_write }) catch
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     defer file.close();
-    file.chmod(mode) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    file.chmod(mode) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // chown / chgrp: accept either a numeric uid/gid or a name and pass to the
 // posix chown(2) syscall. silently degrade to false on failure (most failures
 // are EPERM when not root)
-fn native_chown(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
+fn native_chown(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     var path_z: [std.fs.max_path_bytes:0]u8 = undefined;
-    if (path.len >= path_z.len) return .{ .bool = false };
+    if (path.len >= path_z.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(path_z[0..path.len], path);
     path_z[path.len] = 0;
     const uid: std.c.uid_t = if (args[1] == .int) @intCast(args[1].int) else blk: {
-        if (args[1] != .string) return .{ .bool = false };
+        if (args[1] != .string) return NativeResult.scalar(.{ .bool = false });
         const name_z = try dupZ(ctx, args[1].string.bytes());
-        const pw = std.c.getpwnam(name_z.ptr) orelse return .{ .bool = false };
+        const pw = std.c.getpwnam(name_z.ptr) orelse return NativeResult.scalar(.{ .bool = false });
         break :blk pw.uid;
     };
-    if (chown_extern(@ptrCast(&path_z), uid, std.math.maxInt(std.c.gid_t)) != 0) return .{ .bool = false };
-    return .{ .bool = true };
+    if (chown_extern(@ptrCast(&path_z), uid, std.math.maxInt(std.c.gid_t)) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_chgrp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
+fn native_chgrp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     var path_z: [std.fs.max_path_bytes:0]u8 = undefined;
-    if (path.len >= path_z.len) return .{ .bool = false };
+    if (path.len >= path_z.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(path_z[0..path.len], path);
     path_z[path.len] = 0;
     const gid: std.c.gid_t = if (args[1] == .int) @intCast(args[1].int) else blk: {
-        if (args[1] != .string) return .{ .bool = false };
+        if (args[1] != .string) return NativeResult.scalar(.{ .bool = false });
         const name_z = try dupZ(ctx, args[1].string.bytes());
-        const gr = std.c.getgrnam(name_z.ptr) orelse return .{ .bool = false };
+        const gr = std.c.getgrnam(name_z.ptr) orelse return NativeResult.scalar(.{ .bool = false });
         break :blk gr.gid;
     };
-    if (chown_extern(@ptrCast(&path_z), std.math.maxInt(std.c.uid_t), gid) != 0) return .{ .bool = false };
-    return .{ .bool = true };
+    if (chown_extern(@ptrCast(&path_z), std.math.maxInt(std.c.uid_t), gid) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 extern "c" fn chown(path: [*:0]const u8, owner: std.c.uid_t, group: std.c.gid_t) c_int;
@@ -2624,162 +2609,162 @@ fn dupZ(ctx: *NativeContext, s: []const u8) ![:0]u8 {
     return z[0..s.len :0];
 }
 
-fn native_stat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_stat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     var pbuf: [std.fs.max_path_bytes:0]u8 = undefined;
-    if (path.len >= pbuf.len) return .{ .bool = false };
+    if (path.len >= pbuf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(pbuf[0..path.len], path);
     pbuf[path.len] = 0;
     var st: std.c.Stat = undefined;
-    if (std.c.stat(&pbuf, &st) != 0) return .{ .bool = false };
-    return .{ .array = try buildStatArray(ctx, &st) };
+    if (std.c.stat(&pbuf, &st) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .array = try buildStatArray(ctx, &st) });
 }
 
-fn native_chdir(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_chdir(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
-    var dir = std.fs.cwd().openDir(path, .{}) catch return Value{ .bool = false };
+    var dir = std.fs.cwd().openDir(path, .{}) catch return NativeResult.scalar(.{ .bool = false });
     defer dir.close();
-    std.posix.fchdir(dir.fd) catch return Value{ .bool = false };
-    return .{ .bool = true };
+    std.posix.fchdir(dir.fd) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_stream_is_local(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const scheme = extractScheme(args[0].string.bytes()) orelse return .{ .bool = true };
-    return .{ .bool = std.mem.eql(u8, scheme, "file") or std.mem.eql(u8, scheme, "phar") };
+fn native_stream_is_local(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const scheme = extractScheme(args[0].string.bytes()) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = std.mem.eql(u8, scheme, "file") or std.mem.eql(u8, scheme, "phar") });
 }
 
-fn native_stream_resolve_include_path(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_stream_resolve_include_path(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
-    std.fs.cwd().access(path, .{}) catch return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(path) };
+    std.fs.cwd().access(path, .{}) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.shareString(args[0].string);
 }
 
-fn native_stream_isatty(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_stream_isatty(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
-    if (!std.mem.eql(u8, obj.class_name, "FileHandle")) return .{ .bool = false };
+    if (!std.mem.eql(u8, obj.class_name, "FileHandle")) return NativeResult.scalar(.{ .bool = false });
     const fd_val = obj.get("__fd");
-    if (fd_val != .int) return .{ .bool = false };
+    if (fd_val != .int) return NativeResult.scalar(.{ .bool = false });
     const fd: std.posix.fd_t = @intCast(fd_val.int);
-    return .{ .bool = std.posix.isatty(fd) };
+    return NativeResult.scalar(.{ .bool = std.posix.isatty(fd) });
 }
 
-fn native_clearstatcache(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn native_clearstatcache(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn native_stream_supports_lock(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_stream_supports_lock(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // local file streams (FileHandle backed by an fd from open()) support
     // flock; in-memory streams (php://memory, php://temp), HTTP/curl-backed
     // streams, and other non-fd wrappers do not. detect by inspecting the
     // path: anything starting with 'php://', 'http://', 'https://', 'data:',
     // 'ftp://' is a non-fd stream
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
-    if (!std.mem.eql(u8, obj.class_name, "FileHandle")) return .{ .bool = false };
+    if (!std.mem.eql(u8, obj.class_name, "FileHandle")) return NativeResult.scalar(.{ .bool = false });
     const path_v = obj.get("__path");
-    if (path_v != .string) return .{ .bool = true };
+    if (path_v != .string) return NativeResult.scalar(.{ .bool = true });
     const p = path_v.string.bytes();
     if (std.mem.startsWith(u8, p, "php://") or
         std.mem.startsWith(u8, p, "http://") or
         std.mem.startsWith(u8, p, "https://") or
         std.mem.startsWith(u8, p, "ftp://") or
-        std.mem.startsWith(u8, p, "data:")) return .{ .bool = false };
-    return .{ .bool = true };
+        std.mem.startsWith(u8, p, "data:")) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_stream_set_chunk_size(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 8192 };
+fn native_stream_set_chunk_size(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 8192 });
 }
 
-fn native_stream_set_buffer(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn native_stream_set_buffer(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_umask(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_umask(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len > 0 and args[0] == .int) {
         const old = std.c.umask(@intCast(args[0].int));
-        return .{ .int = @intCast(old) };
+        return NativeResult.scalar(.{ .int = @intCast(old) });
     }
     const current = std.c.umask(0o022);
     _ = std.c.umask(current);
-    return .{ .int = @intCast(current) };
+    return NativeResult.scalar(.{ .int = @intCast(current) });
 }
 
-fn native_fileperms(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return Value{ .bool = false };
-    return .{ .int = @intCast(stat.mode) };
+fn native_fileperms(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(stat.mode) });
 }
 
 extern "c" fn lstat(noalias path: [*:0]const u8, noalias buf: *std.c.Stat) c_int;
 
-fn native_fileowner(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_fileowner(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     var pbuf: [std.fs.max_path_bytes:0]u8 = undefined;
-    if (path.len >= pbuf.len) return .{ .bool = false };
+    if (path.len >= pbuf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(pbuf[0..path.len], path);
     pbuf[path.len] = 0;
     var st: std.c.Stat = undefined;
-    if (std.c.stat(&pbuf, &st) != 0) return .{ .bool = false };
-    return .{ .int = @intCast(st.uid) };
+    if (std.c.stat(&pbuf, &st) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(st.uid) });
 }
 
-fn native_filegroup(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_filegroup(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     var pbuf: [std.fs.max_path_bytes:0]u8 = undefined;
-    if (path.len >= pbuf.len) return .{ .bool = false };
+    if (path.len >= pbuf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(pbuf[0..path.len], path);
     pbuf[path.len] = 0;
     var st: std.c.Stat = undefined;
-    if (std.c.stat(&pbuf, &st) != 0) return .{ .bool = false };
-    return .{ .int = @intCast(st.gid) };
+    if (std.c.stat(&pbuf, &st) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(st.gid) });
 }
 
-fn native_is_link(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_is_link(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     var pbuf: [std.fs.max_path_bytes:0]u8 = undefined;
-    if (path.len >= pbuf.len) return .{ .bool = false };
+    if (path.len >= pbuf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(pbuf[0..path.len], path);
     pbuf[path.len] = 0;
     var st: std.c.Stat = undefined;
-    if (lstat(&pbuf, &st) != 0) return .{ .bool = false };
-    return .{ .bool = (st.mode & 0o170000) == 0o120000 };
+    if (lstat(&pbuf, &st) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = (st.mode & 0o170000) == 0o120000 });
 }
 
-fn native_symlink(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_symlink(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     var t: [std.fs.max_path_bytes:0]u8 = undefined;
     var l: [std.fs.max_path_bytes:0]u8 = undefined;
     const target = args[0].string.bytes();
     const linkpath = args[1].string.bytes();
-    if (target.len >= t.len or linkpath.len >= l.len) return .{ .bool = false };
+    if (target.len >= t.len or linkpath.len >= l.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(t[0..target.len], target);
     t[target.len] = 0;
     @memcpy(l[0..linkpath.len], linkpath);
     l[linkpath.len] = 0;
-    return .{ .bool = std.c.symlink(&t, &l) == 0 };
+    return NativeResult.scalar(.{ .bool = std.c.symlink(&t, &l) == 0 });
 }
 
-fn native_link(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_link(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     var t: [std.fs.max_path_bytes:0]u8 = undefined;
     var l: [std.fs.max_path_bytes:0]u8 = undefined;
     const target = args[0].string.bytes();
     const linkpath = args[1].string.bytes();
-    if (target.len >= t.len or linkpath.len >= l.len) return .{ .bool = false };
+    if (target.len >= t.len or linkpath.len >= l.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(t[0..target.len], target);
     t[target.len] = 0;
     @memcpy(l[0..linkpath.len], linkpath);
     l[linkpath.len] = 0;
-    return .{ .bool = std.c.link(&t, &l) == 0 };
+    return NativeResult.scalar(.{ .bool = std.c.link(&t, &l) == 0 });
 }
 
 fn buildStatArray(ctx: *NativeContext, st: *const std.c.Stat) !*PhpArray {
@@ -2812,37 +2797,35 @@ fn buildStatArray(ctx: *NativeContext, st: *const std.c.Stat) !*PhpArray {
     return arr;
 }
 
-fn native_lstat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_lstat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     var pbuf: [std.fs.max_path_bytes:0]u8 = undefined;
-    if (path.len >= pbuf.len) return .{ .bool = false };
+    if (path.len >= pbuf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(pbuf[0..path.len], path);
     pbuf[path.len] = 0;
     var st: std.c.Stat = undefined;
-    if (lstat(&pbuf, &st) != 0) return .{ .bool = false };
-    return .{ .array = try buildStatArray(ctx, &st) };
+    if (lstat(&pbuf, &st) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .array = try buildStatArray(ctx, &st) });
 }
 
-fn native_readlink(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_readlink(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const target = std.fs.cwd().readLink(args[0].string.bytes(), &buf) catch return Value{ .bool = false };
-    const result = ctx.vm.allocator.dupe(u8, target) catch return .{ .bool = false };
-    try ctx.vm.strings.append(ctx.vm.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    const target = std.fs.cwd().readLink(args[0].string.bytes(), &buf) catch return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, target);
 }
 
-fn native_tmpfile(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_tmpfile(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const dir = std.posix.getenv("TMPDIR") orelse "/tmp";
-    const path = std.fmt.allocPrint(ctx.vm.allocator, "{s}/zphp_tmpfile_{d}_{d}", .{ dir, std.time.nanoTimestamp(), std.crypto.random.int(u32) }) catch return .{ .bool = false };
+    const path = std.fmt.allocPrint(ctx.vm.allocator, "{s}/zphp_tmpfile_{d}_{d}", .{ dir, std.time.nanoTimestamp(), std.crypto.random.int(u32) }) catch return NativeResult.scalar(.{ .bool = false });
     try ctx.vm.strings.append(ctx.vm.allocator, path);
     var open_args: [2]Value = .{ .{ .string = Value.String.borrowed(path) }, .{ .string = Value.String.borrowed("w+b") } };
     const handle = try native_fopen(ctx, open_args[0..2]);
     return handle;
 }
 
-fn native_tempnam(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_tempnam(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const dir = if (args.len > 0 and args[0] == .string) args[0].string.bytes() else "/tmp";
     const prefix = if (args.len > 1 and args[1] == .string) args[1].string.bytes() else "tmp";
     var rng = std.Random.DefaultPrng.init(@intCast(std.time.nanoTimestamp() & 0x7fff_ffff_ffff_ffff));
@@ -2855,13 +2838,12 @@ fn native_tempnam(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const candidate = std.fmt.allocPrint(ctx.vm.allocator, "{s}/{s}{s}", .{ dir, prefix, &buf }) catch continue;
         if (std.fs.cwd().createFile(candidate, .{ .exclusive = true, .mode = 0o600 })) |file| {
             file.close();
-            try ctx.vm.strings.append(ctx.vm.allocator, candidate);
-            return .{ .string = Value.String.borrowed(candidate) };
+            return NativeResult.takeString(try Value.String.adopt(ctx.vm.allocator, candidate));
         } else |_| {
             ctx.vm.allocator.free(candidate);
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 const StdioBehavior = enum { capture, inherit };
@@ -2942,27 +2924,27 @@ fn makePopenWriteHandle(ctx: *NativeContext, command: []const u8) !*PhpObject {
     return obj;
 }
 
-fn native_popen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_popen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const cmd = args[0].string.bytes();
     const mode = args[1].string.bytes();
     if (mode.len > 0 and (mode[0] == 'r')) {
-        const result = runShellCapture(ctx.allocator, cmd, null) catch return .{ .bool = false };
+        const result = runShellCapture(ctx.allocator, cmd, null) catch return NativeResult.scalar(.{ .bool = false });
         ctx.allocator.free(result.stderr);
         try ctx.vm.strings.append(ctx.allocator, result.stdout);
         const obj = try makeReadBufferHandle(ctx, result.stdout);
         try obj.set(ctx.allocator, "__popen_exit", .{ .int = result.exit });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (mode.len > 0 and (mode[0] == 'w')) {
         const obj = try makePopenWriteHandle(ctx, cmd);
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_pclose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .int = -1 };
+fn native_pclose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .int = -1 });
     const obj = args[0].object;
     const cmd_v = obj.get("__popen_cmd");
     if (cmd_v == .string) {
@@ -2973,17 +2955,17 @@ fn native_pclose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         flushVmOutputForInheritedChild(ctx.vm, .inherit, .inherit);
         const result = runShellWith(ctx.allocator, cmd_v.string.bytes(), stdin_data, .inherit, .inherit) catch {
             obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-            return .{ .int = -1 };
+            return NativeResult.scalar(.{ .int = -1 });
         };
         ctx.allocator.free(result.stdout);
         ctx.allocator.free(result.stderr);
         obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-        return .{ .int = result.exit };
+        return NativeResult.scalar(.{ .int = result.exit });
     }
     const exit_v = obj.get("__popen_exit");
     obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
-    if (exit_v == .int) return .{ .int = exit_v.int };
-    return .{ .int = 0 };
+    if (exit_v == .int) return NativeResult.scalar(.{ .int = exit_v.int });
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
 const FdDesc = union(enum) {
@@ -3141,8 +3123,8 @@ fn forkExecDesc(allocator: std.mem.Allocator, cmd: []const u8, specs: []const Pr
     return .{ .pid = pid, .pipe_fds = pipes };
 }
 
-fn native_proc_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string) return .{ .bool = false };
+fn native_proc_open(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const cmd = args[0].string.bytes();
 
     const proc = try ctx.createObject("ProcessResource");
@@ -3217,7 +3199,7 @@ fn native_proc_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         try proc.set(ctx.allocator, "__reaped", .{ .bool = true });
         try proc.set(ctx.allocator, "__running", .{ .bool = false });
         try proc.set(ctx.allocator, "__exit", .{ .int = -1 });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     try ctx.vm.registerProcChild(proc, spawned.pid, spawned.pipe_fds);
     try proc.set(ctx.allocator, "__pid", .{ .int = @intCast(spawned.pid) });
@@ -3255,7 +3237,7 @@ fn native_proc_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     }
 
     ctx.setCallerVar(2, args.len, .{ .array = pipes });
-    return .{ .object = proc };
+    return NativeResult.borrowed(.{ .object = proc });
 }
 
 const PosixW = std.posix.W;
@@ -3277,13 +3259,13 @@ fn cacheProcTerm(ctx: *NativeContext, proc: *PhpObject, status: u32) void {
     }
 }
 
-fn native_proc_close(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .int = -1 };
+fn native_proc_close(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .int = -1 });
     const obj = args[0].object;
     const pc = ctx.vm.lookupProcChild(obj) orelse {
         // already finalized (or spawn failed) - return the cached exit
         const cached = obj.get("__exit");
-        return .{ .int = if (cached == .int) cached.int else 0 };
+        return NativeResult.scalar(.{ .int = if (cached == .int) cached.int else 0 });
     };
     // close stdin first so the child sees EOF and can finish
     for (pc.pipe_fds.items) |*pipe| if (pipe.role == 0 and pipe.fd != -1) {
@@ -3304,11 +3286,11 @@ fn native_proc_close(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     pc.pipe_fds.deinit(ctx.allocator);
     ctx.vm.removeProcChild(obj);
     const exit = obj.get("__exit");
-    return .{ .int = if (exit == .int) exit.int else 0 };
+    return NativeResult.scalar(.{ .int = if (exit == .int) exit.int else 0 });
 }
 
-fn native_proc_get_status(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_proc_get_status(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const obj = args[0].object;
     // non-blocking liveness poll. if the child has exited, reap the zombie (mark
     // .reaped so proc_close/reap won't wait again -> ECHILD) and cache the exit,
@@ -3343,39 +3325,39 @@ fn native_proc_get_status(ctx: *NativeContext, args: []const Value) RuntimeError
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("exitcode") }, if (!running and exit == .int) exit else .{ .int = -1 });
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("termsig") }, if (termsig == .int) termsig else .{ .int = 0 });
     try result.set(ctx.allocator, .{ .string = Value.String.borrowed("stopsig") }, .{ .int = 0 });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_proc_terminate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn native_proc_terminate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const sig: u8 = if (args.len >= 2 and args[1] == .int) @intCast(args[1].int) else std.posix.SIG.TERM;
     if (ctx.vm.lookupProcChild(args[0].object)) |pc| {
-        std.posix.kill(pc.pid, sig) catch return .{ .bool = false };
+        std.posix.kill(pc.pid, sig) catch return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_stream_set_blocking(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object) return .{ .bool = false };
-    const file = getFileHandle(args[0].object) orelse return .{ .bool = false };
+fn native_stream_set_blocking(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const file = getFileHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     const enable = args[1].isTruthy();
     const O_NONBLOCK: u32 = if (@import("builtin").os.tag == .linux) 0x800 else 0x4;
-    const flags = std.posix.fcntl(file.handle, 3, 0) catch return .{ .bool = false };
+    const flags = std.posix.fcntl(file.handle, 3, 0) catch return NativeResult.scalar(.{ .bool = false });
     const new_flags = if (enable) flags & ~@as(usize, O_NONBLOCK) else flags | O_NONBLOCK;
-    _ = std.posix.fcntl(file.handle, 4, new_flags) catch return .{ .bool = false };
-    return .{ .bool = true };
+    _ = std.posix.fcntl(file.handle, 4, new_flags) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_stream_set_timeout(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_stream_set_timeout(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_stream_set_read_buffer(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn native_stream_set_read_buffer(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_stream_set_write_buffer(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn native_stream_set_write_buffer(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
 const MimeEntry = struct { ext: []const u8, mime: []const u8 };
@@ -3465,86 +3447,86 @@ fn detectMimeFromBytes(data: []const u8) ?[]const u8 {
     return null;
 }
 
-fn native_mime_content_type(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_mime_content_type(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
     const file = std.fs.cwd().openFile(path, .{}) catch {
-        return .{ .string = Value.String.borrowed(try ctx.createString(mimeFromExt(path))) };
+        return try NativeResult.copyString(ctx.allocator, mimeFromExt(path));
     };
     defer file.close();
     var buf: [16]u8 = undefined;
-    const n = file.read(&buf) catch return .{ .string = Value.String.borrowed(try ctx.createString(mimeFromExt(path))) };
-    if (detectMimeFromBytes(buf[0..n])) |m| return .{ .string = Value.String.borrowed(try ctx.createString(m)) };
-    return .{ .string = Value.String.borrowed(try ctx.createString(mimeFromExt(path))) };
+    const n = file.read(&buf) catch return try NativeResult.copyString(ctx.allocator, mimeFromExt(path));
+    if (detectMimeFromBytes(buf[0..n])) |m| return try NativeResult.copyString(ctx.allocator, m);
+    return try NativeResult.copyString(ctx.allocator, mimeFromExt(path));
 }
 
 extern fn zphp_disk_space(path: [*:0]const u8, free_bytes: *u64, total_bytes: *u64) c_int;
 
-fn native_disk_free_space(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_disk_free_space(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try ctx.allocator.allocSentinel(u8, args[0].string.bytes().len, 0);
     defer ctx.allocator.free(path_z);
     @memcpy(path_z[0..args[0].string.bytes().len], args[0].string.bytes());
     var free_bytes: u64 = 0;
     var total_bytes: u64 = 0;
-    if (zphp_disk_space(path_z, &free_bytes, &total_bytes) != 0) return .{ .bool = false };
-    return .{ .float = @floatFromInt(free_bytes) };
+    if (zphp_disk_space(path_z, &free_bytes, &total_bytes) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .float = @floatFromInt(free_bytes) });
 }
 
-fn native_disk_total_space(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_disk_total_space(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try ctx.allocator.allocSentinel(u8, args[0].string.bytes().len, 0);
     defer ctx.allocator.free(path_z);
     @memcpy(path_z[0..args[0].string.bytes().len], args[0].string.bytes());
     var free_bytes: u64 = 0;
     var total_bytes: u64 = 0;
-    if (zphp_disk_space(path_z, &free_bytes, &total_bytes) != 0) return .{ .bool = false };
-    return .{ .float = @floatFromInt(total_bytes) };
+    if (zphp_disk_space(path_z, &free_bytes, &total_bytes) != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .float = @floatFromInt(total_bytes) });
 }
 
-fn native_linkinfo(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .int = -1 };
-    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return .{ .int = -1 };
-    return .{ .int = @intCast(stat.inode) };
+fn native_linkinfo(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .int = -1 });
+    const stat = std.fs.cwd().statFile(args[0].string.bytes()) catch return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(stat.inode) });
 }
 
-fn native_finfo_open(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_finfo_open(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.allocator.create(PhpObject);
     obj.* = .{ .class_name = "finfo" };
     try ctx.vm.objects.append(ctx.allocator, obj);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_finfo_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_finfo_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     return native_mime_content_type(ctx, &.{args[1]});
 }
 
-fn native_finfo_buffer(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    if (detectMimeFromBytes(args[1].string.bytes())) |m| return .{ .string = Value.String.borrowed(try ctx.createString(m)) };
-    return .{ .string = Value.String.borrowed("application/octet-stream") };
+fn native_finfo_buffer(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    if (detectMimeFromBytes(args[1].string.bytes())) |m| return try NativeResult.copyString(ctx.allocator, m);
+    return NativeResult.literal("application/octet-stream");
 }
 
-fn native_finfo_close(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_finfo_close(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn finfoConstruct(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn finfoConstruct(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn finfoFile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn finfoFile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     return native_mime_content_type(ctx, args[0..1]);
 }
 
-fn finfoBuffer(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    if (detectMimeFromBytes(args[0].string.bytes())) |m| return .{ .string = Value.String.borrowed(try ctx.createString(m)) };
-    return .{ .string = Value.String.borrowed("application/octet-stream") };
+fn finfoBuffer(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    if (detectMimeFromBytes(args[0].string.bytes())) |m| return try NativeResult.copyString(ctx.allocator, m);
+    return NativeResult.literal("application/octet-stream");
 }
 
-fn finfoNoop(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn finfoNoop(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }

--- a/src/stdlib/ftp.zig
+++ b/src/stdlib/ftp.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const net = std.net;
 const posix = std.posix;
@@ -112,56 +113,56 @@ fn connectTcp(host: []const u8, port: u16, allocator: std.mem.Allocator) !posix.
     return error.ConnectFailed;
 }
 
-fn native_ftp_connect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_ftp_connect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const host = args[0].string.bytes();
     const port: u16 = if (args.len > 1 and args[1] == .int) @intCast(args[1].int) else 21;
-    const fd = connectTcp(host, port, ctx.allocator) catch return .{ .bool = false };
+    const fd = connectTcp(host, port, ctx.allocator) catch return NativeResult.scalar(.{ .bool = false });
     const reply = readReply(ctx.allocator, fd) catch {
         posix.close(fd);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     ctx.allocator.free(reply.body);
     if (reply.code != 220) {
         posix.close(fd);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const obj = try ctx.createObject("FTPHandle");
     try obj.set(ctx.allocator, "__fd", .{ .int = @intCast(fd) });
     try obj.set(ctx.allocator, "__pasv", .{ .bool = true });
-    try obj.set(ctx.allocator, "__host", .{ .string = Value.String.borrowed(try ctx.allocator.dupe(u8, host)) });
-    return .{ .object = obj };
+    try obj.set(ctx.allocator, "__host", args[0]);
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_ftp_ssl_connect(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ftp_ssl_connect(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // FTPS would need TLS over the control + data connections. not yet supported
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_ftp_login(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    if (args.len < 3 or args[1] != .string or args[2] != .string) return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
+fn native_ftp_login(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3 or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
     const user_line = try std.fmt.allocPrint(ctx.allocator, "USER {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(user_line);
-    const r1 = runCmd(ctx.allocator, fd, user_line) catch return .{ .bool = false };
+    const r1 = runCmd(ctx.allocator, fd, user_line) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r1.body);
-    if (r1.code == 230) return .{ .bool = true };
-    if (r1.code != 331) return .{ .bool = false };
+    if (r1.code == 230) return NativeResult.scalar(.{ .bool = true });
+    if (r1.code != 331) return NativeResult.scalar(.{ .bool = false });
     const pass_line = try std.fmt.allocPrint(ctx.allocator, "PASS {s}", .{args[2].string.bytes()});
     defer ctx.allocator.free(pass_line);
-    const r2 = runCmd(ctx.allocator, fd, pass_line) catch return .{ .bool = false };
+    const r2 = runCmd(ctx.allocator, fd, pass_line) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r2.body);
-    return .{ .bool = r2.code == 230 };
+    return NativeResult.scalar(.{ .bool = r2.code == 230 });
 }
 
-fn native_ftp_close(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = true };
+fn native_ftp_close(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = true });
     sendCmd(fd, "QUIT") catch {};
     posix.close(fd);
     o.set(@import("std").heap.page_allocator, "__fd", .{ .int = -1 }) catch {};
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn cmdResult(ctx: *NativeContext, args: []const Value, line: []const u8, ok_codes: []const u16) RuntimeError!bool {
@@ -173,117 +174,116 @@ fn cmdResult(ctx: *NativeContext, args: []const Value, line: []const u8, ok_code
     return false;
 }
 
-fn native_ftp_pwd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
-    const r = runCmd(ctx.allocator, fd, "PWD") catch return .{ .bool = false };
+fn native_ftp_pwd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = runCmd(ctx.allocator, fd, "PWD") catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r.body);
-    if (r.code != 257) return .{ .bool = false };
+    if (r.code != 257) return NativeResult.scalar(.{ .bool = false });
     // body looks like: 257 "/path" comment\r\n
-    const start = std.mem.indexOfScalar(u8, r.body, '"') orelse return .{ .bool = false };
-    const end = std.mem.lastIndexOfScalar(u8, r.body, '"') orelse return .{ .bool = false };
-    if (end <= start) return .{ .bool = false };
+    const start = std.mem.indexOfScalar(u8, r.body, '"') orelse return NativeResult.scalar(.{ .bool = false });
+    const end = std.mem.lastIndexOfScalar(u8, r.body, '"') orelse return NativeResult.scalar(.{ .bool = false });
+    if (end <= start) return NativeResult.scalar(.{ .bool = false });
     const path = try ctx.allocator.dupe(u8, r.body[start + 1 .. end]);
-    try ctx.strings.append(ctx.allocator, path);
-    return .{ .string = Value.String.borrowed(path) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, path));
 }
 
-fn native_ftp_chdir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_ftp_chdir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const line = try std.fmt.allocPrint(ctx.allocator, "CWD {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    return .{ .bool = try cmdResult(ctx, args, line, &[_]u16{ 200, 250 }) };
+    return NativeResult.scalar(.{ .bool = try cmdResult(ctx, args, line, &[_]u16{ 200, 250 }) });
 }
 
-fn native_ftp_cdup(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = try cmdResult(ctx, args, "CDUP", &[_]u16{ 200, 250 }) };
+fn native_ftp_cdup(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = try cmdResult(ctx, args, "CDUP", &[_]u16{ 200, 250 }) });
 }
 
-fn native_ftp_mkdir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_ftp_mkdir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const line = try std.fmt.allocPrint(ctx.allocator, "MKD {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    const r = runCmd(ctx.allocator, fd, line) catch return .{ .bool = false };
+    const r = runCmd(ctx.allocator, fd, line) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r.body);
-    if (r.code != 257) return .{ .bool = false };
+    if (r.code != 257) return NativeResult.scalar(.{ .bool = false });
     const path = try ctx.allocator.dupe(u8, args[1].string.bytes());
-    try ctx.strings.append(ctx.allocator, path);
-    return .{ .string = Value.String.borrowed(path) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, path));
 }
 
-fn native_ftp_rmdir(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_ftp_rmdir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const line = try std.fmt.allocPrint(ctx.allocator, "RMD {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    return .{ .bool = try cmdResult(ctx, args, line, &[_]u16{250}) };
+    return NativeResult.scalar(.{ .bool = try cmdResult(ctx, args, line, &[_]u16{250}) });
 }
 
-fn native_ftp_delete(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_ftp_delete(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const line = try std.fmt.allocPrint(ctx.allocator, "DELE {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    return .{ .bool = try cmdResult(ctx, args, line, &[_]u16{250}) };
+    return NativeResult.scalar(.{ .bool = try cmdResult(ctx, args, line, &[_]u16{250}) });
 }
 
-fn native_ftp_rename(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
-    if (args.len < 3 or args[1] != .string or args[2] != .string) return .{ .bool = false };
+fn native_ftp_rename(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3 or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const l1 = try std.fmt.allocPrint(ctx.allocator, "RNFR {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(l1);
-    const r1 = runCmd(ctx.allocator, fd, l1) catch return .{ .bool = false };
+    const r1 = runCmd(ctx.allocator, fd, l1) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r1.body);
-    if (r1.code != 350) return .{ .bool = false };
+    if (r1.code != 350) return NativeResult.scalar(.{ .bool = false });
     const l2 = try std.fmt.allocPrint(ctx.allocator, "RNTO {s}", .{args[2].string.bytes()});
     defer ctx.allocator.free(l2);
-    const r2 = runCmd(ctx.allocator, fd, l2) catch return .{ .bool = false };
+    const r2 = runCmd(ctx.allocator, fd, l2) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r2.body);
-    return .{ .bool = r2.code == 250 };
+    return NativeResult.scalar(.{ .bool = r2.code == 250 });
 }
 
-fn native_ftp_size(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .int = -1 };
-    const fd = getFd(o) orelse return .{ .int = -1 };
-    if (args.len < 2 or args[1] != .string) return .{ .int = -1 };
-    _ = runCmd(ctx.allocator, fd, "TYPE I") catch return .{ .int = -1 };
+fn native_ftp_size(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .int = -1 });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .int = -1 });
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .int = -1 });
+    const type_reply = runCmd(ctx.allocator, fd, "TYPE I") catch return NativeResult.scalar(.{ .int = -1 });
+    defer ctx.allocator.free(type_reply.body);
     const line = try std.fmt.allocPrint(ctx.allocator, "SIZE {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    const r = runCmd(ctx.allocator, fd, line) catch return .{ .int = -1 };
+    const r = runCmd(ctx.allocator, fd, line) catch return NativeResult.scalar(.{ .int = -1 });
     defer ctx.allocator.free(r.body);
-    if (r.code != 213) return .{ .int = -1 };
+    if (r.code != 213) return NativeResult.scalar(.{ .int = -1 });
     // 213 NNN\r\n
     var iter = std.mem.tokenizeAny(u8, r.body, " \r\n");
     _ = iter.next(); // code
-    const num_str = iter.next() orelse return .{ .int = -1 };
-    const sz = std.fmt.parseInt(i64, num_str, 10) catch return .{ .int = -1 };
-    return .{ .int = sz };
+    const num_str = iter.next() orelse return NativeResult.scalar(.{ .int = -1 });
+    const sz = std.fmt.parseInt(i64, num_str, 10) catch return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = sz });
 }
 
-fn native_ftp_mdtm(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .int = -1 };
-    const fd = getFd(o) orelse return .{ .int = -1 };
-    if (args.len < 2 or args[1] != .string) return .{ .int = -1 };
+fn native_ftp_mdtm(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .int = -1 });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .int = -1 });
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .int = -1 });
     const line = try std.fmt.allocPrint(ctx.allocator, "MDTM {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    const r = runCmd(ctx.allocator, fd, line) catch return .{ .int = -1 };
+    const r = runCmd(ctx.allocator, fd, line) catch return NativeResult.scalar(.{ .int = -1 });
     defer ctx.allocator.free(r.body);
-    if (r.code != 213) return .{ .int = -1 };
+    if (r.code != 213) return NativeResult.scalar(.{ .int = -1 });
     var iter = std.mem.tokenizeAny(u8, r.body, " \r\n");
     _ = iter.next();
-    const ts = iter.next() orelse return .{ .int = -1 };
-    if (ts.len < 14) return .{ .int = -1 };
+    const ts = iter.next() orelse return NativeResult.scalar(.{ .int = -1 });
+    if (ts.len < 14) return NativeResult.scalar(.{ .int = -1 });
     // YYYYMMDDHHMMSS UTC
-    const year = std.fmt.parseInt(i32, ts[0..4], 10) catch return .{ .int = -1 };
-    const mon = std.fmt.parseInt(u8, ts[4..6], 10) catch return .{ .int = -1 };
-    const day = std.fmt.parseInt(u8, ts[6..8], 10) catch return .{ .int = -1 };
-    const hr = std.fmt.parseInt(u8, ts[8..10], 10) catch return .{ .int = -1 };
-    const mn = std.fmt.parseInt(u8, ts[10..12], 10) catch return .{ .int = -1 };
-    const sc = std.fmt.parseInt(u8, ts[12..14], 10) catch return .{ .int = -1 };
+    const year = std.fmt.parseInt(i32, ts[0..4], 10) catch return NativeResult.scalar(.{ .int = -1 });
+    const mon = std.fmt.parseInt(u8, ts[4..6], 10) catch return NativeResult.scalar(.{ .int = -1 });
+    const day = std.fmt.parseInt(u8, ts[6..8], 10) catch return NativeResult.scalar(.{ .int = -1 });
+    const hr = std.fmt.parseInt(u8, ts[8..10], 10) catch return NativeResult.scalar(.{ .int = -1 });
+    const mn = std.fmt.parseInt(u8, ts[10..12], 10) catch return NativeResult.scalar(.{ .int = -1 });
+    const sc = std.fmt.parseInt(u8, ts[12..14], 10) catch return NativeResult.scalar(.{ .int = -1 });
     const epoch_days = daysFromCivil(year, mon, day);
     const epoch = @as(i64, epoch_days) * 86400 + @as(i64, hr) * 3600 + @as(i64, mn) * 60 + sc;
-    return .{ .int = epoch };
+    return NativeResult.scalar(.{ .int = epoch });
 }
 
 fn daysFromCivil(y_in: i32, m: u8, d: u8) i64 {
@@ -335,7 +335,8 @@ fn readAll(allocator: std.mem.Allocator, fd: posix.socket_t) ![]u8 {
 }
 
 fn dataTransfer(ctx: *NativeContext, ctrl: posix.socket_t, list_cmd: []const u8, type_cmd: []const u8) ![]u8 {
-    _ = try runCmd(ctx.allocator, ctrl, type_cmd);
+    const type_reply = try runCmd(ctx.allocator, ctrl, type_cmd);
+    defer ctx.allocator.free(type_reply.body);
     const data_fd = try enterPasv(ctx.allocator, ctrl);
     defer posix.close(data_fd);
     try sendCmd(ctrl, list_cmd);
@@ -343,169 +344,169 @@ fn dataTransfer(ctx: *NativeContext, ctrl: posix.socket_t, list_cmd: []const u8,
     defer ctx.allocator.free(r1.body);
     if (r1.code != 150 and r1.code != 125) return error.BadReply;
     const data = try readAll(ctx.allocator, data_fd);
+    errdefer ctx.allocator.free(data);
     const r2 = try readReply(ctx.allocator, ctrl);
     defer ctx.allocator.free(r2.body);
     if (r2.code != 226 and r2.code != 250) {
-        ctx.allocator.free(data);
         return error.BadReply;
     }
     return data;
 }
 
-fn native_ftp_nlist(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
+fn native_ftp_nlist(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
     const path = if (args.len > 1 and args[1] == .string) args[1].string.bytes() else ".";
     const line = try std.fmt.allocPrint(ctx.allocator, "NLST {s}", .{path});
     defer ctx.allocator.free(line);
-    const data = dataTransfer(ctx, fd, line, "TYPE A") catch return .{ .bool = false };
+    const data = dataTransfer(ctx, fd, line, "TYPE A") catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(data);
     const arr = try ctx.createArray();
     var iter = std.mem.tokenizeAny(u8, data, "\r\n");
     while (iter.next()) |item| {
-        const s = try ctx.allocator.dupe(u8, item);
-        try ctx.strings.append(ctx.allocator, s);
-        try arr.set(ctx.allocator, .{ .int = arr.next_int_key }, .{ .string = Value.String.borrowed(s) });
+        const s = try Value.String.create(ctx.allocator, item);
+        defer s.release();
+        try arr.set(ctx.allocator, .{ .int = arr.next_int_key }, .{ .string = s });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_ftp_rawlist(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
+fn native_ftp_rawlist(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
     const path = if (args.len > 1 and args[1] == .string) args[1].string.bytes() else ".";
     const line = try std.fmt.allocPrint(ctx.allocator, "LIST {s}", .{path});
     defer ctx.allocator.free(line);
-    const data = dataTransfer(ctx, fd, line, "TYPE A") catch return .{ .bool = false };
+    const data = dataTransfer(ctx, fd, line, "TYPE A") catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(data);
     const arr = try ctx.createArray();
     var iter = std.mem.tokenizeAny(u8, data, "\r\n");
     while (iter.next()) |item| {
-        const s = try ctx.allocator.dupe(u8, item);
-        try ctx.strings.append(ctx.allocator, s);
-        try arr.set(ctx.allocator, .{ .int = arr.next_int_key }, .{ .string = Value.String.borrowed(s) });
+        const s = try Value.String.create(ctx.allocator, item);
+        defer s.release();
+        try arr.set(ctx.allocator, .{ .int = arr.next_int_key }, .{ .string = s });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_ftp_raw(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const r = runCmd(ctx.allocator, fd, args[1].string.bytes()) catch return .{ .bool = false };
+fn native_ftp_raw(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const r = runCmd(ctx.allocator, fd, args[1].string.bytes()) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r.body);
     const arr = try ctx.createArray();
     var iter = std.mem.tokenizeAny(u8, r.body, "\r\n");
     while (iter.next()) |item| {
-        const s = try ctx.allocator.dupe(u8, item);
-        try ctx.strings.append(ctx.allocator, s);
-        try arr.set(ctx.allocator, .{ .int = arr.next_int_key }, .{ .string = Value.String.borrowed(s) });
+        const s = try Value.String.create(ctx.allocator, item);
+        defer s.release();
+        try arr.set(ctx.allocator, .{ .int = arr.next_int_key }, .{ .string = s });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_ftp_get(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
-    if (args.len < 3 or args[1] != .string or args[2] != .string) return .{ .bool = false };
+fn native_ftp_get(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3 or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const mode: i64 = if (args.len > 3 and args[3] == .int) args[3].int else 2; // FTP_BINARY
     const tcmd: []const u8 = if (mode == 1) "TYPE A" else "TYPE I";
     const line = try std.fmt.allocPrint(ctx.allocator, "RETR {s}", .{args[2].string.bytes()});
     defer ctx.allocator.free(line);
-    const data = dataTransfer(ctx, fd, line, tcmd) catch return .{ .bool = false };
+    const data = dataTransfer(ctx, fd, line, tcmd) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(data);
-    var f = std.fs.cwd().createFile(args[1].string.bytes(), .{ .truncate = true }) catch return .{ .bool = false };
+    var f = std.fs.cwd().createFile(args[1].string.bytes(), .{ .truncate = true }) catch return NativeResult.scalar(.{ .bool = false });
     defer f.close();
-    f.writeAll(data) catch return .{ .bool = false };
-    return .{ .bool = true };
+    f.writeAll(data) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_ftp_put(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
-    if (args.len < 3 or args[1] != .string or args[2] != .string) return .{ .bool = false };
+fn native_ftp_put(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3 or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const mode: i64 = if (args.len > 3 and args[3] == .int) args[3].int else 2;
     const tcmd: []const u8 = if (mode == 1) "TYPE A" else "TYPE I";
-    _ = runCmd(ctx.allocator, fd, tcmd) catch return .{ .bool = false };
-    const data_fd = enterPasv(ctx.allocator, fd) catch return .{ .bool = false };
+    const type_reply = runCmd(ctx.allocator, fd, tcmd) catch return NativeResult.scalar(.{ .bool = false });
+    defer ctx.allocator.free(type_reply.body);
+    const data_fd = enterPasv(ctx.allocator, fd) catch return NativeResult.scalar(.{ .bool = false });
     defer posix.close(data_fd);
     const line = try std.fmt.allocPrint(ctx.allocator, "STOR {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    sendCmd(fd, line) catch return .{ .bool = false };
-    const r1 = readReply(ctx.allocator, fd) catch return .{ .bool = false };
+    sendCmd(fd, line) catch return NativeResult.scalar(.{ .bool = false });
+    const r1 = readReply(ctx.allocator, fd) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r1.body);
-    if (r1.code != 150 and r1.code != 125) return .{ .bool = false };
+    if (r1.code != 150 and r1.code != 125) return NativeResult.scalar(.{ .bool = false });
 
-    var f = std.fs.cwd().openFile(args[2].string.bytes(), .{}) catch return .{ .bool = false };
+    var f = std.fs.cwd().openFile(args[2].string.bytes(), .{}) catch return NativeResult.scalar(.{ .bool = false });
     defer f.close();
     var buf: [8192]u8 = undefined;
     while (true) {
-        const n = f.read(&buf) catch return .{ .bool = false };
+        const n = f.read(&buf) catch return NativeResult.scalar(.{ .bool = false });
         if (n == 0) break;
-        _ = posix.send(data_fd, buf[0..n], 0) catch return .{ .bool = false };
+        _ = posix.send(data_fd, buf[0..n], 0) catch return NativeResult.scalar(.{ .bool = false });
     }
     posix.shutdown(data_fd, .both) catch {};
-    const r2 = readReply(ctx.allocator, fd) catch return .{ .bool = false };
+    const r2 = readReply(ctx.allocator, fd) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r2.body);
-    return .{ .bool = r2.code == 226 or r2.code == 250 };
+    return NativeResult.scalar(.{ .bool = r2.code == 226 or r2.code == 250 });
 }
 
-fn native_ftp_pasv(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
+fn native_ftp_pasv(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len > 1 and args[1] == .bool) {
         o.set(std.heap.page_allocator, "__pasv", .{ .bool = args[1].bool }) catch {};
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_ftp_systype(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args) orelse return .{ .bool = false };
-    const fd = getFd(o) orelse return .{ .bool = false };
-    const r = runCmd(ctx.allocator, fd, "SYST") catch return .{ .bool = false };
+fn native_ftp_systype(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args) orelse return NativeResult.scalar(.{ .bool = false });
+    const fd = getFd(o) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = runCmd(ctx.allocator, fd, "SYST") catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(r.body);
-    if (r.code != 215) return .{ .bool = false };
+    if (r.code != 215) return NativeResult.scalar(.{ .bool = false });
     var iter = std.mem.tokenizeAny(u8, r.body, " \r\n");
     _ = iter.next();
-    const sys = iter.next() orelse return .{ .bool = false };
+    const sys = iter.next() orelse return NativeResult.scalar(.{ .bool = false });
     const s = try ctx.allocator.dupe(u8, sys);
-    try ctx.strings.append(ctx.allocator, s);
-    return .{ .string = Value.String.borrowed(s) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
 }
 
-fn native_ftp_set_option(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_ftp_set_option(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_ftp_get_option(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_ftp_get_option(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // option 0 = FTP_TIMEOUT_SEC, return 90 as a stable default
-    if (args.len > 1 and args[1] == .int) return .{ .int = 90 };
-    return .{ .bool = false };
+    if (args.len > 1 and args[1] == .int) return NativeResult.scalar(.{ .int = 90 });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_ftp_alloc(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_ftp_alloc(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_ftp_site(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_ftp_site(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const line = try std.fmt.allocPrint(ctx.allocator, "SITE {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    return .{ .bool = try cmdResult(ctx, args, line, &[_]u16{ 200, 250 }) };
+    return NativeResult.scalar(.{ .bool = try cmdResult(ctx, args, line, &[_]u16{ 200, 250 }) });
 }
 
-fn native_ftp_exec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_ftp_exec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const line = try std.fmt.allocPrint(ctx.allocator, "SITE EXEC {s}", .{args[1].string.bytes()});
     defer ctx.allocator.free(line);
-    return .{ .bool = try cmdResult(ctx, args, line, &[_]u16{ 200, 250 }) };
+    return NativeResult.scalar(.{ .bool = try cmdResult(ctx, args, line, &[_]u16{ 200, 250 }) });
 }
 
-fn native_ftp_chmod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[1] != .int or args[2] != .string) return .{ .bool = false };
+fn native_ftp_chmod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[1] != .int or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const line = try std.fmt.allocPrint(ctx.allocator, "SITE CHMOD {o} {s}", .{ @as(u64, @intCast(args[1].int)), args[2].string.bytes() });
     defer ctx.allocator.free(line);
-    if (try cmdResult(ctx, args, line, &[_]u16{ 200, 250 })) return .{ .int = args[1].int };
-    return .{ .bool = false };
+    if (try cmdResult(ctx, args, line, &[_]u16{ 200, 250 })) return NativeResult.scalar(.{ .int = args[1].int });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {

--- a/src/stdlib/gd.zig
+++ b/src/stdlib/gd.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -28,11 +29,11 @@ fn getImg(obj: *const PhpObject) ?*c.gdImageStruct {
     return @ptrFromInt(@as(usize, @intCast(v.int)));
 }
 
-fn wrapImg(ctx: *NativeContext, im: ?*c.gdImageStruct) !Value {
-    if (im == null) return .{ .bool = false };
+fn wrapImg(ctx: *NativeContext, im: ?*c.gdImageStruct) RuntimeError!NativeResult {
+    if (im == null) return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("GdImage");
     try obj.set(ctx.allocator, "__gd_ptr", .{ .int = @intCast(@intFromPtr(im.?)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 fn dupZ(ctx: *NativeContext, s: []const u8) ![:0]u8 {
@@ -78,60 +79,60 @@ fn argImg(args: []const Value, idx: usize) ?*c.gdImageStruct {
 
 // ---------------- create / destroy ----------------
 
-fn imgCreate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const w = argInt(args, 0) orelse return .{ .bool = false };
-    const h = argInt(args, 1) orelse return .{ .bool = false };
+fn imgCreate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const w = argInt(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const h = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     const im = c.gdImageCreate(@intCast(w), @intCast(h));
     return wrapImg(ctx, im);
 }
 
-fn imgCreateTrueColor(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const w = argInt(args, 0) orelse return .{ .bool = false };
-    const h = argInt(args, 1) orelse return .{ .bool = false };
+fn imgCreateTrueColor(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const w = argInt(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const h = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     const im = c.gdImageCreateTrueColor(@intCast(w), @intCast(h));
     return wrapImg(ctx, im);
 }
 
-fn imgDestroy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn imgDestroy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     _ = ctx;
-    const im = argImg(args, 0) orelse return .{ .bool = false };
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageDestroy(im);
     if (args[0] == .object) {
         // zero the pointer so later operations no-op
         args[0].object.set(std.heap.page_allocator, "__gd_ptr", .{ .int = 0 }) catch {};
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgCreateFromPng(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn imgCreateFromPng(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
-    const f = c.fopen(path_z.ptr, "rb") orelse return .{ .bool = false };
+    const f = c.fopen(path_z.ptr, "rb") orelse return NativeResult.scalar(.{ .bool = false });
     defer _ = c.fclose(f);
     const im = c.gdImageCreateFromPng(f);
     return wrapImg(ctx, im);
 }
 
-fn imgCreateFromJpeg(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn imgCreateFromJpeg(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
-    const f = c.fopen(path_z.ptr, "rb") orelse return .{ .bool = false };
+    const f = c.fopen(path_z.ptr, "rb") orelse return NativeResult.scalar(.{ .bool = false });
     defer _ = c.fclose(f);
     const im = c.gdImageCreateFromJpeg(f);
     return wrapImg(ctx, im);
 }
 
-fn imgCreateFromGif(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn imgCreateFromGif(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
-    const f = c.fopen(path_z.ptr, "rb") orelse return .{ .bool = false };
+    const f = c.fopen(path_z.ptr, "rb") orelse return NativeResult.scalar(.{ .bool = false });
     defer _ = c.fclose(f);
     const im = c.gdImageCreateFromGif(f);
     return wrapImg(ctx, im);
 }
 
-fn imgCreateFromString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn imgCreateFromString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const data = args[0].string.bytes();
     // try PNG first, then JPEG, then GIF (sniffed from header)
     if (data.len >= 8 and data[0] == 0x89 and data[1] == 'P' and data[2] == 'N' and data[3] == 'G') {
@@ -146,22 +147,22 @@ fn imgCreateFromString(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         const im = c.gdImageCreateFromGifPtr(@intCast(data.len), @ptrCast(@constCast(data.ptr)));
         return wrapImg(ctx, im);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 // ---------------- output ----------------
 
-fn writeImageTo(ctx: *NativeContext, im: *c.gdImageStruct, args: []const Value, kind: enum { png, jpeg, gif }, quality: c_int) !Value {
+fn writeImageTo(ctx: *NativeContext, im: *c.gdImageStruct, args: []const Value, kind: enum { png, jpeg, gif }, quality: c_int) RuntimeError!NativeResult {
     if (args.len > 1 and args[1] == .string) {
         const path_z = try dupZ(ctx, args[1].string.bytes());
-        const f = c.fopen(path_z.ptr, "wb") orelse return .{ .bool = false };
+        const f = c.fopen(path_z.ptr, "wb") orelse return NativeResult.scalar(.{ .bool = false });
         defer _ = c.fclose(f);
         switch (kind) {
             .png => c.gdImagePng(im, f),
             .jpeg => c.gdImageJpeg(im, f, quality),
             .gif => c.gdImageGif(im, f),
         }
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
     var size: c_int = 0;
     const buf = switch (kind) {
@@ -169,7 +170,7 @@ fn writeImageTo(ctx: *NativeContext, im: *c.gdImageStruct, args: []const Value, 
         .jpeg => c.gdImageJpegPtr(im, &size, quality),
         .gif => c.gdImageGifPtr(im, &size),
     };
-    if (buf == null) return .{ .bool = false };
+    if (buf == null) return NativeResult.scalar(.{ .bool = false });
     defer c.gdFree(buf);
     // when filename is null, PHP writes to the script's output channel - which
     // goes through ob_start buffers, not directly to stdout. append to vm.output
@@ -177,70 +178,70 @@ fn writeImageTo(ctx: *NativeContext, im: *c.gdImageStruct, args: []const Value, 
     const slice_ptr: [*]const u8 = @ptrCast(buf);
     const usize_sz: usize = @intCast(size);
     try ctx.vm.output.appendSlice(ctx.allocator, slice_ptr[0..usize_sz]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgPng(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
+fn imgPng(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     return writeImageTo(ctx, im, args, .png, 0);
 }
 
-fn imgJpeg(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
+fn imgJpeg(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     const q: c_int = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else 75;
     return writeImageTo(ctx, im, args, .jpeg, q);
 }
 
-fn imgGif(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
+fn imgGif(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     return writeImageTo(ctx, im, args, .gif, 0);
 }
 
 // ---------------- colors ----------------
 
-fn imgColorAllocate(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const r = argInt(args, 1) orelse return .{ .bool = false };
-    const g = argInt(args, 2) orelse return .{ .bool = false };
-    const b = argInt(args, 3) orelse return .{ .bool = false };
-    return .{ .int = @intCast(c.gdImageColorAllocate(im, @intCast(r), @intCast(g), @intCast(b))) };
+fn imgColorAllocate(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const g = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const b = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(c.gdImageColorAllocate(im, @intCast(r), @intCast(g), @intCast(b))) });
 }
 
-fn imgColorAllocateAlpha(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const r = argInt(args, 1) orelse return .{ .bool = false };
-    const g = argInt(args, 2) orelse return .{ .bool = false };
-    const b = argInt(args, 3) orelse return .{ .bool = false };
-    const al = argInt(args, 4) orelse return .{ .bool = false };
-    return .{ .int = @intCast(c.gdImageColorAllocateAlpha(im, @intCast(r), @intCast(g), @intCast(b), @intCast(al))) };
+fn imgColorAllocateAlpha(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const g = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const b = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const al = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(c.gdImageColorAllocateAlpha(im, @intCast(r), @intCast(g), @intCast(b), @intCast(al))) });
 }
 
-fn imgColorAt(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const x = argInt(args, 1) orelse return .{ .bool = false };
-    const y = argInt(args, 2) orelse return .{ .bool = false };
-    return .{ .int = @intCast(c.gdImageGetPixel(im, @intCast(x), @intCast(y))) };
+fn imgColorAt(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const x = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const y = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(c.gdImageGetPixel(im, @intCast(x), @intCast(y))) });
 }
 
-fn imgRotate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const angle = argFloat(args, 1) orelse return .{ .bool = false };
+fn imgRotate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const angle = argFloat(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     const bg_color = argInt(args, 2) orelse 0;
     const out = c.gdImageRotateInterpolated(im, @floatCast(angle), @intCast(bg_color));
     return wrapImg(ctx, out);
 }
 
-fn imgColorTransparent(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .int = -1 };
+fn imgColorTransparent(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .int = -1 });
     if (args.len >= 2 and args[1] == .int) {
         c.gdImageColorTransparent(im, @intCast(args[1].int));
     }
-    return .{ .int = @intCast(im.*.transparent) };
+    return NativeResult.scalar(.{ .int = @intCast(im.*.transparent) });
 }
 
-fn imgColorsForIndex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const idx = argInt(args, 1) orelse return .{ .bool = false };
+fn imgColorsForIndex(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const idx = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     var r: c_int = 0;
     var g: c_int = 0;
     var b: c_int = 0;
@@ -253,7 +254,7 @@ fn imgColorsForIndex(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         alpha = (ci >> 24) & 0x7f;
     } else {
         const ci: usize = @intCast(idx);
-        if (ci >= im.*.colorsTotal) return .{ .bool = false };
+        if (ci >= im.*.colorsTotal) return NativeResult.scalar(.{ .bool = false });
         r = im.*.red[ci];
         g = im.*.green[ci];
         b = im.*.blue[ci];
@@ -264,106 +265,106 @@ fn imgColorsForIndex(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("green") }, .{ .int = g });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("blue") }, .{ .int = b });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("alpha") }, .{ .int = alpha });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // ---------------- drawing ----------------
 
-fn imgSetPixel(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const x = argInt(args, 1) orelse return .{ .bool = false };
-    const y = argInt(args, 2) orelse return .{ .bool = false };
-    const col = argInt(args, 3) orelse return .{ .bool = false };
+fn imgSetPixel(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const x = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const y = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageSetPixel(im, @intCast(x), @intCast(y), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgLine(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const x1 = argInt(args, 1) orelse return .{ .bool = false };
-    const y1 = argInt(args, 2) orelse return .{ .bool = false };
-    const x2 = argInt(args, 3) orelse return .{ .bool = false };
-    const y2 = argInt(args, 4) orelse return .{ .bool = false };
-    const col = argInt(args, 5) orelse return .{ .bool = false };
+fn imgLine(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const x1 = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const y1 = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const x2 = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const y2 = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageLine(im, @intCast(x1), @intCast(y1), @intCast(x2), @intCast(y2), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgRectangle(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const x1 = argInt(args, 1) orelse return .{ .bool = false };
-    const y1 = argInt(args, 2) orelse return .{ .bool = false };
-    const x2 = argInt(args, 3) orelse return .{ .bool = false };
-    const y2 = argInt(args, 4) orelse return .{ .bool = false };
-    const col = argInt(args, 5) orelse return .{ .bool = false };
+fn imgRectangle(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const x1 = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const y1 = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const x2 = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const y2 = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageRectangle(im, @intCast(x1), @intCast(y1), @intCast(x2), @intCast(y2), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgFilledRectangle(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const x1 = argInt(args, 1) orelse return .{ .bool = false };
-    const y1 = argInt(args, 2) orelse return .{ .bool = false };
-    const x2 = argInt(args, 3) orelse return .{ .bool = false };
-    const y2 = argInt(args, 4) orelse return .{ .bool = false };
-    const col = argInt(args, 5) orelse return .{ .bool = false };
+fn imgFilledRectangle(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const x1 = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const y1 = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const x2 = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const y2 = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageFilledRectangle(im, @intCast(x1), @intCast(y1), @intCast(x2), @intCast(y2), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgEllipse(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const cx = argInt(args, 1) orelse return .{ .bool = false };
-    const cy = argInt(args, 2) orelse return .{ .bool = false };
-    const w = argInt(args, 3) orelse return .{ .bool = false };
-    const h = argInt(args, 4) orelse return .{ .bool = false };
-    const col = argInt(args, 5) orelse return .{ .bool = false };
+fn imgEllipse(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const cx = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const cy = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const w = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const h = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageEllipse(im, @intCast(cx), @intCast(cy), @intCast(w), @intCast(h), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgFilledEllipse(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const cx = argInt(args, 1) orelse return .{ .bool = false };
-    const cy = argInt(args, 2) orelse return .{ .bool = false };
-    const w = argInt(args, 3) orelse return .{ .bool = false };
-    const h = argInt(args, 4) orelse return .{ .bool = false };
-    const col = argInt(args, 5) orelse return .{ .bool = false };
+fn imgFilledEllipse(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const cx = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const cy = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const w = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const h = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageFilledEllipse(im, @intCast(cx), @intCast(cy), @intCast(w), @intCast(h), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgArc(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const cx = argInt(args, 1) orelse return .{ .bool = false };
-    const cy = argInt(args, 2) orelse return .{ .bool = false };
-    const w = argInt(args, 3) orelse return .{ .bool = false };
-    const h = argInt(args, 4) orelse return .{ .bool = false };
-    const s = argInt(args, 5) orelse return .{ .bool = false };
-    const e = argInt(args, 6) orelse return .{ .bool = false };
-    const col = argInt(args, 7) orelse return .{ .bool = false };
+fn imgArc(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const cx = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const cy = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const w = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const h = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const s = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
+    const e = argInt(args, 6) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 7) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageArc(im, @intCast(cx), @intCast(cy), @intCast(w), @intCast(h), @intCast(s), @intCast(e), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgFill(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const x = argInt(args, 1) orelse return .{ .bool = false };
-    const y = argInt(args, 2) orelse return .{ .bool = false };
-    const col = argInt(args, 3) orelse return .{ .bool = false };
+fn imgFill(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const x = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const y = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageFill(im, @intCast(x), @intCast(y), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // ---------------- text ----------------
 
-fn imgString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const font = argInt(args, 1) orelse return .{ .bool = false };
-    const x = argInt(args, 2) orelse return .{ .bool = false };
-    const y = argInt(args, 3) orelse return .{ .bool = false };
-    if (args.len < 5 or args[4] != .string) return .{ .bool = false };
-    const col = argInt(args, 5) orelse return .{ .bool = false };
+fn imgString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const font = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const x = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const y = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 5 or args[4] != .string) return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
 
     const text_z = try dupZ(ctx, args[4].string.bytes());
     const gd_font = switch (font) {
@@ -374,86 +375,86 @@ fn imgString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         else => c.gdFontGetTiny(),
     };
     c.gdImageString(im, gd_font, @intCast(x), @intCast(y), @ptrCast(@constCast(text_z.ptr)), @intCast(col));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgTtfText(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 8) return .{ .bool = false };
-    const im = argImg(args, 0) orelse return .{ .bool = false };
+fn imgTtfText(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 8) return NativeResult.scalar(.{ .bool = false });
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     const size: f64 = switch (args[1]) {
         .int => |i| @floatFromInt(i),
         .float => |f| f,
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     const angle: f64 = switch (args[2]) {
         .int => |i| @floatFromInt(i),
         .float => |f| f,
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
-    const x = argInt(args, 3) orelse return .{ .bool = false };
-    const y = argInt(args, 4) orelse return .{ .bool = false };
-    const col = argInt(args, 5) orelse return .{ .bool = false };
-    if (args[6] != .string or args[7] != .string) return .{ .bool = false };
+    const x = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const y = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const col = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args[6] != .string or args[7] != .string) return NativeResult.scalar(.{ .bool = false });
     const font_z = try dupZ(ctx, args[6].string.bytes());
     const text_z = try dupZ(ctx, args[7].string.bytes());
 
     var brect: [8]c_int = .{0} ** 8;
     const err = c.gdImageStringFT(im, &brect, @intCast(col), font_z.ptr, size, angle, @intCast(x), @intCast(y), text_z.ptr);
-    if (err != null) return .{ .bool = false };
+    if (err != null) return NativeResult.scalar(.{ .bool = false });
     // return the bounding box as a PHP array (8 ints)
     const arr = try ctx.createArray();
     for (brect, 0..) |v, i| try arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .int = @intCast(v) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // ---------------- copy ----------------
 
-fn imgCopy(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const dst = argImg(args, 0) orelse return .{ .bool = false };
-    const src = argImg(args, 1) orelse return .{ .bool = false };
-    const dx = argInt(args, 2) orelse return .{ .bool = false };
-    const dy = argInt(args, 3) orelse return .{ .bool = false };
-    const sx = argInt(args, 4) orelse return .{ .bool = false };
-    const sy = argInt(args, 5) orelse return .{ .bool = false };
-    const w = argInt(args, 6) orelse return .{ .bool = false };
-    const h = argInt(args, 7) orelse return .{ .bool = false };
+fn imgCopy(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const dst = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const src = argImg(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const dx = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const dy = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const sx = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const sy = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
+    const w = argInt(args, 6) orelse return NativeResult.scalar(.{ .bool = false });
+    const h = argInt(args, 7) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageCopy(dst, src, @intCast(dx), @intCast(dy), @intCast(sx), @intCast(sy), @intCast(w), @intCast(h));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgCopyResampled(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const dst = argImg(args, 0) orelse return .{ .bool = false };
-    const src = argImg(args, 1) orelse return .{ .bool = false };
-    const dx = argInt(args, 2) orelse return .{ .bool = false };
-    const dy = argInt(args, 3) orelse return .{ .bool = false };
-    const sx = argInt(args, 4) orelse return .{ .bool = false };
-    const sy = argInt(args, 5) orelse return .{ .bool = false };
-    const dw = argInt(args, 6) orelse return .{ .bool = false };
-    const dh = argInt(args, 7) orelse return .{ .bool = false };
-    const sw = argInt(args, 8) orelse return .{ .bool = false };
-    const sh = argInt(args, 9) orelse return .{ .bool = false };
+fn imgCopyResampled(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const dst = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const src = argImg(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const dx = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const dy = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const sx = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const sy = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
+    const dw = argInt(args, 6) orelse return NativeResult.scalar(.{ .bool = false });
+    const dh = argInt(args, 7) orelse return NativeResult.scalar(.{ .bool = false });
+    const sw = argInt(args, 8) orelse return NativeResult.scalar(.{ .bool = false });
+    const sh = argInt(args, 9) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageCopyResampled(dst, src, @intCast(dx), @intCast(dy), @intCast(sx), @intCast(sy), @intCast(dw), @intCast(dh), @intCast(sw), @intCast(sh));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgCopyResized(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const dst = argImg(args, 0) orelse return .{ .bool = false };
-    const src = argImg(args, 1) orelse return .{ .bool = false };
-    const dx = argInt(args, 2) orelse return .{ .bool = false };
-    const dy = argInt(args, 3) orelse return .{ .bool = false };
-    const sx = argInt(args, 4) orelse return .{ .bool = false };
-    const sy = argInt(args, 5) orelse return .{ .bool = false };
-    const dw = argInt(args, 6) orelse return .{ .bool = false };
-    const dh = argInt(args, 7) orelse return .{ .bool = false };
-    const sw = argInt(args, 8) orelse return .{ .bool = false };
-    const sh = argInt(args, 9) orelse return .{ .bool = false };
+fn imgCopyResized(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const dst = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const src = argImg(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
+    const dx = argInt(args, 2) orelse return NativeResult.scalar(.{ .bool = false });
+    const dy = argInt(args, 3) orelse return NativeResult.scalar(.{ .bool = false });
+    const sx = argInt(args, 4) orelse return NativeResult.scalar(.{ .bool = false });
+    const sy = argInt(args, 5) orelse return NativeResult.scalar(.{ .bool = false });
+    const dw = argInt(args, 6) orelse return NativeResult.scalar(.{ .bool = false });
+    const dh = argInt(args, 7) orelse return NativeResult.scalar(.{ .bool = false });
+    const sw = argInt(args, 8) orelse return NativeResult.scalar(.{ .bool = false });
+    const sh = argInt(args, 9) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageCopyResized(dst, src, @intCast(dx), @intCast(dy), @intCast(sx), @intCast(sy), @intCast(dw), @intCast(dh), @intCast(sw), @intCast(sh));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgScale(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const src = argImg(args, 0) orelse return .{ .bool = false };
-    const new_w = argInt(args, 1) orelse return .{ .bool = false };
+fn imgScale(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const src = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const new_w = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     var new_h = argInt(args, 2) orelse -1;
     if (new_h <= 0) {
         // preserve aspect ratio when height is -1 or unspecified
@@ -463,14 +464,14 @@ fn imgScale(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         new_h = @intFromFloat(@round(nw_f * sh_f / sw_f));
         if (new_h < 1) new_h = 1;
     }
-    const dst = c.gdImageCreateTrueColor(@intCast(new_w), @intCast(new_h)) orelse return .{ .bool = false };
+    const dst = c.gdImageCreateTrueColor(@intCast(new_w), @intCast(new_h)) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageCopyResampled(dst, src, 0, 0, 0, 0, @intCast(new_w), @intCast(new_h), src.sx, src.sy);
     return wrapImg(ctx, dst);
 }
 
-fn imgFilter(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const kind = argInt(args, 1) orelse return .{ .bool = false };
+fn imgFilter(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const kind = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     // PHP's IMG_FILTER_* constants:
     // 0 NEGATE, 1 GRAYSCALE, 2 BRIGHTNESS, 3 CONTRAST, 4 COLORIZE,
     // 5 EDGEDETECT, 6 EMBOSS, 7 GAUSSIAN_BLUR, 8 SELECTIVE_BLUR,
@@ -496,14 +497,14 @@ fn imgFilter(_: *NativeContext, args: []const Value) RuntimeError!Value {
         },
         5 => c.gdImageEdgeDetectQuick(im),
         7 => c.gdImageGaussianBlur(im),
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
-    return .{ .bool = ok != 0 or kind == 1 or kind == 0 or kind == 5 or kind == 7 };
+    return NativeResult.scalar(.{ .bool = ok != 0 or kind == 1 or kind == 0 or kind == 5 or kind == 7 });
 }
 
-fn imgCrop(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const src = argImg(args, 0) orelse return .{ .bool = false };
-    if (args.len < 2 or args[1] != .array) return .{ .bool = false };
+fn imgCrop(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const src = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2 or args[1] != .array) return NativeResult.scalar(.{ .bool = false });
     const rect = args[1].array;
     const x = blk: {
         const v = rect.get(.{ .string = Value.String.borrowed("x") });
@@ -521,58 +522,58 @@ fn imgCrop(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const v = rect.get(.{ .string = Value.String.borrowed("height") });
         break :blk if (v == .int) v.int else 0;
     };
-    if (w <= 0 or h <= 0) return .{ .bool = false };
-    const dst = c.gdImageCreateTrueColor(@intCast(w), @intCast(h)) orelse return .{ .bool = false };
+    if (w <= 0 or h <= 0) return NativeResult.scalar(.{ .bool = false });
+    const dst = c.gdImageCreateTrueColor(@intCast(w), @intCast(h)) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageCopy(dst, src, 0, 0, @intCast(x), @intCast(y), @intCast(w), @intCast(h));
     return wrapImg(ctx, dst);
 }
 
 // ---------------- dimensions ----------------
 
-fn imgSx(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    return .{ .int = @intCast(im.sx) };
+fn imgSx(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(im.sx) });
 }
 
-fn imgSy(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    return .{ .int = @intCast(im.sy) };
+fn imgSy(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(im.sy) });
 }
 
 // ---------------- alpha / interlace ----------------
 
-fn imgAlphaBlending(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const on = argInt(args, 1) orelse return .{ .bool = false };
+fn imgAlphaBlending(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const on = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageAlphaBlending(im, @intCast(on));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgSaveAlpha(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const on = argInt(args, 1) orelse return .{ .bool = false };
+fn imgSaveAlpha(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const on = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageSaveAlpha(im, @intCast(on));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn imgInterlace(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const im = argImg(args, 0) orelse return .{ .bool = false };
-    const on = argInt(args, 1) orelse return .{ .bool = false };
+fn imgInterlace(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const on = argInt(args, 1) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageInterlace(im, @intCast(on));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // ---------------- info ----------------
 
-fn imgGetSize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn imgGetSize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
     // sniff via fopen + gd helpers (minimal: just open file and check magic, then return dims via libgd)
-    const f = c.fopen(path_z.ptr, "rb") orelse return .{ .bool = false };
+    const f = c.fopen(path_z.ptr, "rb") orelse return NativeResult.scalar(.{ .bool = false });
     defer _ = c.fclose(f);
     var header: [12]u8 = undefined;
     const read = c.fread(&header, 1, header.len, f);
-    if (read < 4) return .{ .bool = false };
+    if (read < 4) return NativeResult.scalar(.{ .bool = false });
     _ = c.fseek(f, 0, c.SEEK_SET);
 
     var im: ?*c.gdImageStruct = null;
@@ -591,9 +592,9 @@ fn imgGetSize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         im = c.gdImageCreateFromGif(f);
         mime = "image/gif";
         typ = 1;
-    } else return .{ .bool = false };
+    } else return NativeResult.scalar(.{ .bool = false });
 
-    if (im == null) return .{ .bool = false };
+    if (im == null) return NativeResult.scalar(.{ .bool = false });
     defer c.gdImageDestroy(im);
 
     const arr = try ctx.createArray();
@@ -603,39 +604,37 @@ fn imgGetSize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try arr.set(ctx.allocator, .{ .int = 3 }, .{ .string = Value.String.borrowed(try dupString(ctx, "")) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "mime")) }, .{ .string = Value.String.borrowed(try dupString(ctx, mime)) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "bits")) }, .{ .int = 8 });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // PHP IMAGETYPE_* constants -> mime/extension mappings
-fn imageTypeToMimeType(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("application/octet-stream") };
+fn imageTypeToMimeType(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("application/octet-stream");
     const t = Value.toInt(args[0]);
-    return .{
-        .string = Value.String.borrowed(switch (t) {
-            1 => "image/gif",
-            2 => "image/jpeg",
-            3 => "image/png",
-            4 => "application/x-shockwave-flash",
-            5 => "image/psd",
-            6 => "image/bmp",
-            7, 8 => "image/tiff",
-            9 => "application/octet-stream", // JPC
-            10 => "image/jp2",
-            11, 12 => "application/octet-stream",
-            13 => "application/x-shockwave-flash",
-            14 => "image/iff",
-            15 => "image/vnd.wap.wbmp",
-            16 => "image/xbm",
-            17 => "image/x-icon",
-            18 => "image/webp",
-            19 => "image/avif",
-            else => "application/octet-stream",
-        }),
-    };
+    return try NativeResult.copyString(ctx.allocator, switch (t) {
+        1 => "image/gif",
+        2 => "image/jpeg",
+        3 => "image/png",
+        4 => "application/x-shockwave-flash",
+        5 => "image/psd",
+        6 => "image/bmp",
+        7, 8 => "image/tiff",
+        9 => "application/octet-stream", // JPC
+        10 => "image/jp2",
+        11, 12 => "application/octet-stream",
+        13 => "application/x-shockwave-flash",
+        14 => "image/iff",
+        15 => "image/vnd.wap.wbmp",
+        16 => "image/xbm",
+        17 => "image/x-icon",
+        18 => "image/webp",
+        19 => "image/avif",
+        else => "application/octet-stream",
+    });
 }
 
-fn imageTypeToExtension(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn imageTypeToExtension(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const t = Value.toInt(args[0]);
     const include_dot = args.len < 2 or args[1].isTruthy();
     const ext: []const u8 = switch (t) {
@@ -652,15 +651,14 @@ fn imageTypeToExtension(ctx: *NativeContext, args: []const Value) RuntimeError!V
         17 => "ico",
         18 => "webp",
         19 => "avif",
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
-    if (!include_dot) return .{ .string = Value.String.borrowed(try ctx.createString(ext)) };
+    if (!include_dot) return try NativeResult.copyString(ctx.allocator, ext);
     const out = try std.fmt.allocPrint(ctx.allocator, ".{s}", .{ext});
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn gdInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn gdInfo(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("GD Version") }, .{ .string = Value.String.borrowed("bundled (2.x compatible)") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("FreeType Support") }, .{ .bool = false });
@@ -676,7 +674,7 @@ fn gdInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("AVIF Support") }, .{ .bool = false });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("TGA Read Support") }, .{ .bool = false });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("JIS-mapped Japanese Font Support") }, .{ .bool = false });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // ---------------- registration ----------------

--- a/src/stdlib/gmp.zig
+++ b/src/stdlib/gmp.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -139,8 +140,8 @@ fn coerceArgToMpz(ctx: *NativeContext, v: Value) !?*ZphpMpz {
 
 // ---------------- top-level functions ----------------
 
-fn gmpInit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
+fn gmpInit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     const obj = try createGmpObj(ctx);
     const dst = getMpz(obj).?;
 
@@ -149,67 +150,67 @@ fn gmpInit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args[0] == .string and args.len >= 2 and args[1] == .int) {
         const base: c_int = @intCast(args[1].int);
         const z = try dupZ(ctx, args[0].string.bytes());
-        if (zphp_mpz_set_str(dst, z.ptr, base) != 0) return .{ .bool = false };
-        return .{ .object = obj };
+        if (zphp_mpz_set_str(dst, z.ptr, base) != 0) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.borrowed(.{ .object = obj });
     }
 
-    const src = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .bool = false };
+    const src = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_mpz_destroy(src);
     const zero = zphp_mpz_create() orelse return error.OutOfMemory;
     defer zphp_mpz_destroy(zero);
     zphp_mpz_add(dst, src, zero);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn gmpStrval(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .null;
+fn gmpStrval(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
     var base: c_int = 10;
     if (args.len > 1 and args[1] == .int) base = @intCast(args[1].int);
-    const src = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+    const src = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(src);
     const cstr = zphp_mpz_get_str(base, src);
-    if (cstr == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (cstr == null) return try NativeResult.copyString(ctx.allocator, "");
     const slice = cstr[0..cstrLen(cstr)];
-    const owned = try dupString(ctx, slice);
+    const owned = try Value.String.create(ctx.allocator, slice);
     zphp_gmp_free(cstr);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(owned);
 }
 
-fn gmpIntval(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .int = 0 };
-    const src = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = 0 };
+fn gmpIntval(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .int = 0 });
+    const src = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(src);
-    return .{ .int = zphp_mpz_get_si(src) };
+    return NativeResult.scalar(.{ .int = zphp_mpz_get_si(src) });
 }
 
 const Binop = *const fn (r: *ZphpMpz, a: *const ZphpMpz, b: *const ZphpMpz) callconv(.c) void;
 const Unop = *const fn (r: *ZphpMpz, a: *const ZphpMpz) callconv(.c) void;
 
-fn binOpCall(ctx: *NativeContext, args: []const Value, op: Binop) RuntimeError!Value {
-    if (args.len < 2) return .null;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn binOpCall(ctx: *NativeContext, args: []const Value, op: Binop) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(a);
-    const b = (try coerceArgToMpz(ctx, args[1])) orelse return .null;
+    const b = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(b);
     const obj = try createGmpObj(ctx);
     op(getMpz(obj).?, a, b);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn unOpCall(ctx: *NativeContext, args: []const Value, op: Unop) RuntimeError!Value {
-    if (args.len < 1) return .null;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn unOpCall(ctx: *NativeContext, args: []const Value, op: Unop) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(a);
     const obj = try createGmpObj(ctx);
     op(getMpz(obj).?, a);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn gmpBinomial(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
-    const an = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn gmpBinomial(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
+    const an = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(an);
-    const ak = (try coerceArgToMpz(ctx, args[1])) orelse return .null;
+    const ak = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(ak);
     const n = zphp_mpz_get_si(an);
     const k_raw = zphp_mpz_get_si(ak);
@@ -217,7 +218,7 @@ fn gmpBinomial(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const result = getMpz(obj).?;
     if (k_raw < 0 or n < 0 or k_raw > n) {
         _ = zphp_mpz_set_si(result, 0);
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     // use C(n,k) = C(n,n-k) and pick the smaller k for efficiency
     var k = k_raw;
@@ -234,18 +235,18 @@ fn gmpBinomial(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         _ = zphp_mpz_set_si(divisor, i + 1);
         zphp_mpz_tdiv_q(result, result, divisor);
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn gmpFact(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .null;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn gmpFact(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(a);
     const n = zphp_mpz_get_si(a);
     const obj = try createGmpObj(ctx);
     const result = getMpz(obj).?;
     _ = zphp_mpz_set_si(result, 1);
-    if (n <= 1) return .{ .object = obj };
+    if (n <= 1) return NativeResult.borrowed(.{ .object = obj });
     const cur = zphp_mpz_create() orelse return error.OutOfMemory;
     defer zphp_mpz_destroy(cur);
     var i: i64 = 2;
@@ -253,216 +254,216 @@ fn gmpFact(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         _ = zphp_mpz_set_si(cur, i);
         zphp_mpz_mul(result, result, cur);
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn gmpAdd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpAdd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_add);
 }
-fn gmpSub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpSub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_sub);
 }
-fn gmpMul(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpMul(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_mul);
 }
-fn gmpAnd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpAnd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_and);
 }
-fn gmpOr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpOr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_ior);
 }
-fn gmpXor(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpXor(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_xor);
 }
-fn gmpGcd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpGcd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_gcd);
 }
-fn gmpLcm(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpLcm(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_lcm);
 }
-fn gmpDivQ(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpDivQ(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_tdiv_q);
 }
-fn gmpDivR(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpDivR(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_tdiv_r);
 }
-fn gmpMod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpMod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return binOpCall(ctx, args, zphp_mpz_mod);
 }
 
-fn gmpNeg(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpNeg(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return unOpCall(ctx, args, zphp_mpz_neg);
 }
-fn gmpAbs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpAbs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return unOpCall(ctx, args, zphp_mpz_abs);
 }
-fn gmpCom(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpCom(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return unOpCall(ctx, args, zphp_mpz_com);
 }
-fn gmpSqrt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpSqrt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return unOpCall(ctx, args, zphp_mpz_sqrt);
 }
-fn gmpNextprime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn gmpNextprime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return unOpCall(ctx, args, zphp_mpz_nextprime);
 }
 
-fn gmpCmp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn gmpCmp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(a);
-    const b = (try coerceArgToMpz(ctx, args[1])) orelse return .null;
+    const b = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(b);
     const r = zphp_mpz_cmp(a, b);
-    return .{ .int = if (r > 0) 1 else if (r < 0) -1 else 0 };
+    return NativeResult.scalar(.{ .int = if (r > 0) 1 else if (r < 0) -1 else 0 });
 }
 
-fn gmpSign(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .int = 0 };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = 0 };
+fn gmpSign(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .int = 0 });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(a);
     const r = zphp_mpz_sgn(a);
-    return .{ .int = if (r > 0) 1 else if (r < 0) -1 else 0 };
+    return NativeResult.scalar(.{ .int = if (r > 0) 1 else if (r < 0) -1 else 0 });
 }
 
-fn gmpPow(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .int) return .null;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn gmpPow(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .int) return NativeResult.scalar(.null);
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(a);
     const obj = try createGmpObj(ctx);
     const e: c_ulong = @intCast(args[1].int);
     zphp_mpz_pow_ui(getMpz(obj).?, a, e);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn gmpPowm(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .null;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn gmpPowm(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.null);
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(a);
-    const e = (try coerceArgToMpz(ctx, args[1])) orelse return .null;
+    const e = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(e);
-    const m = (try coerceArgToMpz(ctx, args[2])) orelse return .null;
+    const m = (try coerceArgToMpz(ctx, args[2])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(m);
     const obj = try createGmpObj(ctx);
     zphp_mpz_powm(getMpz(obj).?, a, e, m);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn gmpInvert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .bool = false };
+fn gmpInvert(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_mpz_destroy(a);
-    const m = (try coerceArgToMpz(ctx, args[1])) orelse return .{ .bool = false };
+    const m = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_mpz_destroy(m);
     const obj = try createGmpObj(ctx);
-    if (zphp_mpz_invert(getMpz(obj).?, a, m) == 0) return .{ .bool = false };
-    return .{ .object = obj };
+    if (zphp_mpz_invert(getMpz(obj).?, a, m) == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn gmpProbPrime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .int = 0 };
+fn gmpProbPrime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .int = 0 });
     const reps: c_int = if (args.len > 1 and args[1] == .int) @intCast(args[1].int) else 10;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = 0 };
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(a);
-    return .{ .int = @intCast(zphp_mpz_probab_prime_p(a, reps)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_mpz_probab_prime_p(a, reps)) });
 }
 
-fn gmpSetbit(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .int) return .null;
+fn gmpSetbit(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.null);
     const obj = args[0].object;
-    if (!std.mem.eql(u8, obj.class_name, "GMP")) return .null;
-    const p = getMpz(obj) orelse return .null;
+    if (!std.mem.eql(u8, obj.class_name, "GMP")) return NativeResult.scalar(.null);
+    const p = getMpz(obj) orelse return NativeResult.scalar(.null);
     const bit: c_ulong = @intCast(args[1].int);
     const set_val: bool = if (args.len > 2 and args[2] == .bool) args[2].bool else true;
     if (set_val) zphp_mpz_setbit(p, bit) else zphp_mpz_clrbit(p, bit);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn gmpClrbit(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object or args[1] != .int) return .null;
+fn gmpClrbit(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.null);
     const obj = args[0].object;
-    if (!std.mem.eql(u8, obj.class_name, "GMP")) return .null;
-    const p = getMpz(obj) orelse return .null;
+    if (!std.mem.eql(u8, obj.class_name, "GMP")) return NativeResult.scalar(.null);
+    const p = getMpz(obj) orelse return NativeResult.scalar(.null);
     zphp_mpz_clrbit(p, @intCast(args[1].int));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn gmpTestbit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .int) return .{ .bool = false };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .bool = false };
+fn gmpTestbit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_mpz_destroy(a);
-    return .{ .bool = zphp_mpz_testbit(a, @intCast(args[1].int)) != 0 };
+    return NativeResult.scalar(.{ .bool = zphp_mpz_testbit(a, @intCast(args[1].int)) != 0 });
 }
 
-fn gmpPopcount(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .int = 0 };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = 0 };
+fn gmpPopcount(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .int = 0 });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(a);
-    return .{ .int = @intCast(zphp_mpz_popcount(a)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_mpz_popcount(a)) });
 }
 
-fn gmpScan0(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .int) return .{ .int = -1 };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = -1 };
+fn gmpScan0(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .int) return NativeResult.scalar(.{ .int = -1 });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = -1 });
     defer zphp_mpz_destroy(a);
     const r = zphp_mpz_scan0(a, @intCast(@max(args[1].int, 0)));
     // GMP returns ULONG_MAX when no zero bit is found; map to -1 like PHP
-    if (r == std.math.maxInt(c_ulong)) return .{ .int = -1 };
-    return .{ .int = @intCast(r) };
+    if (r == std.math.maxInt(c_ulong)) return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(r) });
 }
 
-fn gmpScan1(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .int) return .{ .int = -1 };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = -1 };
+fn gmpScan1(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .int) return NativeResult.scalar(.{ .int = -1 });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = -1 });
     defer zphp_mpz_destroy(a);
     const r = zphp_mpz_scan1(a, @intCast(@max(args[1].int, 0)));
-    if (r == std.math.maxInt(c_ulong)) return .{ .int = -1 };
-    return .{ .int = @intCast(r) };
+    if (r == std.math.maxInt(c_ulong)) return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(r) });
 }
 
-fn gmpHamdist(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = 0 };
+fn gmpHamdist(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(a);
-    const b = (try coerceArgToMpz(ctx, args[1])) orelse return .{ .int = 0 };
+    const b = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(b);
     const xored = zphp_mpz_create() orelse return error.OutOfMemory;
     defer zphp_mpz_destroy(xored);
     zphp_mpz_xor(xored, a, b);
-    return .{ .int = @intCast(zphp_mpz_popcount(xored)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_mpz_popcount(xored)) });
 }
 
-fn gmpLegendre(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = 0 };
+fn gmpLegendre(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(a);
-    const p = (try coerceArgToMpz(ctx, args[1])) orelse return .{ .int = 0 };
+    const p = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(p);
-    return .{ .int = @intCast(zphp_mpz_legendre(a, p)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_mpz_legendre(a, p)) });
 }
 
-fn gmpJacobi(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .int = 0 };
+fn gmpJacobi(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(a);
-    const b = (try coerceArgToMpz(ctx, args[1])) orelse return .{ .int = 0 };
+    const b = (try coerceArgToMpz(ctx, args[1])) orelse return NativeResult.scalar(.{ .int = 0 });
     defer zphp_mpz_destroy(b);
-    return .{ .int = @intCast(zphp_mpz_jacobi(a, b)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_mpz_jacobi(a, b)) });
 }
 
-fn gmpPerfectSquare(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .{ .bool = false };
+fn gmpPerfectSquare(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_mpz_destroy(a);
-    return .{ .bool = zphp_mpz_perfect_square_p(a) != 0 };
+    return NativeResult.scalar(.{ .bool = zphp_mpz_perfect_square_p(a) != 0 });
 }
 
-fn gmpRoot(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .int) return .null;
-    const a = (try coerceArgToMpz(ctx, args[0])) orelse return .null;
+fn gmpRoot(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .int) return NativeResult.scalar(.null);
+    const a = (try coerceArgToMpz(ctx, args[0])) orelse return NativeResult.scalar(.null);
     defer zphp_mpz_destroy(a);
     const obj = try createGmpObj(ctx);
     zphp_mpz_root(getMpz(obj).?, a, @intCast(args[1].int));
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 // ---------------- registration ----------------
@@ -532,17 +533,17 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.php_constants.put(a, "GMP_NATIVE_ENDIAN", .{ .int = 16 });
 }
 
-fn gmpToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.frame_count == 0) return .null;
-    const v = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (v != .object) return .null;
-    const p = getMpz(v.object) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "0")) };
+fn gmpToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    if (ctx.vm.frame_count == 0) return NativeResult.scalar(.null);
+    const v = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (v != .object) return NativeResult.scalar(.null);
+    const p = getMpz(v.object) orelse return try NativeResult.copyString(ctx.allocator, "0");
     const cstr = zphp_mpz_get_str(10, p);
-    if (cstr == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "0")) };
+    if (cstr == null) return try NativeResult.copyString(ctx.allocator, "0");
     const slice = cstr[0..cstrLen(cstr)];
-    const owned = try dupString(ctx, slice);
+    const owned = try Value.String.create(ctx.allocator, slice);
     zphp_gmp_free(cstr);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(owned);
 }
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {

--- a/src/stdlib/http.zig
+++ b/src/stdlib/http.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -39,33 +40,35 @@ fn isCallable(v: Value) bool {
     };
 }
 
-fn native_ob_start(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_ob_start(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     var level: OutputBufferLevel = .{ .start = ctx.vm.output.items.len };
     if (args.len >= 1 and args[0] != .null) {
         // verify the handler resolves to a real callable; PHP returns false
         // and does not start a buffer when the handler can't be found
         if (args[0] == .string) {
             const name = args[0].string.bytes();
-            if (!ctx.vm.functions.contains(name) and !ctx.vm.native_fns.contains(name)) return .{ .bool = false };
+            if (!ctx.vm.functions.contains(name) and !ctx.vm.native_fns.contains(name)) return NativeResult.scalar(.{ .bool = false });
         } else if (!isCallable(args[0])) {
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         }
         level.callback = args[0];
     }
     try ctx.vm.ob_stack.append(ctx.allocator, level);
     if (level.callback) |cb| @import("../runtime/vm.zig").VM.retainValue(cb);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // Keep the handler on the stack during invocation (ob_get_level/contents can
-// observe it). Copy input into request-owned storage: callbacks may retain it.
-fn processBuffer(ctx: *NativeContext, clean: bool, final: bool, get: bool) RuntimeError!Value {
+// observe it). Counted input allows callbacks to retain their argument.
+fn processBuffer(ctx: *NativeContext, clean: bool, final: bool, get: bool) RuntimeError!NativeResult {
     const len = ctx.vm.ob_stack.items.len;
-    if (len == 0) return .{ .bool = false };
+    if (len == 0) return NativeResult.scalar(.{ .bool = false });
     const index = len - 1;
     var level = ctx.vm.ob_stack.items[index];
     if (level.disabled) level.start = ctx.vm.output.items.len;
-    const raw = try ctx.createString(ctx.vm.output.items[level.start..]);
+    const raw_owned = try Value.String.create(ctx.allocator, ctx.vm.output.items[level.start..]);
+    defer raw_owned.release();
+    const raw = raw_owned.bytes();
     var transformed: []const u8 = raw;
     const discard = clean and !level.disabled;
     if (if (level.disabled) null else level.callback) |cb| {
@@ -74,7 +77,7 @@ fn processBuffer(ctx: *NativeContext, clean: bool, final: bool, get: bool) Runti
             (if (final) @as(i64, 8) else if (!clean) @as(i64, 4) else 0);
         ctx.vm.ob_stack.items[index].started = true;
         const result = ctx.invokeCallable(cb, &.{
-            .{ .string = Value.String.borrowed(raw) }, .{ .int = phase },
+            .{ .string = raw_owned }, .{ .int = phase },
         }) catch |err| {
             // PHP disables a throwing handler. Clean discards input; flush
             // forwards it unchanged. Final operations still remove the level.
@@ -108,65 +111,65 @@ fn processBuffer(ctx: *NativeContext, clean: bool, final: bool, get: bool) Runti
     } else {
         ctx.vm.ob_stack.items[index].start = ctx.vm.output.items.len;
     }
-    return if (get) .{ .string = Value.String.borrowed(raw) } else .{ .bool = true };
+    return if (get) NativeResult.shareString(raw_owned) else NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_ob_get_clean(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ob_get_clean(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return processBuffer(ctx, true, true, true);
 }
 
-fn native_ob_end_clean(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ob_end_clean(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return processBuffer(ctx, true, true, false);
 }
 
-fn native_ob_get_contents(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
+fn native_ob_get_contents(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    if (ctx.vm.ob_stack.items.len == 0) return NativeResult.scalar(.{ .bool = false });
     const level = ctx.vm.ob_stack.getLast();
-    if (level.disabled) return .{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try ctx.createString(ctx.vm.output.items[level.start..])) };
+    if (level.disabled) return NativeResult.literal("");
+    return NativeResult.copyString(ctx.allocator, ctx.vm.output.items[level.start..]);
 }
 
-fn native_ob_get_level(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(ctx.vm.ob_stack.items.len) };
+fn native_ob_get_level(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(ctx.vm.ob_stack.items.len) });
 }
 
-fn native_ob_end_flush(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ob_end_flush(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return processBuffer(ctx, false, true, false);
 }
 
-fn native_ob_get_flush(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ob_get_flush(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return processBuffer(ctx, false, true, true);
 }
 
-fn native_ob_flush(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ob_flush(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return processBuffer(ctx, false, false, false);
 }
 
-fn native_ob_clean(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ob_clean(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return processBuffer(ctx, true, false, false);
 }
 
-fn native_ob_get_length(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.ob_stack.items.len == 0) return .{ .bool = false };
+fn native_ob_get_length(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    if (ctx.vm.ob_stack.items.len == 0) return NativeResult.scalar(.{ .bool = false });
     const level = ctx.vm.ob_stack.getLast();
-    if (level.disabled) return .{ .int = 0 };
-    return .{ .int = @intCast(ctx.vm.output.items.len - level.start) };
+    if (level.disabled) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(ctx.vm.output.items.len - level.start) });
 }
 
-fn native_ob_implicit_flush(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn native_ob_implicit_flush(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn native_flush(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_flush(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // CLI: nothing to flush at HTTP level
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_ob_get_status(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_ob_get_status(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const full_status = args.len >= 1 and args[0].isTruthy();
     const stack_len = ctx.vm.ob_stack.items.len;
     if (stack_len == 0) {
-        return .{ .array = try ctx.createArray() };
+        return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     }
     if (!full_status) {
         const arr = try ctx.createArray();
@@ -177,7 +180,7 @@ fn native_ob_get_status(ctx: *NativeContext, args: []const Value) RuntimeError!V
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("chunk_size") }, .{ .int = 0 });
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("buffer_size") }, .{ .int = 16384 });
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("buffer_used") }, .{ .int = 0 });
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
     const result = try ctx.createArray();
     var i: usize = 0;
@@ -192,25 +195,25 @@ fn native_ob_get_status(ctx: *NativeContext, args: []const Value) RuntimeError!V
         try sub.set(ctx.allocator, .{ .string = Value.String.borrowed("buffer_used") }, .{ .int = 0 });
         try result.append(ctx.allocator, .{ .array = sub });
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_ob_list_handlers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ob_list_handlers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     for (0..ctx.vm.ob_stack.items.len) |_| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("default output handler") });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_header(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .null;
-    const hdr = try ctx.createString(args[0].string.bytes());
+fn native_header(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.null);
+    const hdr = args[0].string.bytes();
     const replace = args.len < 2 or args[1] != .bool or args[1].bool;
 
     if (startsWithIgnoreCase(hdr, "Content-Type:")) {
         if (std.mem.indexOf(u8, hdr, ": ")) |sep| {
-            ctx.vm.response_content_type = hdr[sep + 2 ..];
+            ctx.vm.response_content_type = try ctx.createString(hdr[sep + 2 ..]);
         }
     }
 
@@ -241,22 +244,23 @@ fn native_header(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     try appendResponseHeader(ctx, hdr);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_http_response_code(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_http_response_code(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len >= 1 and args[0] == .int) {
         ctx.vm.response_code = args[0].int;
     }
-    return .{ .int = ctx.vm.response_code };
+    return NativeResult.scalar(.{ .int = ctx.vm.response_code });
 }
 
-fn native_setcookie(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_setcookie(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     const value = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "";
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     try buf.appendSlice(ctx.allocator, "Set-Cookie: ");
     try buf.appendSlice(ctx.allocator, name);
     try buf.append(ctx.allocator, '=');
@@ -268,44 +272,43 @@ fn native_setcookie(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         try appendCookieOptionsPositional(&buf, ctx.allocator, args);
     }
 
-    const hdr = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, hdr);
-    try appendResponseHeader(ctx, hdr);
-    return .{ .bool = true };
+    try appendResponseHeader(ctx, buf.items);
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_header_remove(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_header_remove(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) {
         if (getResponseHeaders(ctx)) |arr| {
-            arr.entries.clearRetainingCapacity();
-            arr.string_index.clearRetainingCapacity();
+            while (arr.entries.items.len > 0) {
+                ctx.vm.arrayRemoveOwned(arr, arr.entries.items[arr.entries.items.len - 1].key);
+            }
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
     if (args[0] == .string) removeHeaderByName(ctx, args[0].string.bytes());
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_headers_sent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = ctx.vm.headers_sent };
+fn native_headers_sent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = ctx.vm.headers_sent });
 }
 
-fn native_headers_list(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (getResponseHeaders(ctx)) |arr| return .{ .array = arr };
-    return .{ .array = try ctx.createArray() };
+fn native_headers_list(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    if (getResponseHeaders(ctx)) |arr| return NativeResult.borrowed(.{ .array = arr });
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
-fn native_http_get_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_http_get_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     if (ctx.vm.last_http_response_headers) |arr| {
-        return .{ .array = try ctx.vm.cloneArray(arr) };
+        return NativeResult.borrowed(.{ .array = try ctx.vm.cloneArray(arr) });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_http_clear_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_http_clear_last_response_headers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     if (ctx.vm.last_http_response_headers) |arr| ctx.vm.arrayRelease(arr);
     ctx.vm.last_http_response_headers = null;
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn appendCookieOptionsArray(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, opts: *PhpArray) !void {
@@ -378,11 +381,13 @@ fn getResponseHeaders(ctx: *NativeContext) ?*PhpArray {
 }
 
 pub fn appendResponseHeader(ctx: *NativeContext, hdr: []const u8) !void {
+    const owned = try Value.String.create(ctx.allocator, hdr);
+    defer owned.release();
     if (ctx.vm.response_headers) |arr| {
-        try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(hdr) });
+        try arr.append(ctx.allocator, .{ .string = owned });
     } else {
         const arr = try ctx.createArray();
-        try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(hdr) });
+        try arr.append(ctx.allocator, .{ .string = owned });
         ctx.vm.response_headers = arr;
     }
 }

--- a/src/stdlib/ini.zig
+++ b/src/stdlib/ini.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -11,19 +12,19 @@ pub const entries = .{
 
 const ScannerMode = enum(u2) { normal = 0, raw = 1, typed = 2 };
 
-fn native_parse_ini_string(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_parse_ini_string(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const input = args[0].string.bytes();
     const process_sections = if (args.len >= 2) Value.isTruthy(args[1]) else false;
     const mode = parseMode(if (args.len >= 3) args[2] else .{ .int = 0 });
     return parseIni(ctx, input, process_sections, mode);
 }
 
-fn native_parse_ini_file(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_parse_ini_file(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path = args[0].string.bytes();
-    const content = std.fs.cwd().readFileAlloc(ctx.allocator, path, 1024 * 1024 * 64) catch return Value{ .bool = false };
-    try ctx.strings.append(ctx.allocator, content);
+    const content = std.fs.cwd().readFileAlloc(ctx.allocator, path, 1024 * 1024 * 64) catch return NativeResult.scalar(Value{ .bool = false });
+    defer ctx.allocator.free(content);
     const process_sections = if (args.len >= 2) Value.isTruthy(args[1]) else false;
     const mode = parseMode(if (args.len >= 3) args[2] else .{ .int = 0 });
     return parseIni(ctx, content, process_sections, mode);
@@ -38,8 +39,8 @@ fn parseMode(v: Value) ScannerMode {
     };
 }
 
-fn parseIni(ctx: *NativeContext, input: []const u8, process_sections: bool, mode: ScannerMode) RuntimeError!Value {
-    var result = try ctx.createArray();
+fn parseIni(ctx: *NativeContext, input: []const u8, process_sections: bool, mode: ScannerMode) RuntimeError!NativeResult {
+    const result = try ctx.createArray();
     var current_section: ?*PhpArray = null;
 
     var pos: usize = 0;
@@ -61,11 +62,11 @@ fn parseIni(ctx: *NativeContext, input: []const u8, process_sections: bool, mode
                 if (process_sections) {
                     const section_name = line[1..end];
                     const section_arr = try ctx.createArray();
-                    try result.set(ctx.allocator, .{ .string = Value.String.borrowed(section_name) }, .{ .array = section_arr });
+                    try storeKey(ctx, result, section_name, .{ .array = section_arr });
                     current_section = section_arr;
                 }
             } else {
-                return .{ .bool = false };
+                return NativeResult.scalar(.{ .bool = false });
             }
             continue;
         }
@@ -75,26 +76,27 @@ fn parseIni(ctx: *NativeContext, input: []const u8, process_sections: bool, mode
             const raw_key = trimSpaces(line[0..eq_pos]);
             const raw_val = trimSpaces(if (eq_pos + 1 < line.len) line[eq_pos + 1 ..] else "");
 
-            const value = processValue(ctx, raw_val, mode);
+            const value = (try processValue(ctx, raw_val, mode)).value;
+            defer if (value == .string) value.string.release();
             const target = if (process_sections and current_section != null) current_section.? else result;
 
             if (isArrayKey(raw_key)) {
                 try setArrayKey(ctx, target, raw_key, value);
             } else {
-                try target.set(ctx.allocator, .{ .string = Value.String.borrowed(raw_key) }, value);
+                try storeKey(ctx, target, raw_key, value);
             }
         }
     }
 
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn processValue(ctx: *NativeContext, raw: []const u8, mode: ScannerMode) Value {
-    if (raw.len == 0) return .{ .string = Value.String.borrowed("") };
+fn processValue(ctx: *NativeContext, raw: []const u8, mode: ScannerMode) RuntimeError!NativeResult {
+    if (raw.len == 0) return NativeResult.literal("");
 
     // strip quotes
     if (raw.len >= 2 and ((raw[0] == '"' and raw[raw.len - 1] == '"') or (raw[0] == '\'' and raw[raw.len - 1] == '\''))) {
-        return .{ .string = Value.String.borrowed(raw[1 .. raw.len - 1]) };
+        return NativeResult.copyString(ctx.allocator, raw[1 .. raw.len - 1]);
     }
 
     // strip inline comments (unquoted values only)
@@ -105,38 +107,38 @@ fn processValue(ctx: *NativeContext, raw: []const u8, mode: ScannerMode) Value {
         }
     }
 
-    if (mode == .raw) return .{ .string = Value.String.borrowed(val) };
+    if (mode == .raw) return NativeResult.copyString(ctx.allocator, val);
 
     // normal + typed modes: substitute bare PHP constants (PHP_INT_MAX,
     // user-defined via define(), etc.) - identifier-shaped values match
     // against vm.php_constants then vm.user_constants
     if (looksLikeIdentifier(val)) {
         if (ctx.vm.php_constants.get(val)) |cv| {
-            if (mode == .typed) return cv;
+            if (mode == .typed) return NativeResult.share(cv);
             // normal mode: coerce to string representation
             return constToString(ctx, cv);
         }
         if (ctx.vm.user_constants.contains(val)) {
             if (ctx.vm.php_constants.get(val)) |cv| {
-                if (mode == .typed) return cv;
+                if (mode == .typed) return NativeResult.share(cv);
                 return constToString(ctx, cv);
             }
         }
     }
 
     if (mode == .typed) {
-        if (isBoolTrue(val)) return .{ .bool = true };
-        if (isBoolFalse(val)) return .{ .bool = false };
-        if (isNull(val)) return .null;
-        if (parseInteger(val)) |i| return .{ .int = i };
-        if (parseFloat(val)) |f| return .{ .float = f };
-        return .{ .string = Value.String.borrowed(val) };
+        if (isBoolTrue(val)) return NativeResult.scalar(.{ .bool = true });
+        if (isBoolFalse(val)) return NativeResult.scalar(.{ .bool = false });
+        if (isNull(val)) return NativeResult.scalar(.null);
+        if (parseInteger(val)) |i| return NativeResult.scalar(.{ .int = i });
+        if (parseFloat(val)) |f| return NativeResult.scalar(.{ .float = f });
+        return NativeResult.copyString(ctx.allocator, val);
     }
 
     // normal mode: booleans become "1"/""
-    if (isBoolTrue(val)) return .{ .string = Value.String.borrowed("1") };
-    if (isBoolFalse(val)) return .{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(val) };
+    if (isBoolTrue(val)) return NativeResult.literal("1");
+    if (isBoolFalse(val)) return NativeResult.literal("");
+    return NativeResult.copyString(ctx.allocator, val);
 }
 
 fn looksLikeIdentifier(s: []const u8) bool {
@@ -150,22 +152,20 @@ fn looksLikeIdentifier(s: []const u8) bool {
     return true;
 }
 
-fn constToString(ctx: *NativeContext, v: Value) Value {
+fn constToString(ctx: *NativeContext, v: Value) RuntimeError!NativeResult {
     switch (v) {
-        .string => return v,
+        .string => return NativeResult.share(v),
         .int => |i| {
-            const s = std.fmt.allocPrint(ctx.allocator, "{d}", .{i}) catch return .{ .string = Value.String.borrowed("") };
-            ctx.strings.append(ctx.allocator, s) catch {};
-            return .{ .string = Value.String.borrowed(s) };
+            const s = try std.fmt.allocPrint(ctx.allocator, "{d}", .{i});
+            return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
         },
         .float => |f| {
-            const s = std.fmt.allocPrint(ctx.allocator, "{d}", .{f}) catch return .{ .string = Value.String.borrowed("") };
-            ctx.strings.append(ctx.allocator, s) catch {};
-            return .{ .string = Value.String.borrowed(s) };
+            const s = try std.fmt.allocPrint(ctx.allocator, "{d}", .{f});
+            return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
         },
-        .bool => |b| return .{ .string = Value.String.borrowed(if (b) "1" else "") },
-        .null => return .{ .string = Value.String.borrowed("") },
-        else => return .{ .string = Value.String.borrowed("") },
+        .bool => |b| return if (b) NativeResult.literal("1") else NativeResult.literal(""),
+        .null => return NativeResult.literal(""),
+        else => return NativeResult.literal(""),
     }
 }
 
@@ -216,13 +216,13 @@ fn setArrayKey(ctx: *NativeContext, target: *PhpArray, key: []const u8, value: V
         arr = existing.array;
     } else {
         arr = try ctx.createArray();
-        try target.set(ctx.allocator, .{ .string = Value.String.borrowed(base) }, .{ .array = arr });
+        try storeKey(ctx, target, base, .{ .array = arr });
     }
 
     if (inner.len == 0) {
         try arr.append(ctx.allocator, value);
     } else {
-        try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(inner) }, value);
+        try storeKey(ctx, arr, inner, value);
     }
 }
 
@@ -232,4 +232,10 @@ fn trimSpaces(s: []const u8) []const u8 {
     var end = s.len;
     while (end > start and (s[end - 1] == ' ' or s[end - 1] == '\t')) end -= 1;
     return s[start..end];
+}
+
+fn storeKey(ctx: *NativeContext, array: *PhpArray, bytes: []const u8, value: Value) RuntimeError!void {
+    const key = try Value.String.create(ctx.allocator, bytes);
+    defer key.release();
+    try ctx.vm.arraySetOwned(array, .{ .string = key }, value);
 }

--- a/src/stdlib/intl.zig
+++ b/src/stdlib/intl.zig
@@ -9,6 +9,7 @@ const ClassDef = vm_mod.ClassDef;
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 const strings_mod = @import("strings.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 
 // libicu uses preprocessor macros to rename its API per ABI version
 // (u_strFromUTF8 -> u_strFromUTF8_77 on linux distros). zig's @cImport doesn't
@@ -194,8 +195,7 @@ fn utf8ToU16(ctx: *NativeContext, s: []const u8) ![]u16 {
     return buf;
 }
 
-fn u16ToUtf8(ctx: *NativeContext, s: []const u16) ![]const u8 {
-    if (s.len == 0) return try dupString(ctx, "");
+fn u16ToOwned(ctx: *NativeContext, s: []const u16) ![]u8 {
     const cap: i32 = @intCast(s.len * 3 + 4);
     var buf = try ctx.allocator.alloc(u8, @intCast(cap));
     errdefer ctx.allocator.free(buf);
@@ -204,8 +204,22 @@ fn u16ToUtf8(ctx: *NativeContext, s: []const u16) ![]const u8 {
     _ = zphp_u_strToUTF8(buf.ptr, cap, &actual, s.ptr, @intCast(s.len), &status);
     if (intlRecord(ctx.vm, status)) return error.RuntimeError;
     buf = try ctx.allocator.realloc(buf, @intCast(actual));
+    return buf;
+}
+
+fn u16ToUtf8(ctx: *NativeContext, s: []const u16) ![]const u8 {
+    if (s.len == 0) return try dupString(ctx, "");
+    const buf = try u16ToOwned(ctx, s);
+    errdefer ctx.allocator.free(buf);
     try ctx.strings.append(ctx.allocator, buf);
     return buf;
+}
+
+fn u16ToResult(ctx: *NativeContext, s: []const u16) !NativeResult {
+    if (s.len == 0) return NativeResult.literal("");
+    const buf = try u16ToOwned(ctx, s);
+    errdefer ctx.allocator.free(buf);
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
 // ---------------- Normalizer ----------------
@@ -227,10 +241,10 @@ fn getNormalizer(form: i64) ?*const UNormalizer2 {
     return n;
 }
 
-fn normalizerNormalize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn normalizerNormalize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const form: i64 = if (args.len > 1 and args[1] == .int) args[1].int else 1;
-    const norm = getNormalizer(form) orelse return .{ .bool = false };
+    const norm = getNormalizer(form) orelse return NativeResult.scalar(.{ .bool = false });
 
     const u16src = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(u16src);
@@ -240,98 +254,96 @@ fn normalizerNormalize(ctx: *NativeContext, args: []const Value) RuntimeError!Va
     defer ctx.allocator.free(buf);
     var status: UErrorCode = U_ZERO_ERROR;
     const actual = zphp_unorm2_normalize(norm, u16src.ptr, @intCast(u16src.len), buf.ptr, cap, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
 
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(actual)]);
-    return .{ .string = Value.String.borrowed(out) };
+    return try u16ToResult(ctx, buf[0..@intCast(actual)]);
 }
 
-fn normalizerIsNormalized(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn normalizerIsNormalized(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const form: i64 = if (args.len > 1 and args[1] == .int) args[1].int else 1;
-    const norm = getNormalizer(form) orelse return .{ .bool = false };
+    const norm = getNormalizer(form) orelse return NativeResult.scalar(.{ .bool = false });
     const u16src = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(u16src);
     var status: UErrorCode = U_ZERO_ERROR;
     const ok = zphp_unorm2_isNormalized(norm, u16src.ptr, @intCast(u16src.len), &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    return .{ .bool = ok != 0 };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = ok != 0 });
 }
 
 // ---------------- Locale ----------------
 
-fn localeGetDefault(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn localeGetDefault(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const def = zphp_uloc_getDefault();
-    return .{ .string = Value.String.borrowed(try dupString(ctx, def[0..cstrLen(def)])) };
+    return try NativeResult.copyString(ctx.allocator, def[0..cstrLen(def)]);
 }
 
-fn localeSetDefault(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn localeSetDefault(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     var buf: [256]u8 = undefined;
     const n = @min(args[0].string.bytes().len, buf.len - 1);
     @memcpy(buf[0..n], args[0].string.bytes()[0..n]);
     buf[n] = 0;
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_uloc_setDefault(@ptrCast(&buf), &status);
-    return .{ .bool = status <= U_ZERO_ERROR };
+    return NativeResult.scalar(.{ .bool = status <= U_ZERO_ERROR });
 }
 
 const KeywordFn = *const fn (loc: [*:0]const u8, buf: [*]u8, cap: i32, err: *UErrorCode) callconv(.c) i32;
 
-fn locKeywordCall(ctx: *NativeContext, args: []const Value, comptime fn_ptr: KeywordFn) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn locKeywordCall(ctx: *NativeContext, args: []const Value, comptime fn_ptr: KeywordFn) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const loc_z = try dupZ(ctx, args[0].string.bytes());
     var buf: [128]u8 = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = fn_ptr(loc_z.ptr, &buf, @intCast(buf.len), &status);
-    if (status > U_ZERO_ERROR or n <= 0) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    return .{ .string = Value.String.borrowed(try dupString(ctx, buf[0..@intCast(n)])) };
+    if (status > U_ZERO_ERROR or n <= 0) return try NativeResult.copyString(ctx.allocator, "");
+    return try NativeResult.copyString(ctx.allocator, buf[0..@intCast(n)]);
 }
 
-fn localeGetPrimaryLanguage(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetPrimaryLanguage(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return locKeywordCall(ctx, args, zphp_uloc_getLanguage);
 }
-fn localeGetRegion(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetRegion(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return locKeywordCall(ctx, args, zphp_uloc_getCountry);
 }
-fn localeGetScript(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetScript(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return locKeywordCall(ctx, args, zphp_uloc_getScript);
 }
-fn localeCanonicalize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn localeCanonicalize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const loc_z = try dupZ(ctx, args[0].string.bytes());
     var buf: [256]u8 = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = zphp_uloc_canonicalize(loc_z.ptr, &buf, @intCast(buf.len), &status);
-    if (status > U_ZERO_ERROR or n <= 0) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    return .{ .string = Value.String.borrowed(try dupString(ctx, buf[0..@intCast(n)])) };
+    if (status > U_ZERO_ERROR or n <= 0) return try NativeResult.copyString(ctx.allocator, "");
+    return try NativeResult.copyString(ctx.allocator, buf[0..@intCast(n)]);
 }
 
 const DisplayFn = *const fn (loc: [*:0]const u8, inLoc: [*:0]const u8, buf: [*]UChar, cap: i32, err: *UErrorCode) callconv(.c) i32;
 
-fn displayCall(ctx: *NativeContext, args: []const Value, comptime fn_ptr: DisplayFn) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn displayCall(ctx: *NativeContext, args: []const Value, comptime fn_ptr: DisplayFn) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const tgt_z = try dupZ(ctx, args[0].string.bytes());
     const in_z: ?[:0]u8 = if (args.len > 1 and args[1] == .string) try dupZ(ctx, args[1].string.bytes()) else null;
     const in_ptr: [*:0]const u8 = if (in_z) |z| z.ptr else zphp_uloc_getDefault();
     var buf: [256]UChar = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = fn_ptr(tgt_z.ptr, in_ptr, &buf, @intCast(buf.len), &status);
-    if (status > U_ZERO_ERROR or n <= 0) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (status > U_ZERO_ERROR or n <= 0) return try NativeResult.copyString(ctx.allocator, "");
+    return try u16ToResult(ctx, buf[0..@intCast(n)]);
 }
 
-fn localeGetDisplayName(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetDisplayName(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return displayCall(ctx, args, zphp_uloc_getDisplayName);
 }
-fn localeGetDisplayLanguage(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetDisplayLanguage(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return displayCall(ctx, args, zphp_uloc_getDisplayLanguage);
 }
-fn localeGetDisplayRegion(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetDisplayRegion(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return displayCall(ctx, args, zphp_uloc_getDisplayCountry);
 }
-fn localeGetDisplayScript(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetDisplayScript(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return displayCall(ctx, args, zphp_uloc_getDisplayScript);
 }
 
@@ -351,60 +363,60 @@ fn openCollatorFor(ctx: *NativeContext, locale: []const u8) !?*UCollator {
     return c;
 }
 
-fn collConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const c = (try openCollatorFor(ctx, args[0].string.bytes())) orelse return .null;
+fn collConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const c = (try openCollatorFor(ctx, args[0].string.bytes())) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__coll", .{ .int = @intCast(@intFromPtr(c)) });
     try obj.set(ctx.allocator, "__locale", .{ .string = args[0].string });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn collCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn collCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("Collator");
-    const c = (try openCollatorFor(ctx, args[0].string.bytes())) orelse return .null;
+    const c = (try openCollatorFor(ctx, args[0].string.bytes())) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__coll", .{ .int = @intCast(@intFromPtr(c)) });
     try obj.set(ctx.allocator, "__locale", .{ .string = args[0].string });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn collCompare(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const c = getCollator(obj) orelse return .{ .bool = false };
+fn collCompare(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const c = getCollator(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const a = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(a);
     const b = try utf8ToU16(ctx, args[1].string.bytes());
     defer ctx.allocator.free(b);
-    return .{ .int = @intCast(zphp_ucol_strcoll(c, a.ptr, @intCast(a.len), b.ptr, @intCast(b.len))) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ucol_strcoll(c, a.ptr, @intCast(a.len), b.ptr, @intCast(b.len))) });
 }
 
-fn collSetStrength(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const c = getCollator(obj) orelse return .{ .bool = false };
+fn collSetStrength(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const c = getCollator(obj) orelse return NativeResult.scalar(.{ .bool = false });
     zphp_ucol_setStrength(c, @intCast(args[0].int));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn collGetStrength(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const c = getCollator(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(zphp_ucol_getStrength(c)) };
+fn collGetStrength(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const c = getCollator(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ucol_getStrength(c)) });
 }
 
-fn collGetLocale(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+fn collGetLocale(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
     const v = obj.get("__locale");
-    if (v == .string) return v;
-    return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == .string) return NativeResult.share(v);
+    return try NativeResult.copyString(ctx.allocator, "");
 }
 
-fn collSort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .array) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const c = getCollator(obj) orelse return .{ .bool = false };
+fn collSort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const c = getCollator(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     const arr = args[0].array;
     const SortContext = struct { coll: *UCollator, ctx: *NativeContext };
@@ -427,7 +439,7 @@ fn collSort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     arr.string_index.clearRetainingCapacity();
     arr.next_int_key = @intCast(arr.entries.items.len);
     arr.has_int_keys = true;
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // ---------------- NumberFormatter ----------------
@@ -458,30 +470,30 @@ fn openNumFmt(ctx: *NativeContext, locale: []const u8, style: i32, pattern: ?[]c
     return f;
 }
 
-fn nfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn nfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const style: i32 = if (args[1] == .int) @intCast(args[1].int) else 1;
     const pattern: ?[]const u8 = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else null;
-    const f = (try openNumFmt(ctx, args[0].string.bytes(), style, pattern)) orelse return .null;
+    const f = (try openNumFmt(ctx, args[0].string.bytes(), style, pattern)) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__nfmt", .{ .int = @intCast(@intFromPtr(f)) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn nfCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .null;
+fn nfCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("NumberFormatter");
     const style: i32 = if (args[1] == .int) @intCast(args[1].int) else 1;
     const pattern: ?[]const u8 = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else null;
-    const f = (try openNumFmt(ctx, args[0].string.bytes(), style, pattern)) orelse return .null;
+    const f = (try openNumFmt(ctx, args[0].string.bytes(), style, pattern)) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__nfmt", .{ .int = @intCast(@intFromPtr(f)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn nfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getNumFmt(obj) orelse return .{ .bool = false };
+fn nfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getNumFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     var buf: [128]UChar = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
@@ -490,66 +502,64 @@ fn nfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     switch (args[0]) {
         .int => |i| n = zphp_unum_formatInt64(f, i, &buf, @intCast(buf.len), null, &status),
         .float => |fl| n = zphp_unum_formatDouble(f, fl, &buf, @intCast(buf.len), null, &status),
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     }
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, buf[0..@intCast(n)]);
 }
 
-fn nfFormatCurrency(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getNumFmt(obj) orelse return .{ .bool = false };
+fn nfFormatCurrency(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getNumFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const amount: f64 = switch (args[0]) {
         .int => |i| @floatFromInt(i),
         .float => |fl| fl,
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     const ccy_u16 = try utf8ToU16(ctx, args[1].string.bytes());
     defer ctx.allocator.free(ccy_u16);
     var buf: [128]UChar = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = zphp_unum_formatDoubleCurrency(f, amount, ccy_u16.ptr, &buf, @intCast(buf.len), null, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, buf[0..@intCast(n)]);
 }
 
-fn nfParse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getNumFmt(obj) orelse return .{ .bool = false };
+fn nfParse(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getNumFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const u16src = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(u16src);
     var pos: i32 = 0;
     var status: UErrorCode = U_ZERO_ERROR;
     const result = zphp_unum_parseDouble(f, u16src.ptr, @intCast(u16src.len), &pos, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
     if (@trunc(result) == result and result < 1e15 and result > -1e15) {
-        return .{ .int = @intFromFloat(result) };
+        return NativeResult.scalar(.{ .int = @intFromFloat(result) });
     }
-    return .{ .float = result };
+    return NativeResult.scalar(.{ .float = result });
 }
 
-fn nfSetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getNumFmt(obj) orelse return .{ .bool = false };
+fn nfSetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getNumFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
     switch (args[1]) {
         .int => |i| zphp_unum_setAttribute(f, @intCast(args[0].int), @intCast(i)),
         .float => |fl| zphp_unum_setDoubleAttribute(f, @intCast(args[0].int), fl),
         .bool => |b| zphp_unum_setAttribute(f, @intCast(args[0].int), if (b) 1 else 0),
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn nfGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getNumFmt(obj) orelse return .{ .bool = false };
-    return .{ .int = @intCast(zphp_unum_getAttribute(f, @intCast(args[0].int))) };
+fn nfGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getNumFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_unum_getAttribute(f, @intCast(args[0].int))) });
 }
 
 // ---------------- Transliterator ----------------
@@ -560,24 +570,24 @@ fn getTranslit(obj: *const PhpObject) ?*UTransliterator {
     return @ptrFromInt(@as(usize, @intCast(v.int)));
 }
 
-fn transCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn transCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const id_u16 = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(id_u16);
     var status: UErrorCode = U_ZERO_ERROR;
     const dir: i32 = if (args.len > 1 and args[1] == .int and args[1].int == 1) 1 else 0;
     const t = zphp_utrans_openU(id_u16.ptr, @intCast(id_u16.len), dir, null, 0, null, &status);
-    if (status > U_ZERO_ERROR or t == null) return .null;
+    if (status > U_ZERO_ERROR or t == null) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("Transliterator");
     try obj.set(ctx.allocator, "__trans", .{ .int = @intCast(@intFromPtr(t.?)) });
     try obj.set(ctx.allocator, "id", .{ .string = args[0].string });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn transTransliterate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const t = getTranslit(obj) orelse return .{ .bool = false };
+fn transTransliterate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const t = getTranslit(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const u16src = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(u16src);
 
@@ -590,9 +600,8 @@ fn transTransliterate(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     var limit: i32 = text_len;
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_utrans_transUChars(t, buf.ptr, &text_len, cap, 0, &limit, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(text_len)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, buf[0..@intCast(text_len)]);
 }
 
 // ---------------- IntlDateFormatter ----------------
@@ -630,36 +639,36 @@ fn defaultTzName(ctx: *NativeContext) []const u8 {
     return ctx.vm.default_tz_name;
 }
 
-fn dfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn dfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const date_style: i32 = if (args[1] == .int) @intCast(args[1].int) else 0;
     const time_style: i32 = if (args[2] == .int) @intCast(args[2].int) else 0;
     const tz_opt: ?[]const u8 = if (args.len > 3 and args[3] == .string and args[3].string.bytes().len > 0) args[3].string.bytes() else defaultTzName(ctx);
     // skip args[4] (calendar) for now
     const pat_opt: ?[]const u8 = if (args.len > 5 and args[5] == .string and args[5].string.bytes().len > 0) args[5].string.bytes() else null;
 
-    const f = (try openDateFmt(ctx, args[0].string.bytes(), date_style, time_style, tz_opt, pat_opt)) orelse return .null;
+    const f = (try openDateFmt(ctx, args[0].string.bytes(), date_style, time_style, tz_opt, pat_opt)) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__dfmt", .{ .int = @intCast(@intFromPtr(f)) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dfCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string) return .null;
+fn dfCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("IntlDateFormatter");
     const date_style: i32 = if (args[1] == .int) @intCast(args[1].int) else 0;
     const time_style: i32 = if (args[2] == .int) @intCast(args[2].int) else 0;
     const tz_opt: ?[]const u8 = if (args.len > 3 and args[3] == .string and args[3].string.bytes().len > 0) args[3].string.bytes() else defaultTzName(ctx);
     const pat_opt: ?[]const u8 = if (args.len > 5 and args[5] == .string and args[5].string.bytes().len > 0) args[5].string.bytes() else null;
-    const f = (try openDateFmt(ctx, args[0].string.bytes(), date_style, time_style, tz_opt, pat_opt)) orelse return .null;
+    const f = (try openDateFmt(ctx, args[0].string.bytes(), date_style, time_style, tz_opt, pat_opt)) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__dfmt", .{ .int = @intCast(@intFromPtr(f)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn dfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getDateFmt(obj) orelse return .{ .bool = false };
+fn dfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getDateFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const millis: f64 = switch (args[0]) {
         .int => |i| @as(f64, @floatFromInt(i)) * 1000.0,
         .float => |fl| fl * 1000.0,
@@ -668,60 +677,58 @@ fn dfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const ts_v = o.get("timestamp");
             if (ts_v == .int) break :blk @as(f64, @floatFromInt(ts_v.int)) * 1000.0;
             if (ts_v == .float) break :blk ts_v.float * 1000.0;
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         },
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     var buf: [256]UChar = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = zphp_udat_format(f, millis, &buf, @intCast(buf.len), null, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, buf[0..@intCast(n)]);
 }
 
-fn dfParse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getDateFmt(obj) orelse return .{ .bool = false };
+fn dfParse(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getDateFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const u16src = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(u16src);
     var pos: i32 = 0;
     var status: UErrorCode = U_ZERO_ERROR;
     const millis = zphp_udat_parse(f, u16src.ptr, @intCast(u16src.len), &pos, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    return .{ .int = @intFromFloat(millis / 1000.0) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intFromFloat(millis / 1000.0) });
 }
 
-fn dfGetPattern(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getDateFmt(obj) orelse return .{ .bool = false };
+fn dfGetPattern(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getDateFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var buf: [256]UChar = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = zphp_udat_toPattern(f, 0, &buf, @intCast(buf.len), &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, buf[0..@intCast(n)]);
 }
 
-fn dfSetPattern(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const f = getDateFmt(obj) orelse return .{ .bool = false };
+fn dfSetPattern(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const f = getDateFmt(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const u16src = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(u16src);
     zphp_udat_applyPattern(f, 0, u16src.ptr, @intCast(u16src.len));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // ---------------- IDNA (idn_to_ascii / idn_to_utf8) ----------------
 
-fn idnConvert(ctx: *NativeContext, args: []const Value, to_ascii: bool) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn idnConvert(ctx: *NativeContext, args: []const Value, to_ascii: bool) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
-    const idna = zphp_uidna_openUTS46(0, &status) orelse return .{ .bool = false };
+    const idna = zphp_uidna_openUTS46(0, &status) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_uidna_close(idna);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
 
     const info_size = zphp_uidna_info_size();
     const info_buf = try ctx.allocator.alloc(u8, info_size);
@@ -736,16 +743,15 @@ fn idnConvert(ctx: *NativeContext, args: []const Value, to_ascii: bool) RuntimeE
         zphp_uidna_nameToASCII(idna, u16src.ptr, @intCast(u16src.len), &dest, @intCast(dest.len), @ptrCast(info_buf.ptr), &status)
     else
         zphp_uidna_nameToUnicode(idna, u16src.ptr, @intCast(u16src.len), &dest, @intCast(dest.len), @ptrCast(info_buf.ptr), &status);
-    if (status > U_ZERO_ERROR or n < 0) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, dest[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (status > U_ZERO_ERROR or n < 0) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, dest[0..@intCast(n)]);
 }
 
-fn idnToAscii(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn idnToAscii(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return idnConvert(ctx, args, true);
 }
 
-fn idnToUtf8(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn idnToUtf8(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return idnConvert(ctx, args, false);
 }
 
@@ -796,8 +802,8 @@ fn buildArgEntries(ctx: *NativeContext, arr: *PhpArray, owned_u16: *std.ArrayLis
     return out;
 }
 
-fn msgFormatCommon(ctx: *NativeContext, locale: []const u8, pattern: []const u8, args_val: Value) RuntimeError!Value {
-    if (args_val != .array) return .{ .bool = false };
+fn msgFormatCommon(ctx: *NativeContext, locale: []const u8, pattern: []const u8, args_val: Value) RuntimeError!NativeResult {
+    if (args_val != .array) return NativeResult.scalar(.{ .bool = false });
     const arr = args_val.array;
 
     const loc_z = try dupZ(ctx, locale);
@@ -826,60 +832,59 @@ fn msgFormatCommon(ctx: *NativeContext, locale: []const u8, pattern: []const u8,
     else
         zphp_msgfmt_format_positional(loc_z.ptr, pat_u16.ptr, @intCast(pat_u16.len), arg_entries.ptr, @intCast(arg_entries.len), &buf, @intCast(buf.len), &status);
 
-    if (status > U_ZERO_ERROR or n < 0) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (status > U_ZERO_ERROR or n < 0) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, buf[0..@intCast(n)]);
 }
 
-fn mfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn mfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__locale", .{ .string = args[0].string });
     try obj.set(ctx.allocator, "__pattern", .{ .string = args[1].string });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn mfCreate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn mfCreate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("MessageFormatter");
     try obj.set(ctx.allocator, "__locale", .{ .string = args[0].string });
     try obj.set(ctx.allocator, "__pattern", .{ .string = args[1].string });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn mfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn mfFormat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const loc = obj.get("__locale");
     const pat = obj.get("__pattern");
-    if (loc != .string or pat != .string) return .{ .bool = false };
+    if (loc != .string or pat != .string) return NativeResult.scalar(.{ .bool = false });
     return msgFormatCommon(ctx, loc.string.bytes(), pat.string.bytes(), args[0]);
 }
 
-fn mfFormatMessage(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn mfFormatMessage(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     return msgFormatCommon(ctx, args[0].string.bytes(), args[1].string.bytes(), args[2]);
 }
 
-fn mfGetPattern(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+fn mfGetPattern(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
     const v = obj.get("__pattern");
-    if (v == .string) return v;
-    return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == .string) return NativeResult.share(v);
+    return try NativeResult.copyString(ctx.allocator, "");
 }
 
-fn mfSetPattern(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn mfSetPattern(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     try obj.set(ctx.allocator, "__pattern", .{ .string = args[0].string });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn mfGetLocale(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+fn mfGetLocale(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
     const v = obj.get("__locale");
-    if (v == .string) return v;
-    return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == .string) return NativeResult.share(v);
+    return try NativeResult.copyString(ctx.allocator, "");
 }
 
 // ---------------- IntlCalendar ----------------
@@ -902,7 +907,7 @@ fn openCalendar(ctx: *NativeContext, tz_opt: ?[]const u8, locale: []const u8, ca
     return cal;
 }
 
-fn calCreateInstance(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn calCreateInstance(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     var tz_opt: ?[]const u8 = null;
     if (args.len > 0 and args[0] == .string) tz_opt = args[0].string.bytes();
     var locale: []const u8 = "";
@@ -911,20 +916,20 @@ fn calCreateInstance(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         const def = zphp_uloc_getDefault();
         locale = def[0..cstrLen(def)];
     }
-    const cal = (try openCalendar(ctx, tz_opt, locale, 0)) orelse return .null;
+    const cal = (try openCalendar(ctx, tz_opt, locale, 0)) orelse return NativeResult.scalar(.null);
     const obj = try ctx.createObject("IntlGregorianCalendar");
     try obj.set(ctx.allocator, "__cal", .{ .int = @intCast(@intFromPtr(cal)) });
     try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, locale)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn calConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn calConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP: new IntlGregorianCalendar(...) supports several arg shapes:
     //   ()                          - default tz, default locale
     //   (string $tz, string $loc)   - explicit
     //   (int y, int m, int d)       - by-date
     //   (int y, int m, int d, int h, int mi, int s)
-    const obj = getThis(ctx) orelse return .null;
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     // tz/locale form
     if (args.len <= 2 and (args.len == 0 or args[0] == .string or args[0] == .null)) {
@@ -936,16 +941,16 @@ fn calConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const def = zphp_uloc_getDefault();
             locale = def[0..cstrLen(def)];
         }
-        const cal = (try openCalendar(ctx, tz_opt, locale, 0)) orelse return .null;
+        const cal = (try openCalendar(ctx, tz_opt, locale, 0)) orelse return NativeResult.scalar(.null);
         try obj.set(ctx.allocator, "__cal", .{ .int = @intCast(@intFromPtr(cal)) });
         try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, locale)) });
-        return .null;
+        return NativeResult.scalar(.null);
     }
 
     // integer form: y, m, d, [h, mi, s]
     const def_locale_ptr = zphp_uloc_getDefault();
     const def_locale = def_locale_ptr[0..cstrLen(def_locale_ptr)];
-    const cal = (try openCalendar(ctx, null, def_locale, 0)) orelse return .null;
+    const cal = (try openCalendar(ctx, null, def_locale, 0)) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__cal", .{ .int = @intCast(@intFromPtr(cal)) });
     try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, def_locale)) });
     if (args.len >= 3 and args[0] == .int and args[1] == .int and args[2] == .int) {
@@ -956,30 +961,30 @@ fn calConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             zphp_ucal_setDate(cal, @intCast(args[0].int), @intCast(args[1].int), @intCast(args[2].int), &status);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn calGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
     const r = zphp_ucal_get(cal, @intCast(args[0].int), &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    return .{ .int = @intCast(r) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(r) });
 }
 
-fn calSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
-    for (args) |a| if (a != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    for (args) |a| if (a != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     // PHP overloads: set(field, value) | set(y, m, d) | set(y, m, d, h, i) |
     // set(y, m, d, h, i, s). matches ICU's ucal_setDateTime convenience helpers
     // by setting each field individually
     if (args.len == 2) {
         zphp_ucal_set(cal, @intCast(args[0].int), @intCast(args[1].int));
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
     // year/month/day positional form
     const UCAL_YEAR: i32 = 1;
@@ -994,195 +999,194 @@ fn calSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len >= 4) zphp_ucal_set(cal, UCAL_HOUR_OF_DAY, @intCast(args[3].int));
     if (args.len >= 5) zphp_ucal_set(cal, UCAL_MINUTE, @intCast(args[4].int));
     if (args.len >= 6) zphp_ucal_set(cal, UCAL_SECOND, @intCast(args[5].int));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn calAdd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int or args[1] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calAdd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_ucal_add(cal, @intCast(args[0].int), @intCast(args[1].int), &status);
-    return .{ .bool = status <= U_ZERO_ERROR };
+    return NativeResult.scalar(.{ .bool = status <= U_ZERO_ERROR });
 }
 
-fn calRoll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calRoll(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const amount: i32 = switch (args[1]) {
         .int => |i| @intCast(i),
         .bool => |b| if (b) 1 else -1,
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_ucal_roll(cal, @intCast(args[0].int), amount, &status);
-    return .{ .bool = status <= U_ZERO_ERROR };
+    return NativeResult.scalar(.{ .bool = status <= U_ZERO_ERROR });
 }
 
-fn calGetTime(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calGetTime(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
     const millis = zphp_ucal_getMillis(cal, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    return .{ .float = millis };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .float = millis });
 }
 
-fn calSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calSetTime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const millis: f64 = switch (args[0]) {
         .int => |i| @floatFromInt(i),
         .float => |f| f,
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_ucal_setMillis(cal, millis, &status);
-    return .{ .bool = status <= U_ZERO_ERROR };
+    return NativeResult.scalar(.{ .bool = status <= U_ZERO_ERROR });
 }
 
-fn calInDaylightTime(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calInDaylightTime(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
-    return .{ .bool = zphp_ucal_inDaylightTime(cal, &status) != 0 };
+    return NativeResult.scalar(.{ .bool = zphp_ucal_inDaylightTime(cal, &status) != 0 });
 }
 
-fn calIsSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
-    return .{ .bool = zphp_ucal_isSet(cal, @intCast(args[0].int)) != 0 };
+fn calIsSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = zphp_ucal_isSet(cal, @intCast(args[0].int)) != 0 });
 }
 
-fn calClear(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calClear(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len > 0 and args[0] == .int) {
         zphp_ucal_clearField(cal, @intCast(args[0].int));
     } else {
         zphp_ucal_clear(cal);
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn calGetTimeZoneId(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calGetTimeZoneId(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var buf: [128]UChar = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = zphp_ucal_getTimeZoneID(cal, &buf, @intCast(buf.len), &status);
-    if (status > U_ZERO_ERROR or n <= 0) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(n)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (status > U_ZERO_ERROR or n <= 0) return try NativeResult.copyString(ctx.allocator, "");
+    return try u16ToResult(ctx, buf[0..@intCast(n)]);
 }
 
-fn calSetTimeZone(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calSetTimeZone(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const u16src = try utf8ToU16(ctx, args[0].string.bytes());
     defer ctx.allocator.free(u16src);
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_ucal_setTimeZone(cal, u16src.ptr, @intCast(u16src.len), &status);
-    return .{ .bool = status <= U_ZERO_ERROR };
+    return NativeResult.scalar(.{ .bool = status <= U_ZERO_ERROR });
 }
 
-fn calGetFirstDayOfWeek(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const cal = getCal(obj) orelse return .{ .int = 0 };
+fn calGetFirstDayOfWeek(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .int = 0 });
     var status: UErrorCode = U_ZERO_ERROR;
-    return .{ .int = @intCast(zphp_ucal_getFirstDayOfWeek(cal, &status)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ucal_getFirstDayOfWeek(cal, &status)) });
 }
 
-fn calSetFirstDayOfWeek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calSetFirstDayOfWeek(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     zphp_ucal_setFirstDayOfWeek(cal, @intCast(args[0].int));
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn calIsWeekend(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calIsWeekend(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
     const date: f64 = if (args.len > 0) switch (args[0]) {
         .int => |i| @floatFromInt(i),
         .float => |f| f,
         else => zphp_ucal_getMillis(cal, &status),
     } else zphp_ucal_getMillis(cal, &status);
-    return .{ .bool = zphp_ucal_isWeekend(cal, date, &status) != 0 };
+    return NativeResult.scalar(.{ .bool = zphp_ucal_isWeekend(cal, date, &status) != 0 });
 }
 
-fn calGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calGetType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var buf: [64]u8 = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const n = zphp_ucal_getType(cal, &buf, @intCast(buf.len), &status);
-    if (status > U_ZERO_ERROR or n <= 0) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    return .{ .string = Value.String.borrowed(try dupString(ctx, buf[0..@intCast(n)])) };
+    if (status > U_ZERO_ERROR or n <= 0) return try NativeResult.copyString(ctx.allocator, "");
+    return try NativeResult.copyString(ctx.allocator, buf[0..@intCast(n)]);
 }
 
-fn calGetLocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calGetLocale(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var buf: [128]u8 = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const ltype: c_int = if (args.len > 0 and args[0] == .int) @intCast(args[0].int) else 0;
     const n = zphp_ucal_getLocaleByType(cal, ltype, &buf, @intCast(buf.len), &status);
-    if (status > U_ZERO_ERROR or n <= 0) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    return .{ .string = Value.String.borrowed(try dupString(ctx, buf[0..@intCast(n)])) };
+    if (status > U_ZERO_ERROR or n <= 0) return try NativeResult.copyString(ctx.allocator, "");
+    return try NativeResult.copyString(ctx.allocator, buf[0..@intCast(n)]);
 }
 
-fn calGetActualMaximum(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calGetActualMaximum(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
     // UCAL_ACTUAL_MAXIMUM = 5: this-calendar's actual maximum for the field
     // (e.g. 29 for Feb in a leap year). UCAL_LEAST_MAXIMUM (3) would return
     // 28 across all years which is the wrong thing
-    return .{ .int = @intCast(zphp_ucal_getLimit(cal, @intCast(args[0].int), 5, &status)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ucal_getLimit(cal, @intCast(args[0].int), 5, &status)) });
 }
 
-fn calGetActualMinimum(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calGetActualMinimum(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
     // UCAL_ACTUAL_MINIMUM = 4
-    return .{ .int = @intCast(zphp_ucal_getLimit(cal, @intCast(args[0].int), 4, &status)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ucal_getLimit(cal, @intCast(args[0].int), 4, &status)) });
 }
 
-fn calIsLenient(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
-    return .{ .bool = zphp_ucal_getLenient(cal) != 0 };
+fn calIsLenient(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = zphp_ucal_getLenient(cal) != 0 });
 }
 
-fn calSetLenient(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .bool) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const cal = getCal(obj) orelse return .{ .bool = false };
+fn calSetLenient(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .bool) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const cal = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
     zphp_ucal_setLenient(cal, if (args[0].bool) 1 else 0);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn calEquals(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn calEquals(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP's IntlCalendar::equals compares calendars by their effective wall
     // time. ucal_equivalentTo is the wrong check - it tests calendar-type
     // and tz equivalence which is stricter than what PHP does
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const a = getCal(obj) orelse return .{ .bool = false };
-    const b = getCal(args[0].object) orelse return .{ .bool = false };
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const a = getCal(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const b = getCal(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
     var s1: UErrorCode = U_ZERO_ERROR;
     var s2: UErrorCode = U_ZERO_ERROR;
-    return .{ .bool = zphp_ucal_getMillis(a, &s1) == zphp_ucal_getMillis(b, &s2) };
+    return NativeResult.scalar(.{ .bool = zphp_ucal_getMillis(a, &s1) == zphp_ucal_getMillis(b, &s2) });
 }
 
 // ---------------- IntlBreakIterator ----------------
@@ -1205,76 +1209,76 @@ fn openBrk(ctx: *NativeContext, brk_type: c_int, locale: []const u8) !?*ZphpBrk 
     return w;
 }
 
-fn brkMakeInstance(ctx: *NativeContext, brk_type: c_int, locale: []const u8) RuntimeError!Value {
-    const w = (try openBrk(ctx, brk_type, locale)) orelse return .null;
+fn brkMakeInstance(ctx: *NativeContext, brk_type: c_int, locale: []const u8) RuntimeError!NativeResult {
+    const w = (try openBrk(ctx, brk_type, locale)) orelse return NativeResult.scalar(.null);
     const obj = try ctx.createObject("IntlBreakIterator");
     try obj.set(ctx.allocator, "__brk", .{ .int = @intCast(@intFromPtr(w)) });
     try obj.set(ctx.allocator, "__type", .{ .int = @intCast(brk_type) });
     try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, locale)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn brkCreateWord(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn brkCreateWord(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const locale = if (args.len > 0 and args[0] == .string) args[0].string.bytes() else "";
     return brkMakeInstance(ctx, 1, locale);
 }
 
-fn brkCreateChar(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn brkCreateChar(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const locale = if (args.len > 0 and args[0] == .string) args[0].string.bytes() else "";
     return brkMakeInstance(ctx, 0, locale);
 }
 
-fn brkCreateLine(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn brkCreateLine(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const locale = if (args.len > 0 and args[0] == .string) args[0].string.bytes() else "";
     return brkMakeInstance(ctx, 2, locale);
 }
 
-fn brkCreateSentence(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn brkCreateSentence(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const locale = if (args.len > 0 and args[0] == .string) args[0].string.bytes() else "";
     return brkMakeInstance(ctx, 3, locale);
 }
 
-fn brkCreateTitle(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn brkCreateTitle(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const locale = if (args.len > 0 and args[0] == .string) args[0].string.bytes() else "";
     return brkMakeInstance(ctx, 4, locale);
 }
 
-fn brkSetText(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const w = getBrk(obj) orelse return .{ .bool = false };
+fn brkSetText(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var status: UErrorCode = U_ZERO_ERROR;
     const txt = args[0].string.bytes();
     const ptr: [*]const u8 = if (txt.len > 0) txt.ptr else @ptrCast(""[0..]);
     zphp_ubrk_setText(w, ptr, @intCast(txt.len), &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
     // also store the text so getText round-trips without losing it
     try obj.set(ctx.allocator, "__text", .{ .string = Value.String.borrowed(try dupString(ctx, txt)) });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn brkGetText(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn brkGetText(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const v = obj.get("__text");
-    if (v == .string) return v;
-    return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == .string) return NativeResult.share(v);
+    return try NativeResult.copyString(ctx.allocator, "");
 }
 
-fn brkFirst(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const w = getBrk(obj) orelse return .{ .int = -1 };
-    return .{ .int = @intCast(zphp_ubrk_first(w)) };
+fn brkFirst(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_first(w)) });
 }
 
-fn brkLast(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const w = getBrk(obj) orelse return .{ .int = -1 };
-    return .{ .int = @intCast(zphp_ubrk_last(w)) };
+fn brkLast(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_last(w)) });
 }
 
-fn brkNext(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const w = getBrk(obj) orelse return .{ .int = -1 };
+fn brkNext(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = -1 });
     // PHP's next($offset) advances by that many boundaries when given
     if (args.len > 0 and args[0] == .int) {
         const n = args[0].int;
@@ -1292,64 +1296,64 @@ fn brkNext(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 if (last == -1) break;
             }
         }
-        return .{ .int = @intCast(last) };
+        return NativeResult.scalar(.{ .int = @intCast(last) });
     }
-    return .{ .int = @intCast(zphp_ubrk_next(w)) };
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_next(w)) });
 }
 
-fn brkPrevious(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const w = getBrk(obj) orelse return .{ .int = -1 };
-    return .{ .int = @intCast(zphp_ubrk_previous(w)) };
+fn brkPrevious(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_previous(w)) });
 }
 
-fn brkCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const w = getBrk(obj) orelse return .{ .int = -1 };
-    return .{ .int = @intCast(zphp_ubrk_current(w)) };
+fn brkCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_current(w)) });
 }
 
-fn brkFollowing(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .int = -1 };
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const w = getBrk(obj) orelse return .{ .int = -1 };
-    return .{ .int = @intCast(zphp_ubrk_following(w, @intCast(args[0].int))) };
+fn brkFollowing(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .int = -1 });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_following(w, @intCast(args[0].int))) });
 }
 
-fn brkPreceding(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .int = -1 };
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const w = getBrk(obj) orelse return .{ .int = -1 };
-    return .{ .int = @intCast(zphp_ubrk_preceding(w, @intCast(args[0].int))) };
+fn brkPreceding(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .int = -1 });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_preceding(w, @intCast(args[0].int))) });
 }
 
-fn brkIsBoundary(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const w = getBrk(obj) orelse return .{ .bool = false };
-    return .{ .bool = zphp_ubrk_isBoundary(w, @intCast(args[0].int)) != 0 };
+fn brkIsBoundary(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = zphp_ubrk_isBoundary(w, @intCast(args[0].int)) != 0 });
 }
 
-fn brkGetRuleStatus(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const w = getBrk(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(zphp_ubrk_getRuleStatus(w)) };
+fn brkGetRuleStatus(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const w = getBrk(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(zphp_ubrk_getRuleStatus(w)) });
 }
 
-fn brkGetLocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    const w = getBrk(obj) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+fn brkGetLocale(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
+    const w = getBrk(obj) orelse return try NativeResult.copyString(ctx.allocator, "");
     var buf: [128]u8 = undefined;
     var status: UErrorCode = U_ZERO_ERROR;
     const ltype: c_int = if (args.len > 0 and args[0] == .int) @intCast(args[0].int) else 0;
     const n = zphp_ubrk_getLocaleByType(w, ltype, &buf, @intCast(buf.len), &status);
-    if (status > U_ZERO_ERROR or n <= 0) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    return .{ .string = Value.String.borrowed(try dupString(ctx, buf[0..@intCast(n)])) };
+    if (status > U_ZERO_ERROR or n <= 0) return try NativeResult.copyString(ctx.allocator, "");
+    return try NativeResult.copyString(ctx.allocator, buf[0..@intCast(n)]);
 }
 
 // ---------------- registration ----------------
 
-const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!Value;
+const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!NativeResult;
 
 // every intl op resets vm.last_intl_error_code on entry so a successful call
 // surfaces "U_ZERO_ERROR" through intl_get_error_*. failures record the failing
@@ -1357,7 +1361,7 @@ const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!Value;
 // get_error_message, is_failure, error_name) do NOT reset
 fn intlWrap(comptime inner: NativeFn) NativeFn {
     return struct {
-        fn wrapped(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+        fn wrapped(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
             ctx.vm.last_intl_error_code = 0;
             return inner(ctx, args);
         }
@@ -1406,24 +1410,24 @@ fn errorNameForCode(code: i32) []const u8 {
     };
 }
 
-fn intlGetErrorMessage(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed(errorNameForCode(ctx.vm.last_intl_error_code)) };
+fn intlGetErrorMessage(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return try NativeResult.copyString(ctx.allocator, errorNameForCode(ctx.vm.last_intl_error_code));
 }
 
-fn intlGetErrorCode(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = ctx.vm.last_intl_error_code };
+fn intlGetErrorCode(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = ctx.vm.last_intl_error_code });
 }
 
-fn intlIsFailure(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
+fn intlIsFailure(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     const c = Value.toInt(args[0]);
-    return .{ .bool = c > 0 };
+    return NativeResult.scalar(.{ .bool = c > 0 });
 }
 
-fn intlErrorName(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .string = Value.String.borrowed("U_ZERO_ERROR") };
+fn intlErrorName(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.literal("U_ZERO_ERROR");
     const c: i32 = @intCast(Value.toInt(args[0]));
-    return .{ .string = Value.String.borrowed(errorNameForCode(c)) };
+    return try NativeResult.copyString(ctx.allocator, errorNameForCode(c));
 }
 
 pub const entries = .{
@@ -1463,32 +1467,32 @@ pub const entries = .{
 
 // count grapheme clusters in a UTF-8 string. uses ICU's character-level
 // BreakIterator and counts boundary crossings
-fn graphemeStrlen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn graphemeStrlen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
-    const w = (try openBrk(ctx, 0, "")) orelse return .{ .bool = false };
+    const w = (try openBrk(ctx, 0, "")) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_ubrk_close(w);
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_ubrk_setText(w, s.ptr, @intCast(s.len), &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
     var count: i64 = 0;
     _ = zphp_ubrk_first(w);
     while (zphp_ubrk_next(w) != -1) count += 1;
-    return .{ .int = count };
+    return NativeResult.scalar(.{ .int = count });
 }
 
 // grapheme-aware substring. start and length are in grapheme units.
-fn graphemeSubstr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
+fn graphemeSubstr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     const start: i64 = Value.toInt(args[1]);
     const length_arg: ?i64 = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else null;
 
-    const w = (try openBrk(ctx, 0, "")) orelse return .{ .bool = false };
+    const w = (try openBrk(ctx, 0, "")) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_ubrk_close(w);
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_ubrk_setText(w, s.ptr, @intCast(s.len), &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
 
     // collect grapheme byte offsets
     var offsets = std.ArrayListUnmanaged(i32){};
@@ -1500,7 +1504,7 @@ fn graphemeSubstr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const n: i64 = @intCast(offsets.items.len -| 1);
     var s_idx: i64 = start;
     if (s_idx < 0) s_idx = @max(0, n + s_idx);
-    if (s_idx > n) return .{ .bool = false };
+    if (s_idx > n) return NativeResult.scalar(.{ .bool = false });
     const start_byte: usize = @intCast(offsets.items[@intCast(s_idx)]);
 
     var end_byte: usize = s.len;
@@ -1516,7 +1520,7 @@ fn graphemeSubstr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (end_byte < start_byte) end_byte = start_byte;
     }
 
-    return .{ .string = Value.String.borrowed(try dupString(ctx, s[start_byte..end_byte])) };
+    return try NativeResult.copyString(ctx.allocator, s[start_byte..end_byte]);
 }
 
 // grapheme_extract($haystack, $size, $type, $offset): extract a run of grapheme
@@ -1525,20 +1529,20 @@ fn graphemeSubstr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 // returns the extracted string or false. the by-ref $next (5th) out-param isn't
 // written back (no generic native by-ref path); callers using only the return
 // value (e.g. symfony/string startsWith) are unaffected
-fn graphemeExtract(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
+fn graphemeExtract(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     const size: i64 = Value.toInt(args[1]);
     const extr_type: i64 = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else 0;
     const start_off: i64 = if (args.len >= 4 and args[3] != .null) Value.toInt(args[3]) else 0;
-    if (size < 0 or extr_type < 0 or extr_type > 2 or start_off < 0 or @as(usize, @intCast(start_off)) > s.len) return .{ .bool = false };
+    if (size < 0 or extr_type < 0 or extr_type > 2 or start_off < 0 or @as(usize, @intCast(start_off)) > s.len) return NativeResult.scalar(.{ .bool = false });
     const start: usize = @intCast(start_off);
 
-    const w = (try openBrk(ctx, 0, "")) orelse return .{ .bool = false };
+    const w = (try openBrk(ctx, 0, "")) orelse return NativeResult.scalar(.{ .bool = false });
     defer zphp_ubrk_close(w);
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_ubrk_setText(w, s.ptr, @intCast(s.len), &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
 
     var offsets = std.ArrayListUnmanaged(i32){};
     defer offsets.deinit(ctx.allocator);
@@ -1549,10 +1553,10 @@ fn graphemeExtract(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     // first cluster boundary at or after the requested byte offset
     var bi: usize = 0;
     while (bi < offsets.items.len and @as(usize, @intCast(offsets.items[bi])) < start) bi += 1;
-    if (bi >= offsets.items.len) return .{ .bool = false };
+    if (bi >= offsets.items.len) return NativeResult.scalar(.{ .bool = false });
     const begin_byte: usize = @intCast(offsets.items[bi]);
     // nothing to extract (empty haystack, or offset at/after the last cluster)
-    if (begin_byte >= s.len) return .{ .bool = false };
+    if (begin_byte >= s.len) return NativeResult.scalar(.{ .bool = false });
 
     var end_byte: usize = begin_byte;
     var taken: i64 = 0;
@@ -1572,7 +1576,7 @@ fn graphemeExtract(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         taken += 1;
         chars += cl_chars;
     }
-    return .{ .string = Value.String.borrowed(try dupString(ctx, s[begin_byte..end_byte])) };
+    return try NativeResult.copyString(ctx.allocator, s[begin_byte..end_byte]);
 }
 
 // grapheme cluster boundary byte offsets for s: [0, ..., s.len]. count of
@@ -1636,25 +1640,25 @@ fn graphemeIndexOfByte(bounds: []const i32, byte_pos: usize) ?usize {
     return null;
 }
 
-fn graphemeOffsetError(ctx: *NativeContext, comptime fname: []const u8) RuntimeError!Value {
+fn graphemeOffsetError(ctx: *NativeContext, comptime fname: []const u8) RuntimeError!NativeResult {
     try ctx.vm.setPendingException("ValueError", fname ++ "(): Argument #3 ($offset) must be contained in argument #1 ($haystack)");
     return error.RuntimeError;
 }
 
-fn graphemePositionImpl(ctx: *NativeContext, args: []const Value, comptime fname: []const u8, case_insensitive: bool, reverse: bool) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return Value{ .bool = false };
+fn graphemePositionImpl(ctx: *NativeContext, args: []const Value, comptime fname: []const u8, case_insensitive: bool, reverse: bool) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
     const offset: i64 = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else 0;
 
-    var bounds = (try collectGraphemeBounds(ctx, haystack)) orelse return Value{ .bool = false };
+    var bounds = (try collectGraphemeBounds(ctx, haystack)) orelse return NativeResult.scalar(.{ .bool = false });
     defer bounds.deinit(ctx.allocator);
     const n_g: i64 = @intCast(bounds.items.len - 1);
     if (offset < -n_g or offset > n_g) return graphemeOffsetError(ctx, fname);
 
     if (needle.len == 0) {
-        if (reverse) return .{ .int = if (offset >= 0) n_g else n_g + offset };
-        return .{ .int = if (offset >= 0) offset else n_g + offset };
+        if (reverse) return NativeResult.scalar(.{ .int = if (offset >= 0) n_g else n_g + offset });
+        return NativeResult.scalar(.{ .int = if (offset >= 0) offset else n_g + offset });
     }
 
     var h_search: []const u8 = haystack;
@@ -1686,47 +1690,47 @@ fn graphemePositionImpl(ctx: *NativeContext, args: []const Value, comptime fname
                 if (gi <= n_g + offset) best = gi;
             }
         }
-        if (best) |b| return .{ .int = b };
-        return .{ .bool = false };
+        if (best) |b| return NativeResult.scalar(.{ .int = b });
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     const start_g: usize = @intCast(if (offset >= 0) offset else n_g + offset);
     var from: usize = @intCast(bounds.items[start_g]);
     while (std.mem.indexOfPos(u8, h_search, from, n_search)) |p| : (from = p + 1) {
         const g = graphemeIndexOfByte(bounds.items, p) orelse continue;
-        return .{ .int = @intCast(g) };
+        return NativeResult.scalar(.{ .int = @intCast(g) });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn graphemeStrpos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn graphemeStrpos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return graphemePositionImpl(ctx, args, "grapheme_strpos", false, false);
 }
 
-fn graphemeStripos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn graphemeStripos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return graphemePositionImpl(ctx, args, "grapheme_stripos", true, false);
 }
 
-fn graphemeStrrpos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn graphemeStrrpos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return graphemePositionImpl(ctx, args, "grapheme_strrpos", false, true);
 }
 
-fn graphemeStrripos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn graphemeStrripos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return graphemePositionImpl(ctx, args, "grapheme_strripos", true, true);
 }
 
-fn graphemeStrstrImpl(ctx: *NativeContext, args: []const Value, case_insensitive: bool) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return Value{ .bool = false };
+fn graphemeStrstrImpl(ctx: *NativeContext, args: []const Value, case_insensitive: bool) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
     const before_needle = args.len >= 3 and args[2].isTruthy();
 
     if (needle.len == 0) {
-        if (before_needle) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, haystack)) };
+        if (before_needle) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, haystack);
     }
 
-    var bounds = (try collectGraphemeBounds(ctx, haystack)) orelse return Value{ .bool = false };
+    var bounds = (try collectGraphemeBounds(ctx, haystack)) orelse return NativeResult.scalar(.{ .bool = false });
     defer bounds.deinit(ctx.allocator);
 
     var h_search: []const u8 = haystack;
@@ -1745,22 +1749,22 @@ fn graphemeStrstrImpl(ctx: *NativeContext, args: []const Value, case_insensitive
     var from: usize = 0;
     while (std.mem.indexOfPos(u8, h_search, from, n_search)) |p| : (from = p + 1) {
         if (graphemeIndexOfByte(bounds.items, p) == null) continue;
-        if (before_needle) return .{ .string = Value.String.borrowed(try dupString(ctx, haystack[0..p])) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, haystack[p..])) };
+        if (before_needle) return try NativeResult.copyString(ctx.allocator, haystack[0..p]);
+        return try NativeResult.copyString(ctx.allocator, haystack[p..]);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn graphemeStrstr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn graphemeStrstr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return graphemeStrstrImpl(ctx, args, false);
 }
 
-fn graphemeStristr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn graphemeStristr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return graphemeStrstrImpl(ctx, args, true);
 }
 
-fn graphemeStrSplit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn graphemeStrSplit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     const length: i64 = if (args.len >= 2 and args[1] != .null) Value.toInt(args[1]) else 1;
     if (length < 1 or length > 1073741823) {
@@ -1768,7 +1772,7 @@ fn graphemeStrSplit(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         return error.RuntimeError;
     }
 
-    var bounds = (try collectGraphemeBounds(ctx, s)) orelse return Value{ .bool = false };
+    var bounds = (try collectGraphemeBounds(ctx, s)) orelse return NativeResult.scalar(.{ .bool = false });
     defer bounds.deinit(ctx.allocator);
     const n_g = bounds.items.len - 1;
 
@@ -1781,12 +1785,12 @@ fn graphemeStrSplit(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         const b: usize = @intCast(bounds.items[end]);
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, s[a..b])) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // procedural shim: accepts a Transliterator instance or an ID string
-fn transliteratorTransliterate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn transliteratorTransliterate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
 
     var t_obj: ?*PhpObject = null;
     var owned = false;
@@ -1796,19 +1800,19 @@ fn transliteratorTransliterate(ctx: *NativeContext, args: []const Value) Runtime
 
     switch (args[0]) {
         .object => |o| {
-            if (!std.mem.eql(u8, o.class_name, "Transliterator")) return .{ .bool = false };
+            if (!std.mem.eql(u8, o.class_name, "Transliterator")) return NativeResult.scalar(.{ .bool = false });
             t_obj = o;
         },
         .string => {
-            const created = try transCreateStatic(ctx, args[0..1]);
-            if (created != .object) return .{ .bool = false };
+            const created = (try transCreateStatic(ctx, args[0..1])).value;
+            if (created != .object) return NativeResult.scalar(.{ .bool = false });
             t_obj = created.object;
             owned = false; // the wrapper is tracked by ctx; native close would double-free
         },
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     }
 
-    const t = getTranslit(t_obj.?) orelse return .{ .bool = false };
+    const t = getTranslit(t_obj.?) orelse return NativeResult.scalar(.{ .bool = false });
     const u16src = try utf8ToU16(ctx, args[1].string.bytes());
     defer ctx.allocator.free(u16src);
 
@@ -1821,9 +1825,8 @@ fn transliteratorTransliterate(ctx: *NativeContext, args: []const Value) Runtime
     var limit: i32 = text_len;
     var status: UErrorCode = U_ZERO_ERROR;
     zphp_utrans_transUChars(t, buf.ptr, &text_len, cap, 0, &limit, &status);
-    if (intlRecord(ctx.vm, status)) return .{ .bool = false };
-    const out = try u16ToUtf8(ctx, buf[0..@intCast(text_len)]);
-    return .{ .string = Value.String.borrowed(out) };
+    if (intlRecord(ctx.vm, status)) return NativeResult.scalar(.{ .bool = false });
+    return try u16ToResult(ctx, buf[0..@intCast(text_len)]);
 }
 
 pub fn register(vm: *VM, a: Allocator) !void {
@@ -1869,10 +1872,10 @@ fn registerIntlCharStub(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "IntlChar::getUnicodeVersion", intlCharGetUnicodeVersion);
 }
 
-fn intlCharGetUnicodeVersion(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn intlCharGetUnicodeVersion(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     for ([_]i64{ 17, 0, 0, 0 }) |part| try arr.append(ctx.allocator, .{ .int = part });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // decode the first UTF-8 codepoint of a string, or accept an int directly.
@@ -1889,20 +1892,19 @@ fn intlCharCodepoint(v: Value) ?u32 {
     return std.unicode.utf8Decode(s[0..len]) catch null;
 }
 
-fn intlCharOrd(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const cp = intlCharCodepoint(args[0]) orelse return .null;
-    return .{ .int = @intCast(cp) };
+fn intlCharOrd(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const cp = intlCharCodepoint(args[0]) orelse return NativeResult.scalar(.null);
+    return NativeResult.scalar(.{ .int = @intCast(cp) });
 }
 
-fn intlCharChr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const cp = intlCharCodepoint(args[0]) orelse return .null;
+fn intlCharChr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const cp = intlCharCodepoint(args[0]) orelse return NativeResult.scalar(.null);
     var buf: [4]u8 = undefined;
-    const n = std.unicode.utf8Encode(@intCast(cp), &buf) catch return .null;
+    const n = std.unicode.utf8Encode(@intCast(cp), &buf) catch return NativeResult.scalar(.null);
     const owned = try ctx.allocator.dupe(u8, buf[0..n]);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
 fn intlBoolPredicate(args: []const Value, comptime pred: fn (u32) bool) Value {
@@ -1948,55 +1950,55 @@ fn isXDigitCp(cp: u32) bool {
     return isDigitCp(cp) or (cp >= 'a' and cp <= 'f') or (cp >= 'A' and cp <= 'F');
 }
 
-fn intlCharIsalpha(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isAlphaCp);
+fn intlCharIsalpha(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isAlphaCp));
 }
-fn intlCharIsdigit(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isDigitCp);
+fn intlCharIsdigit(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isDigitCp));
 }
-fn intlCharIsalnum(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isAlnumCp);
+fn intlCharIsalnum(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isAlnumCp));
 }
-fn intlCharIsupper(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isUpperCp);
+fn intlCharIsupper(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isUpperCp));
 }
-fn intlCharIslower(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isLowerCp);
+fn intlCharIslower(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isLowerCp));
 }
-fn intlCharIsspace(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isSpaceCp);
+fn intlCharIsspace(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isSpaceCp));
 }
-fn intlCharIscntrl(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isCntrlCp);
+fn intlCharIscntrl(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isCntrlCp));
 }
-fn intlCharIsblank(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isBlankCp);
+fn intlCharIsblank(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isBlankCp));
 }
-fn intlCharIspunct(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isPunctCp);
+fn intlCharIspunct(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isPunctCp));
 }
-fn intlCharIsgraph(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isGraphCp);
+fn intlCharIsgraph(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isGraphCp));
 }
-fn intlCharIsprint(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isPrintCp);
+fn intlCharIsprint(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isPrintCp));
 }
-fn intlCharIsxdigit(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return intlBoolPredicate(args, isXDigitCp);
+fn intlCharIsxdigit(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(intlBoolPredicate(args, isXDigitCp));
 }
 
-fn intlCharTolower(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const cp = intlCharCodepoint(args[0]) orelse return .null;
+fn intlCharTolower(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const cp = intlCharCodepoint(args[0]) orelse return NativeResult.scalar(.null);
     const out: u32 = if (cp >= 'A' and cp <= 'Z') cp + 32 else cp;
-    return .{ .int = @intCast(out) };
+    return NativeResult.scalar(.{ .int = @intCast(out) });
 }
 
-fn intlCharToupper(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const cp = intlCharCodepoint(args[0]) orelse return .null;
+fn intlCharToupper(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const cp = intlCharCodepoint(args[0]) orelse return NativeResult.scalar(.null);
     const out: u32 = if (cp >= 'a' and cp <= 'z') cp - 32 else cp;
-    return .{ .int = @intCast(out) };
+    return NativeResult.scalar(.{ .int = @intCast(out) });
 }
 
 fn registerBreakIteratorClass(vm: *VM, a: Allocator) !void {
@@ -2266,8 +2268,8 @@ fn registerLocaleClass(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "Locale::acceptFromHttp", intlWrap(localeAcceptFromHttp));
 }
 
-fn localeComposeLocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .array) return .{ .bool = false };
+fn localeComposeLocale(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const arr = args[0].array;
     var buf: std.ArrayListUnmanaged(u8) = .{};
     defer buf.deinit(ctx.allocator);
@@ -2294,13 +2296,11 @@ fn localeComposeLocale(ctx: *NativeContext, args: []const Value) RuntimeError!Va
             try buf.appendSlice(ctx.allocator, v.string.bytes());
         } else break;
     }
-    const owned = try ctx.allocator.dupe(u8, buf.items);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, buf.items);
 }
 
-fn localeParseLocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn localeParseLocale(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const s = args[0].string.bytes();
     const out = try ctx.createArray();
     // split on '_' / '-' separators
@@ -2344,14 +2344,14 @@ fn localeParseLocale(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         try ctx.vm.strings.append(ctx.allocator, owned_key);
         try out.set(ctx.allocator, .{ .string = Value.String.borrowed(owned_key) }, .{ .string = Value.String.borrowed(parts[idx]) });
     }
-    return .{ .array = out };
+    return NativeResult.borrowed(.{ .array = out });
 }
 
-fn localeGetAllVariants(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeGetAllVariants(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const out = try ctx.createArray();
-    if (args.len < 1 or args[0] != .string) return .{ .array = out };
-    const parsed = try localeParseLocale(ctx, args);
-    if (parsed != .array) return .{ .array = out };
+    if (args.len < 1 or args[0] != .string) return NativeResult.borrowed(.{ .array = out });
+    const parsed = (try localeParseLocale(ctx, args)).value;
+    if (parsed != .array) return NativeResult.borrowed(.{ .array = out });
     var i: usize = 0;
     while (i < 16) : (i += 1) {
         var key_buf: [16]u8 = undefined;
@@ -2359,26 +2359,26 @@ fn localeGetAllVariants(ctx: *NativeContext, args: []const Value) RuntimeError!V
         const v = parsed.array.get(.{ .string = Value.String.borrowed(key) });
         if (v == .string) try out.append(ctx.allocator, v) else break;
     }
-    return .{ .array = out };
+    return NativeResult.borrowed(.{ .array = out });
 }
 
-fn localeGetKeywords(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .array = try ctx.createArray() };
+fn localeGetKeywords(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
-fn localeFilterMatches(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    return .{ .bool = std.ascii.eqlIgnoreCase(args[0].string.bytes(), args[1].string.bytes()) };
+fn localeFilterMatches(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = std.ascii.eqlIgnoreCase(args[0].string.bytes(), args[1].string.bytes()) });
 }
 
-fn localeLookup(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .string = Value.String.borrowed("") };
-    return args[1];
+fn localeLookup(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.literal("");
+    return NativeResult.share(args[1]);
 }
 
-fn localeAcceptFromHttp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn localeAcceptFromHttp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // best-effort: take the first locale from a comma-separated header
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     var first_end: usize = s.len;
     for (s, 0..) |c, i| {
@@ -2388,9 +2388,7 @@ fn localeAcceptFromHttp(ctx: *NativeContext, args: []const Value) RuntimeError!V
         }
     }
     const slice = std.mem.trim(u8, s[0..first_end], " \t");
-    const owned = try ctx.allocator.dupe(u8, slice);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, slice);
 }
 
 fn registerCollatorClass(vm: *VM, a: Allocator) !void {
@@ -2497,30 +2495,30 @@ fn registerTransliteratorClass(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "IntlTimeZone::getRawOffset", intlTimeZoneGetRawOffset);
 }
 
-fn intlTimeZoneCreate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn intlTimeZoneCreate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("IntlTimeZone");
     try obj.set(ctx.allocator, "__id", .{ .string = args[0].string });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn intlTimeZoneCreateDefault(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn intlTimeZoneCreateDefault(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("IntlTimeZone");
     try obj.set(ctx.allocator, "__id", .{ .string = Value.String.borrowed(ctx.vm.default_tz_name) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn intlTimeZoneGetId(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = ctx.vm.currentFrame().vars.get("$this") orelse return .{ .bool = false };
-    if (this != .object) return .{ .bool = false };
-    return this.object.get("__id");
+fn intlTimeZoneGetId(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.{ .bool = false });
+    if (this != .object) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(this.object.get("__id"));
 }
 
-fn intlTimeZoneGetRawOffset(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn intlTimeZoneGetRawOffset(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // raw offset (ignoring DST) in milliseconds; zphp's tz table tracks
     // std_offset in seconds. UTC fallback when unknown
     _ = ctx;
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
 fn registerConstants(vm: *VM, a: Allocator) !void {

--- a/src/stdlib/json.zig
+++ b/src/stdlib/json.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const vm_mod = @import("../runtime/vm.zig");
 const NativeContext = vm_mod.NativeContext;
+const NativeResult = vm_mod.NativeResult;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
 const PhpObject = @import("../runtime/value.zig").PhpObject;
@@ -34,17 +35,17 @@ pub const entries = .{
     .{ "json_validate", json_validate },
 };
 
-fn json_encode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn json_encode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const flags = if (args.len >= 2) Value.toInt(args[1]) else 0;
     const depth: usize = if (args.len >= 3) @intCast(@max(1, Value.toInt(args[2]))) else 512;
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var visited = std.ArrayListUnmanaged(usize){};
     defer visited.deinit(ctx.allocator);
     last_error = 0;
     last_error_msg = "No error";
     encodeValue(&buf, ctx.allocator, args[0], 0, depth, flags, ctx.vm, &visited) catch {
-        buf.deinit(ctx.allocator);
         if (last_error == 0) {
             last_error = 5;
             last_error_msg = "Malformed UTF-8 characters, possibly incorrectly encoded";
@@ -52,13 +53,12 @@ fn json_encode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if ((flags & JSON_THROW_ON_ERROR) != 0) {
             return throwJsonException(ctx, last_error_msg);
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     last_error = 0;
     last_error_msg = "No error";
-    const result = buf.toOwnedSlice(ctx.allocator) catch return .{ .bool = false };
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    const result = try buf.toOwnedSlice(ctx.allocator);
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 fn encodeValue(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, val: Value, depth: usize, max_depth: usize, flags: i64, vm: ?*vm_mod.VM, visited: *std.ArrayListUnmanaged(usize)) !void {
@@ -485,8 +485,8 @@ fn appendIndent(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, depth: u
     for (0..depth) |_| try buf.appendSlice(a, "    ");
 }
 
-fn json_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .null;
+fn json_decode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.null);
     const s = args[0].string.bytes();
     const flags = if (args.len >= 4) Value.toInt(args[3]) else 0;
     // PHP semantics: JSON_OBJECT_AS_ARRAY only applies when $associative is
@@ -505,7 +505,7 @@ fn json_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if ((flags & JSON_THROW_ON_ERROR) != 0) {
             return throwJsonException(ctx, "Syntax error");
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
     var pos: usize = 0;
     const result = parseValue(ctx, s, &pos, assoc, depth, 0, flags) catch |err| {
@@ -517,8 +517,9 @@ fn json_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if ((flags & JSON_THROW_ON_ERROR) != 0) {
             return throwJsonException(ctx, last_error_msg);
         }
-        return .null;
+        return NativeResult.scalar(.null);
     };
+    defer if (result == .string) result.string.release();
     skipWhitespace(s, &pos);
     if (pos < s.len) {
         last_error = 4;
@@ -526,11 +527,11 @@ fn json_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if ((flags & JSON_THROW_ON_ERROR) != 0) {
             return throwJsonException(ctx, "Syntax error");
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
     last_error = 0;
     last_error_msg = "No error";
-    return result;
+    return NativeResult.share(result);
 }
 
 // Match PHP's array-key coercion: a string key that looks like a decimal
@@ -658,8 +659,7 @@ fn parseString(ctx: *NativeContext, s: []const u8, pos: *usize) !Value {
     }
     pos.* += 1;
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return .{ .string = try Value.String.adopt(ctx.allocator, result) };
 }
 
 fn parseNumber(ctx: *NativeContext, s: []const u8, pos: *usize, flags: i64) !Value {
@@ -685,9 +685,7 @@ fn parseNumber(ctx: *NativeContext, s: []const u8, pos: *usize, flags: i64) !Val
     }
     const i = std.fmt.parseInt(i64, num_str, 10) catch {
         if ((flags & JSON_BIGINT_AS_STRING) != 0) {
-            const dup = try ctx.allocator.dupe(u8, num_str);
-            try ctx.strings.append(ctx.allocator, dup);
-            return .{ .string = Value.String.borrowed(dup) };
+            return .{ .string = try Value.String.create(ctx.allocator, num_str) };
         }
         const f = std.fmt.parseFloat(f64, num_str) catch 0.0;
         return .{ .float = f };
@@ -737,6 +735,7 @@ fn parseArray(ctx: *NativeContext, s: []const u8, pos: *usize, assoc: bool, max_
     }
     while (pos.* < s.len) {
         const val = try parseValue(ctx, s, pos, assoc, max_depth, cur_depth + 1, flags);
+        defer if (val == .string) val.string.release();
         try arr.append(ctx.allocator, val);
         skipWhitespace(s, pos);
         if (pos.* < s.len and s[pos.*] == ',') {
@@ -767,7 +766,7 @@ fn parseObject(ctx: *NativeContext, s: []const u8, pos: *usize, assoc: bool, max
     skipWhitespace(s, pos);
 
     if (assoc) {
-        var arr = try ctx.createArray();
+        const arr = try ctx.createArray();
         if (pos.* < s.len and s[pos.*] == '}') {
             pos.* += 1;
             return .{ .array = arr };
@@ -779,6 +778,7 @@ fn parseObject(ctx: *NativeContext, s: []const u8, pos: *usize, assoc: bool, max
                 return error.RuntimeError;
             }
             const key_val = try parseString(ctx, s, pos);
+            defer key_val.string.release();
             const key_str = if (key_val == .string) key_val.string.bytes() else "";
             skipWhitespace(s, pos);
             if (pos.* >= s.len or s[pos.*] != ':') {
@@ -787,7 +787,10 @@ fn parseObject(ctx: *NativeContext, s: []const u8, pos: *usize, assoc: bool, max
             }
             pos.* += 1;
             const val = try parseValue(ctx, s, pos, assoc, max_depth, cur_depth + 1, flags);
-            try arr.set(ctx.allocator, decodeKeyToArrayKey(key_str), val);
+            defer if (val == .string) val.string.release();
+            var key = decodeKeyToArrayKey(key_str);
+            if (key == .string) key.string = key_val.string;
+            try ctx.vm.arraySetOwned(arr, key, val);
             skipWhitespace(s, pos);
             if (pos.* < s.len and s[pos.*] == ',') {
                 pos.* += 1;
@@ -816,6 +819,7 @@ fn parseObject(ctx: *NativeContext, s: []const u8, pos: *usize, assoc: bool, max
             return error.RuntimeError;
         }
         const key_val = try parseString(ctx, s, pos);
+        defer key_val.string.release();
         const key_str = if (key_val == .string) key_val.string.bytes() else "";
         skipWhitespace(s, pos);
         if (pos.* >= s.len or s[pos.*] != ':') {
@@ -824,7 +828,9 @@ fn parseObject(ctx: *NativeContext, s: []const u8, pos: *usize, assoc: bool, max
         }
         pos.* += 1;
         const val = try parseValue(ctx, s, pos, assoc, max_depth, cur_depth + 1, flags);
-        try obj.set(ctx.allocator, key_str, val);
+        defer if (val == .string) val.string.release();
+        const stored_key = if (obj.properties.getKey(key_str)) |existing| existing else try ctx.createString(key_str);
+        try obj.set(ctx.allocator, stored_key, val);
         skipWhitespace(s, pos);
         if (pos.* < s.len and s[pos.*] == ',') {
             pos.* += 1;
@@ -848,8 +854,8 @@ fn throwJsonException(ctx: *NativeContext, msg: []const u8) RuntimeError {
     return error.RuntimeError;
 }
 
-fn json_validate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn json_validate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     const depth: usize = if (args.len >= 2) @intCast(@max(1, Value.toInt(args[1]))) else 512;
     const flags = if (args.len >= 3) Value.toInt(args[2]) else 0;
@@ -858,29 +864,30 @@ fn json_validate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (s.len == 0) {
         last_error = 4;
         last_error_msg = "Syntax error";
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     var pos: usize = 0;
-    _ = parseValue(ctx, s, &pos, true, depth, 0, flags) catch {
+    const parsed = parseValue(ctx, s, &pos, true, depth, 0, flags) catch {
         if (last_error == 0) {
             last_error = 4;
             last_error_msg = "Syntax error";
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
+    defer if (parsed == .string) parsed.string.release();
     skipWhitespace(s, &pos);
     if (pos < s.len) {
         last_error = 4;
         last_error_msg = "Syntax error";
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_json_last_error(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = last_error };
+fn native_json_last_error(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = last_error });
 }
 
-fn native_json_last_error_msg(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed(last_error_msg) };
+fn native_json_last_error_msg(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.copyString(ctx.allocator, last_error_msg);
 }

--- a/src/stdlib/ldap.zig
+++ b/src/stdlib/ldap.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
@@ -61,32 +62,31 @@ fn getResult(obj: *PhpObject) ?*c.LDAPMessage {
     return @ptrFromInt(@as(usize, @intCast(v.int)));
 }
 
-fn cstrToOwned(ctx: *NativeContext, p: ?[*:0]const u8) RuntimeError!Value {
-    if (p == null) return .{ .string = Value.String.borrowed("") };
+fn cstrToOwned(ctx: *NativeContext, p: ?[*:0]const u8) RuntimeError!NativeResult {
+    if (p == null) return NativeResult.literal("");
     const s = std.mem.span(p.?);
     const owned = try ctx.allocator.dupe(u8, s);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
-fn native_connect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_connect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     var uri_buf: [512]u8 = undefined;
     var uri_slice: []const u8 = "ldap://localhost:389";
 
     if (args.len >= 1 and args[0] == .string) {
         const a0 = args[0].string.bytes();
         if (std.mem.indexOf(u8, a0, "://") != null) {
-            uri_slice = std.fmt.bufPrint(&uri_buf, "{s}", .{a0}) catch return .{ .bool = false };
+            uri_slice = std.fmt.bufPrint(&uri_buf, "{s}", .{a0}) catch return NativeResult.scalar(.{ .bool = false });
         } else {
             const port: u16 = if (args.len > 1 and args[1] == .int) @intCast(args[1].int) else 389;
-            uri_slice = std.fmt.bufPrint(&uri_buf, "ldap://{s}:{d}", .{ a0, port }) catch return .{ .bool = false };
+            uri_slice = std.fmt.bufPrint(&uri_buf, "ldap://{s}:{d}", .{ a0, port }) catch return NativeResult.scalar(.{ .bool = false });
         }
     }
 
     const uri_z = try ctx.allocator.dupeZ(u8, uri_slice);
     defer ctx.allocator.free(uri_z);
     var ldap_ptr: ?*c.LDAP = null;
-    if (c.ldap_initialize(&ldap_ptr, uri_z.ptr) != c.LDAP_SUCCESS or ldap_ptr == null) return .{ .bool = false };
+    if (c.ldap_initialize(&ldap_ptr, uri_z.ptr) != c.LDAP_SUCCESS or ldap_ptr == null) return NativeResult.scalar(.{ .bool = false });
 
     // protocol version 3 by default (matches PHP)
     var version: c_int = 3;
@@ -94,12 +94,12 @@ fn native_connect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     const obj = try ctx.createObject("LDAP\\Connection");
     try obj.set(ctx.allocator, "__ptr", .{ .int = @intCast(@intFromPtr(ldap_ptr)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_bind(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
+fn native_bind(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
     const dn: [*:0]const u8 = if (args.len > 1 and args[1] == .string)
         (try ctx.allocator.dupeZ(u8, args[1].string.bytes())).ptr
     else
@@ -111,23 +111,23 @@ fn native_bind(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const rc = c.ldap_simple_bind_s(ld, dn, pw);
     if (rc != c.LDAP_SUCCESS) {
         try o.set(ctx.allocator, "__errno", .{ .int = @intCast(rc) });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_unbind(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = true };
+fn native_unbind(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = true });
     _ = c.ldap_unbind_ext_s(ld, null, null);
     o.set(std.heap.page_allocator, "__ptr", .{ .int = 0 }) catch {};
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn doSearch(ctx: *NativeContext, args: []const Value, scope: c_int) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
-    if (args.len < 3) return .{ .bool = false };
+fn doSearch(ctx: *NativeContext, args: []const Value, scope: c_int) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3) return NativeResult.scalar(.{ .bool = false });
     const base = if (args[1] == .string) args[1].string.bytes() else "";
     const filter = if (args[2] == .string) args[2].string.bytes() else "(objectClass=*)";
     const base_z = try ctx.allocator.dupeZ(u8, base);
@@ -144,6 +144,7 @@ fn doSearch(ctx: *NativeContext, args: []const Value, scope: c_int) RuntimeError
         for (args[3].array.entries.items) |entry| {
             if (entry.value != .string) continue;
             const s = try ctx.allocator.dupeZ(u8, entry.value.string.bytes());
+            errdefer ctx.allocator.free(s);
             try attrs_storage.append(ctx.allocator, s.ptr);
         }
         try attrs_storage.append(ctx.allocator, null);
@@ -155,41 +156,41 @@ fn doSearch(ctx: *NativeContext, args: []const Value, scope: c_int) RuntimeError
     if (rc != c.LDAP_SUCCESS) {
         try o.set(ctx.allocator, "__errno", .{ .int = @intCast(rc) });
         if (result) |r| _ = c.ldap_msgfree(r);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const obj = try ctx.createObject("LDAP\\Result");
     try obj.set(ctx.allocator, "__ptr", .{ .int = @intCast(@intFromPtr(result)) });
     try obj.set(ctx.allocator, "__ld", .{ .int = @intCast(@intFromPtr(ld)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_search(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_search(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return doSearch(ctx, args, c.LDAP_SCOPE_SUBTREE);
 }
-fn native_list(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_list(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return doSearch(ctx, args, c.LDAP_SCOPE_ONELEVEL);
 }
-fn native_read(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_read(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return doSearch(ctx, args, c.LDAP_SCOPE_BASE);
 }
 
-fn native_count_entries(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .object) return .{ .bool = false };
-    const conn = getHandle(args[0..1], "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(conn) orelse return .{ .bool = false };
+fn native_count_entries(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .object) return NativeResult.scalar(.{ .bool = false });
+    const conn = getHandle(args[0..1], "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(conn) orelse return NativeResult.scalar(.{ .bool = false });
     const ro = args[1].object;
-    if (!std.mem.eql(u8, ro.class_name, "LDAP\\Result")) return .{ .bool = false };
-    const r = getResult(ro) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(c.ldap_count_entries(ld, r)) };
+    if (!std.mem.eql(u8, ro.class_name, "LDAP\\Result")) return NativeResult.scalar(.{ .bool = false });
+    const r = getResult(ro) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(c.ldap_count_entries(ld, r)) });
 }
 
-fn native_get_entries(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .object) return .{ .bool = false };
-    const conn = getHandle(args[0..1], "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(conn) orelse return .{ .bool = false };
+fn native_get_entries(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .object) return NativeResult.scalar(.{ .bool = false });
+    const conn = getHandle(args[0..1], "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(conn) orelse return NativeResult.scalar(.{ .bool = false });
     const ro = args[1].object;
-    if (!std.mem.eql(u8, ro.class_name, "LDAP\\Result")) return .{ .bool = false };
-    const r = getResult(ro) orelse return .{ .bool = false };
+    if (!std.mem.eql(u8, ro.class_name, "LDAP\\Result")) return NativeResult.scalar(.{ .bool = false });
+    const r = getResult(ro) orelse return NativeResult.scalar(.{ .bool = false });
 
     const arr = try ctx.createArray();
     var count: i64 = 0;
@@ -203,15 +204,17 @@ fn native_get_entries(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         const e_arr = try ctx.createArray();
         const dn = c.ldap_get_dn(ld, entry);
         if (dn) |d| {
+            defer c.ldap_memfree(d);
             const dn_s = std.mem.span(d);
-            const owned = try ctx.allocator.dupe(u8, dn_s);
-            try ctx.strings.append(ctx.allocator, owned);
-            try e_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("dn") }, .{ .string = Value.String.borrowed(owned) });
-            c.ldap_memfree(d);
+            const owned = try Value.String.create(ctx.allocator, dn_s);
+            defer owned.release();
+            try e_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("dn") }, .{ .string = owned });
         }
 
         var ber: ?*c.BerElement = null;
+        defer if (ber) |b| c.ber_free(b, 0);
         var attr: ?[*:0]u8 = c.ldap_first_attribute(ld, entry, &ber);
+        errdefer if (attr) |attribute| c.ldap_memfree(attribute);
         var attr_count: i64 = 0;
         while (attr != null) : ({
             c.ldap_memfree(attr);
@@ -220,137 +223,141 @@ fn native_get_entries(ctx: *NativeContext, args: []const Value) RuntimeError!Val
             const attr_name = std.mem.span(attr.?);
             const lower_name = try ctx.allocator.dupe(u8, attr_name);
             for (lower_name) |*ch| ch.* = std.ascii.toLower(ch.*);
-            try ctx.strings.append(ctx.allocator, lower_name);
+            const lower_owned = try Value.String.adopt(ctx.allocator, lower_name);
+            defer lower_owned.release();
 
             const values = c.ldap_get_values_len(ld, entry, attr_name);
             const v_arr = try ctx.createArray();
             var vlen: i64 = 0;
             if (values != null) {
+                defer c.ldap_value_free_len(values);
                 var i: usize = 0;
                 while (values[i] != null) : (i += 1) {
                     const bv = values[i];
                     const data = bv.*.bv_val[0..@as(usize, @intCast(bv.*.bv_len))];
-                    const owned_v = try ctx.allocator.dupe(u8, data);
-                    try ctx.strings.append(ctx.allocator, owned_v);
-                    try v_arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .string = Value.String.borrowed(owned_v) });
+                    const owned_v = try Value.String.create(ctx.allocator, data);
+                    defer owned_v.release();
+                    try v_arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .string = owned_v });
                     vlen += 1;
                 }
-                c.ldap_value_free_len(values);
             }
             try v_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("count") }, .{ .int = vlen });
-            try e_arr.set(ctx.allocator, .{ .string = Value.String.borrowed(lower_name) }, .{ .array = v_arr });
-            try e_arr.set(ctx.allocator, .{ .int = attr_count }, .{ .string = Value.String.borrowed(lower_name) });
+            try e_arr.set(ctx.allocator, .{ .string = lower_owned }, .{ .array = v_arr });
+            try e_arr.set(ctx.allocator, .{ .int = attr_count }, .{ .string = lower_owned });
             attr_count += 1;
         }
-        if (ber) |b| c.ber_free(b, 0);
         try e_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("count") }, .{ .int = attr_count });
         try arr.set(ctx.allocator, .{ .int = idx }, .{ .array = e_arr });
     }
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("count") }, .{ .int = count });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn buildLDAPMods(ctx: *NativeContext, dict: *const PhpArray, op: c_int) ![]?*c.LDAPMod {
+fn buildLDAPMods(allocator: std.mem.Allocator, dict: *const PhpArray, op: c_int) ![]?*c.LDAPMod {
     var list = std.ArrayListUnmanaged(?*c.LDAPMod){};
-    errdefer list.deinit(ctx.allocator);
+    errdefer list.deinit(allocator);
     for (dict.entries.items) |entry| {
         const attr_name = switch (entry.key) {
             .string => |s| s.bytes(),
             else => continue,
         };
-        const attr_z = try ctx.allocator.dupeZ(u8, attr_name);
+        const attr_z = try allocator.dupeZ(u8, attr_name);
 
         var vals_storage = std.ArrayListUnmanaged([*c]u8){};
-        errdefer vals_storage.deinit(ctx.allocator);
+        errdefer vals_storage.deinit(allocator);
 
         switch (entry.value) {
             .array => |inner| {
                 for (inner.entries.items) |ie| {
                     if (ie.value != .string) continue;
-                    const sz = try ctx.allocator.dupeZ(u8, ie.value.string.bytes());
-                    try vals_storage.append(ctx.allocator, sz.ptr);
+                    const sz = try allocator.dupeZ(u8, ie.value.string.bytes());
+                    try vals_storage.append(allocator, sz.ptr);
                 }
             },
             .string => |s| {
-                const sz = try ctx.allocator.dupeZ(u8, s.bytes());
-                try vals_storage.append(ctx.allocator, sz.ptr);
+                const sz = try allocator.dupeZ(u8, s.bytes());
+                try vals_storage.append(allocator, sz.ptr);
             },
             else => {},
         }
-        try vals_storage.append(ctx.allocator, null);
+        try vals_storage.append(allocator, null);
 
-        const mod = try ctx.allocator.create(c.LDAPMod);
+        const mod = try allocator.create(c.LDAPMod);
         mod.* = .{
             .mod_op = op,
             .mod_type = attr_z.ptr,
-            .mod_vals = .{ .modv_strvals = (try vals_storage.toOwnedSlice(ctx.allocator)).ptr },
+            .mod_vals = .{ .modv_strvals = (try vals_storage.toOwnedSlice(allocator)).ptr },
         };
-        try list.append(ctx.allocator, mod);
+        try list.append(allocator, mod);
     }
-    try list.append(ctx.allocator, null);
-    return try list.toOwnedSlice(ctx.allocator);
+    try list.append(allocator, null);
+    return try list.toOwnedSlice(allocator);
 }
 
-fn doMod(ctx: *NativeContext, args: []const Value, op: c_int) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
-    if (args.len < 3 or args[1] != .string or args[2] != .array) return .{ .bool = false };
+fn doMod(ctx: *NativeContext, args: []const Value, op: c_int) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3 or args[1] != .string or args[2] != .array) return NativeResult.scalar(.{ .bool = false });
     const dn_z = try ctx.allocator.dupeZ(u8, args[1].string.bytes());
     defer ctx.allocator.free(dn_z);
-    const mods = buildLDAPMods(ctx, args[2].array, op) catch return .{ .bool = false };
+    var temporary = std.heap.ArenaAllocator.init(ctx.allocator);
+    defer temporary.deinit();
+    const mods = buildLDAPMods(temporary.allocator(), args[2].array, op) catch return NativeResult.scalar(.{ .bool = false });
     const rc = c.ldap_modify_ext_s(ld, dn_z.ptr, @ptrCast(mods.ptr), null, null);
     if (rc != c.LDAP_SUCCESS) {
         try o.set(ctx.allocator, "__errno", .{ .int = @intCast(rc) });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_add(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
-    if (args.len < 3 or args[1] != .string or args[2] != .array) return .{ .bool = false };
+fn native_add(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3 or args[1] != .string or args[2] != .array) return NativeResult.scalar(.{ .bool = false });
     const dn_z = try ctx.allocator.dupeZ(u8, args[1].string.bytes());
     defer ctx.allocator.free(dn_z);
-    const mods = buildLDAPMods(ctx, args[2].array, 0) catch return .{ .bool = false };
+    var temporary = std.heap.ArenaAllocator.init(ctx.allocator);
+    defer temporary.deinit();
+    const mods = buildLDAPMods(temporary.allocator(), args[2].array, 0) catch return NativeResult.scalar(.{ .bool = false });
     const rc = c.ldap_add_ext_s(ld, dn_z.ptr, @ptrCast(mods.ptr), null, null);
     if (rc != c.LDAP_SUCCESS) {
         try o.set(ctx.allocator, "__errno", .{ .int = @intCast(rc) });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_modify(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_modify(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return doMod(ctx, args, c.LDAP_MOD_REPLACE);
 }
-fn native_mod_add(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_mod_add(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return doMod(ctx, args, c.LDAP_MOD_ADD);
 }
-fn native_mod_del(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_mod_del(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return doMod(ctx, args, c.LDAP_MOD_DELETE);
 }
 
-fn native_delete(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_delete(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const dn_z = try ctx.allocator.dupeZ(u8, args[1].string.bytes());
     defer ctx.allocator.free(dn_z);
     const rc = c.ldap_delete_ext_s(ld, dn_z.ptr, null, null);
     if (rc != c.LDAP_SUCCESS) {
         try o.set(ctx.allocator, "__errno", .{ .int = @intCast(rc) });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_rename(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
-    if (args.len < 5) return .{ .bool = false };
-    const dn = if (args[1] == .string) args[1].string.bytes() else return .{ .bool = false };
-    const newrdn = if (args[2] == .string) args[2].string.bytes() else return .{ .bool = false };
+fn native_rename(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 5) return NativeResult.scalar(.{ .bool = false });
+    const dn = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const newrdn = if (args[2] == .string) args[2].string.bytes() else return NativeResult.scalar(.{ .bool = false });
     const newparent: ?[*:0]const u8 = if (args[3] == .string) (try ctx.allocator.dupeZ(u8, args[3].string.bytes())).ptr else null;
     const delete_old: c_int = if (args[4] == .bool) (if (args[4].bool) 1 else 0) else 0;
     const dn_z = try ctx.allocator.dupeZ(u8, dn);
@@ -360,87 +367,87 @@ fn native_rename(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const rc = c.ldap_rename_s(ld, dn_z.ptr, new_z.ptr, newparent, delete_old, null, null);
     if (rc != c.LDAP_SUCCESS) {
         try o.set(ctx.allocator, "__errno", .{ .int = @intCast(rc) });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_compare(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .int = -1 };
-    const ld = getLdap(o) orelse return .{ .int = -1 };
-    if (args.len < 4 or args[1] != .string or args[2] != .string or args[3] != .string) return .{ .int = -1 };
+fn native_compare(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .int = -1 });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .int = -1 });
+    if (args.len < 4 or args[1] != .string or args[2] != .string or args[3] != .string) return NativeResult.scalar(.{ .int = -1 });
     const dn_z = try ctx.allocator.dupeZ(u8, args[1].string.bytes());
     defer ctx.allocator.free(dn_z);
     const attr_z = try ctx.allocator.dupeZ(u8, args[2].string.bytes());
     defer ctx.allocator.free(attr_z);
     var bval = c.berval{ .bv_len = args[3].string.bytes().len, .bv_val = @constCast(args[3].string.bytes().ptr) };
     const rc = c.ldap_compare_ext_s(ld, dn_z.ptr, attr_z.ptr, &bval, null, null);
-    if (rc == c.LDAP_COMPARE_TRUE) return .{ .bool = true };
-    if (rc == c.LDAP_COMPARE_FALSE) return .{ .bool = false };
-    return .{ .int = -1 };
+    if (rc == c.LDAP_COMPARE_TRUE) return NativeResult.scalar(.{ .bool = true });
+    if (rc == c.LDAP_COMPARE_FALSE) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = -1 });
 }
 
-fn native_set_option(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .object or args[1] != .int) return .{ .bool = false };
-    const o = getHandle(args[0..1], "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
+fn native_set_option(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
+    const o = getHandle(args[0..1], "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
     const opt: c_int = @intCast(args[1].int);
     switch (args[2]) {
         .int, .bool => {
             var v: c_int = if (args[2] == .int) @intCast(args[2].int) else @intFromBool(args[2].bool);
-            return .{ .bool = c.ldap_set_option(ld, opt, &v) == c.LDAP_OPT_SUCCESS };
+            return NativeResult.scalar(.{ .bool = c.ldap_set_option(ld, opt, &v) == c.LDAP_OPT_SUCCESS });
         },
         .string => {
             const sz = try ctx.allocator.dupeZ(u8, args[2].string.bytes());
             defer ctx.allocator.free(sz);
-            return .{ .bool = c.ldap_set_option(ld, opt, sz.ptr) == c.LDAP_OPT_SUCCESS };
+            return NativeResult.scalar(.{ .bool = c.ldap_set_option(ld, opt, sz.ptr) == c.LDAP_OPT_SUCCESS });
         },
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     }
 }
 
-fn native_get_option(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .object or args[1] != .int) return .{ .bool = false };
-    const o = getHandle(args[0..1], "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
+fn native_get_option(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .object or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
+    const o = getHandle(args[0..1], "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
     const opt: c_int = @intCast(args[1].int);
     var v: c_int = 0;
-    if (c.ldap_get_option(ld, opt, &v) != c.LDAP_OPT_SUCCESS) return .{ .bool = false };
+    if (c.ldap_get_option(ld, opt, &v) != c.LDAP_OPT_SUCCESS) return NativeResult.scalar(.{ .bool = false });
     ctx.setCallerVar(2, args.len, .{ .int = @intCast(v) });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_err2str(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .string = Value.String.borrowed("") };
+fn native_err2str(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.literal("");
     const s = c.ldap_err2string(@intCast(args[0].int));
     return try cstrToOwned(ctx, s);
 }
 
-fn native_errno(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .int = 0 };
+fn native_errno(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .int = 0 });
     const v = o.get("__errno");
-    if (v == .int) return v;
-    return .{ .int = 0 };
+    if (v == .int) return NativeResult.scalar(v);
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_error(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_error(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const v = try native_errno(ctx, args);
-    return try native_err2str(ctx, &[_]Value{v});
+    return try native_err2str(ctx, &[_]Value{v.value});
 }
 
-fn native_start_tls(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getHandle(args, "LDAP\\Connection") orelse return .{ .bool = false };
-    const ld = getLdap(o) orelse return .{ .bool = false };
+fn native_start_tls(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
+    const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = false });
     const rc = c.ldap_start_tls_s(ld, null, null);
     if (rc != c.LDAP_SUCCESS) {
         try o.set(ctx.allocator, "__errno", .{ .int = @intCast(rc) });
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_escape(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_escape(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.literal("");
     const v = args[0].string.bytes();
     const ignore: []const u8 = if (args.len > 1 and args[1] == .string) args[1].string.bytes() else "";
     const flags: i64 = if (args.len > 2 and args[2] == .int) args[2].int else 0;
@@ -466,52 +473,51 @@ fn native_escape(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         } else try out.append(ctx.allocator, ch);
     }
     const owned = try out.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
-fn native_free_result(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
+fn native_free_result(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const o = args[0].object;
-    if (!std.mem.eql(u8, o.class_name, "LDAP\\Result")) return .{ .bool = false };
-    const r = getResult(o) orelse return .{ .bool = true };
+    if (!std.mem.eql(u8, o.class_name, "LDAP\\Result")) return NativeResult.scalar(.{ .bool = false });
+    const r = getResult(o) orelse return NativeResult.scalar(.{ .bool = true });
     _ = c.ldap_msgfree(r);
     o.set(std.heap.page_allocator, "__ptr", .{ .int = 0 }) catch {};
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_explode_dn(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_explode_dn(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const with_attrib: c_int = if (args.len > 1 and args[1] == .int) @intCast(args[1].int) else 1;
     const dn_z = try ctx.allocator.dupeZ(u8, args[0].string.bytes());
     defer ctx.allocator.free(dn_z);
     const parts = c.ldap_explode_dn(dn_z.ptr, with_attrib);
-    if (parts == null) return .{ .bool = false };
+    if (parts == null) return NativeResult.scalar(.{ .bool = false });
     defer c.ldap_memvfree(@ptrCast(parts));
     const arr = try ctx.createArray();
     var i: usize = 0;
     while (parts[i] != null) : (i += 1) {
         const s = std.mem.span(parts[i]);
-        const owned = try ctx.allocator.dupe(u8, s);
-        try ctx.strings.append(ctx.allocator, owned);
-        try arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .string = Value.String.borrowed(owned) });
+        const owned = try Value.String.create(ctx.allocator, s);
+        defer owned.release();
+        try arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .string = owned });
     }
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("count") }, .{ .int = @intCast(i) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_dn2ufn(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_dn2ufn(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const dn_z = try ctx.allocator.dupeZ(u8, args[0].string.bytes());
     defer ctx.allocator.free(dn_z);
     const ufn = c.ldap_dn2ufn(dn_z.ptr);
-    if (ufn == null) return .{ .bool = false };
+    if (ufn == null) return NativeResult.scalar(.{ .bool = false });
     defer c.ldap_memfree(ufn);
     return try cstrToOwned(ctx, ufn);
 }
 
-fn native_count_references(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn native_count_references(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {

--- a/src/stdlib/math.zig
+++ b/src/stdlib/math.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
@@ -79,10 +80,10 @@ fn requireNumeric(ctx: *NativeContext, v: Value, comptime fn_name: []const u8, c
     return true;
 }
 
-fn native_abs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn native_abs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
     if (try requireNumeric(ctx, args[0], "abs", "int|float")) return error.RuntimeError;
-    return switch (args[0]) {
+    return NativeResult.scalar(switch (args[0]) {
         .int => |i| if (i == std.math.minInt(i64))
             .{ .float = -@as(f64, @floatFromInt(i)) }
         else
@@ -101,21 +102,21 @@ fn native_abs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             if (i == std.math.minInt(i64)) break :blk Value{ .float = -@as(f64, @floatFromInt(i)) };
             break :blk Value{ .int = if (i < 0) -i else i };
         },
-    };
+    });
 }
 
-fn native_floor(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = @floor(Value.toFloat(args[0])) };
+fn native_floor(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = @floor(Value.toFloat(args[0])) });
 }
 
-fn native_ceil(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = @ceil(Value.toFloat(args[0])) };
+fn native_ceil(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = @ceil(Value.toFloat(args[0])) });
 }
 
-fn native_round(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_round(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const v = Value.toFloat(args[0]);
     const precision: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     // PHP 8.4 accepts a RoundingMode enum case for the mode arg; map case
@@ -136,7 +137,7 @@ fn native_round(_: *NativeContext, args: []const Value) RuntimeError!Value {
     const factor = std.math.pow(f64, 10.0, @floatFromInt(precision));
     const scaled = v * factor;
     const rounded = roundWithMode(scaled, mode);
-    return .{ .float = rounded / factor };
+    return NativeResult.scalar(.{ .float = rounded / factor });
 }
 
 fn roundWithMode(v: f64, mode: i64) f64 {
@@ -171,8 +172,8 @@ fn roundWithMode(v: f64, mode: i64) f64 {
     return out * sign;
 }
 
-fn native_min(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn native_min(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     if (args.len == 1 and args[0] == .array) {
         const arr = args[0].array;
         if (arr.entries.items.len == 0) {
@@ -183,17 +184,17 @@ fn native_min(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         for (arr.entries.items[1..]) |e| {
             if (Value.lessThan(e.value, result)) result = e.value;
         }
-        return result;
+        return NativeResult.share(result);
     }
     var result = args[0];
     for (args[1..]) |a| {
         if (Value.lessThan(a, result)) result = a;
     }
-    return result;
+    return NativeResult.share(result);
 }
 
-fn native_max(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn native_max(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     if (args.len == 1 and args[0] == .array) {
         const arr = args[0].array;
         if (arr.entries.items.len == 0) {
@@ -204,34 +205,34 @@ fn native_max(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         for (arr.entries.items[1..]) |e| {
             if (Value.lessThan(result, e.value)) result = e.value;
         }
-        return result;
+        return NativeResult.share(result);
     }
     var result = args[0];
     for (args[1..]) |a| {
         if (Value.lessThan(result, a)) result = a;
     }
-    return result;
+    return NativeResult.share(result);
 }
 
-fn native_lcg_value(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .float = std.crypto.random.float(f64) };
+fn native_lcg_value(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .float = std.crypto.random.float(f64) });
 }
 
-fn native_srand_noop(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_srand_noop(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const seed: u32 = if (args.len >= 1) blk: {
         const v = Value.toInt(args[0]);
         break :blk @as(u32, @truncate(@as(u64, @bitCast(v))));
     } else @truncate(@as(u64, @intCast(std.time.timestamp())));
     ctx.vm.mt19937.seed(seed);
     ctx.vm.rng_seeded = true;
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_getrandmax(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 2147483647 };
+fn native_getrandmax(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 2147483647 });
 }
 
-fn native_rand(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_rand(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (!ctx.vm.rng_seeded) {
         var entropy: [4]u8 = undefined;
         std.crypto.random.bytes(&entropy);
@@ -242,80 +243,80 @@ fn native_rand(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const lo: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     const hi: i64 = if (args.len >= 2) Value.toInt(args[1]) else 2147483647;
     // mt_rand() with no args returns a 31-bit value
-    if (args.len < 2) return .{ .int = ctx.vm.mt19937.next31() };
+    if (args.len < 2) return NativeResult.scalar(.{ .int = ctx.vm.mt19937.next31() });
     // PHP 8+: mt_rand throws ValueError if max < min. rand silently swaps
     // (a historical alias quirk preserved for back-compat). distinguish by
     // the calling-name in ctx.call_name
     if (lo > hi) {
         const fn_name: []const u8 = if (ctx.call_name) |c| c else "mt_rand";
         if (std.mem.eql(u8, fn_name, "rand")) {
-            return .{ .int = ctx.vm.mt19937.nextRange(hi, lo) };
+            return NativeResult.scalar(.{ .int = ctx.vm.mt19937.nextRange(hi, lo) });
         }
         const msg = try std.fmt.allocPrint(ctx.allocator, "{s}(): Argument #2 ($max) must be greater than or equal to argument #1 ($min)", .{fn_name});
         try ctx.vm.strings.append(ctx.allocator, msg);
         try ctx.vm.setPendingException("ValueError", msg);
         return error.RuntimeError;
     }
-    if (lo == hi) return .{ .int = lo };
-    return .{ .int = ctx.vm.mt19937.nextRange(lo, hi) };
+    if (lo == hi) return NativeResult.scalar(.{ .int = lo });
+    return NativeResult.scalar(.{ .int = ctx.vm.mt19937.nextRange(lo, hi) });
 }
 
-fn native_pow(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
-    return Value.power(args[0], args[1]);
+fn native_pow(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(Value.power(args[0], args[1]));
 }
 
-fn native_sqrt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_sqrt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     if (try requireNumeric(ctx, args[0], "sqrt", "float")) return error.RuntimeError;
-    return .{ .float = @sqrt(Value.toFloat(args[0])) };
+    return NativeResult.scalar(.{ .float = @sqrt(Value.toFloat(args[0])) });
 }
 
-fn native_log(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_log(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const v = Value.toFloat(args[0]);
     if (args.len >= 2) {
         const base = Value.toFloat(args[1]);
-        return .{ .float = @log(v) / @log(base) };
+        return NativeResult.scalar(.{ .float = @log(v) / @log(base) });
     }
-    return .{ .float = @log(v) };
+    return NativeResult.scalar(.{ .float = @log(v) });
 }
 
-fn native_log10(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = std.math.log10(Value.toFloat(args[0])) };
+fn native_log10(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = std.math.log10(Value.toFloat(args[0])) });
 }
 
-fn native_log1p(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = std.math.log1p(Value.toFloat(args[0])) };
+fn native_log1p(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = std.math.log1p(Value.toFloat(args[0])) });
 }
 
-fn native_expm1(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_expm1(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
-    return .{ .float = @exp(x) - 1.0 };
+    return NativeResult.scalar(.{ .float = @exp(x) - 1.0 });
 }
 
-fn native_exp(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 1.0 };
-    return .{ .float = @exp(Value.toFloat(args[0])) };
+fn native_exp(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 1.0 });
+    return NativeResult.scalar(.{ .float = @exp(Value.toFloat(args[0])) });
 }
 
-fn native_pi(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .float = std.math.pi };
+fn native_pi(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .float = std.math.pi });
 }
 
-fn native_fmod(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .float = 0.0 };
+fn native_fmod(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
     const y = Value.toFloat(args[1]);
-    if (y == 0.0) return .{ .float = std.math.nan(f64) };
-    return .{ .float = @rem(x, y) };
+    if (y == 0.0) return NativeResult.scalar(.{ .float = std.math.nan(f64) });
+    return NativeResult.scalar(.{ .float = @rem(x, y) });
 }
 
-fn native_intdiv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
+fn native_intdiv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
     const a = Value.toInt(args[0]);
     const b = Value.toInt(args[1]);
     if (b == 0) {
@@ -326,16 +327,16 @@ fn native_intdiv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("ArithmeticError", "Division of PHP_INT_MIN by -1 is not an integer");
         return error.RuntimeError;
     }
-    return .{ .int = @divTrunc(a, b) };
+    return NativeResult.scalar(.{ .int = @divTrunc(a, b) });
 }
 
-fn native_base_convert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .{ .string = Value.String.borrowed("0") };
-    var num_str = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("0") };
+fn native_base_convert(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.literal("0");
+    var num_str = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("0");
     const from_base: u8 = @intCast(@max(2, @min(36, Value.toInt(args[1]))));
     const to_base: u8 = @intCast(@max(2, @min(36, Value.toInt(args[2]))));
     if (num_str.len > 0 and (num_str[0] == '-' or num_str[0] == '+')) num_str = num_str[1..];
-    const val = std.fmt.parseInt(u64, num_str, from_base) catch return Value{ .string = Value.String.borrowed("0") };
+    const val = std.fmt.parseInt(u64, num_str, from_base) catch return NativeResult.literal("0");
     const digits = "0123456789abcdefghijklmnopqrstuvwxyz";
     var buf: [65]u8 = undefined;
     var pos: usize = buf.len;
@@ -350,7 +351,7 @@ fn native_base_convert(ctx: *NativeContext, args: []const Value) RuntimeError!Va
             v /= to_base;
         }
     }
-    return .{ .string = Value.String.borrowed(try ctx.createString(buf[pos..])) };
+    return NativeResult.copyString(ctx.allocator, buf[pos..]);
 }
 
 // parses digits in `base`, returning int if it fits in i64 and float on
@@ -390,173 +391,173 @@ fn baseDecimal(s: []const u8, base: u8) Value {
     return .{ .int = @intCast(int_val) };
 }
 
-fn native_bindec(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
-    return baseDecimal(s, 2);
+fn native_bindec(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
+    return NativeResult.scalar(baseDecimal(s, 2));
 }
 
-fn native_octdec(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
-    return baseDecimal(s, 8);
+fn native_octdec(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
+    return NativeResult.scalar(baseDecimal(s, 8));
 }
 
-fn native_hexdec(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
-    return baseDecimal(s, 16);
+fn native_hexdec(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
+    return NativeResult.scalar(baseDecimal(s, 16));
 }
 
-fn native_decbin(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("0") };
+fn native_decbin(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("0");
     const val = Value.toInt(args[0]);
     var buf: [65]u8 = undefined;
-    const s = std.fmt.bufPrint(&buf, "{b}", .{@as(u64, @bitCast(val))}) catch return Value{ .string = Value.String.borrowed("0") };
-    return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+    const s = std.fmt.bufPrint(&buf, "{b}", .{@as(u64, @bitCast(val))}) catch return NativeResult.literal("0");
+    return NativeResult.copyString(ctx.allocator, s);
 }
 
-fn native_decoct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("0") };
+fn native_decoct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("0");
     const val = Value.toInt(args[0]);
     var buf: [32]u8 = undefined;
-    const s = std.fmt.bufPrint(&buf, "{o}", .{@as(u64, @bitCast(val))}) catch return Value{ .string = Value.String.borrowed("0") };
-    return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+    const s = std.fmt.bufPrint(&buf, "{o}", .{@as(u64, @bitCast(val))}) catch return NativeResult.literal("0");
+    return NativeResult.copyString(ctx.allocator, s);
 }
 
-fn native_dechex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("0") };
+fn native_dechex(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("0");
     const val = Value.toInt(args[0]);
     var buf: [17]u8 = undefined;
-    const s = std.fmt.bufPrint(&buf, "{x}", .{@as(u64, @bitCast(val))}) catch return Value{ .string = Value.String.borrowed("0") };
-    return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+    const s = std.fmt.bufPrint(&buf, "{x}", .{@as(u64, @bitCast(val))}) catch return NativeResult.literal("0");
+    return NativeResult.copyString(ctx.allocator, s);
 }
 
-fn native_sin(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = @sin(Value.toFloat(args[0])) };
+fn native_sin(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = @sin(Value.toFloat(args[0])) });
 }
 
-fn native_cos(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = @cos(Value.toFloat(args[0])) };
+fn native_cos(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = @cos(Value.toFloat(args[0])) });
 }
 
-fn native_tan(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = @tan(Value.toFloat(args[0])) };
+fn native_tan(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = @tan(Value.toFloat(args[0])) });
 }
 
-fn native_asin(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = std.math.asin(Value.toFloat(args[0])) };
+fn native_asin(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = std.math.asin(Value.toFloat(args[0])) });
 }
 
-fn native_acos(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = std.math.acos(Value.toFloat(args[0])) };
+fn native_acos(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = std.math.acos(Value.toFloat(args[0])) });
 }
 
-fn native_atan(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = std.math.atan(Value.toFloat(args[0])) };
+fn native_atan(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = std.math.atan(Value.toFloat(args[0])) });
 }
 
-fn native_atan2(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .float = 0.0 };
-    return .{ .float = std.math.atan2(Value.toFloat(args[0]), Value.toFloat(args[1])) };
+fn native_atan2(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = std.math.atan2(Value.toFloat(args[0]), Value.toFloat(args[1])) });
 }
 
-fn native_sinh(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_sinh(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
-    return .{ .float = (@exp(x) - @exp(-x)) / 2.0 };
+    return NativeResult.scalar(.{ .float = (@exp(x) - @exp(-x)) / 2.0 });
 }
 
-fn native_cosh(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_cosh(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
-    return .{ .float = (@exp(x) + @exp(-x)) / 2.0 };
+    return NativeResult.scalar(.{ .float = (@exp(x) + @exp(-x)) / 2.0 });
 }
 
-fn native_tanh(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_tanh(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
     const ex = @exp(x);
     const enx = @exp(-x);
-    return .{ .float = (ex - enx) / (ex + enx) };
+    return NativeResult.scalar(.{ .float = (ex - enx) / (ex + enx) });
 }
 
-fn native_asinh(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_asinh(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
-    return .{ .float = @log(x + @sqrt(x * x + 1.0)) };
+    return NativeResult.scalar(.{ .float = @log(x + @sqrt(x * x + 1.0)) });
 }
 
-fn native_acosh(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_acosh(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
-    if (x < 1.0) return .{ .float = std.math.nan(f64) };
-    return .{ .float = @log(x + @sqrt(x * x - 1.0)) };
+    if (x < 1.0) return NativeResult.scalar(.{ .float = std.math.nan(f64) });
+    return NativeResult.scalar(.{ .float = @log(x + @sqrt(x * x - 1.0)) });
 }
 
-fn native_atanh(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
+fn native_atanh(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
-    if (x <= -1.0 or x >= 1.0) return .{ .float = if (x == 1.0) std.math.inf(f64) else if (x == -1.0) -std.math.inf(f64) else std.math.nan(f64) };
-    return .{ .float = 0.5 * @log((1.0 + x) / (1.0 - x)) };
+    if (x <= -1.0 or x >= 1.0) return NativeResult.scalar(.{ .float = if (x == 1.0) std.math.inf(f64) else if (x == -1.0) -std.math.inf(f64) else std.math.nan(f64) });
+    return NativeResult.scalar(.{ .float = 0.5 * @log((1.0 + x) / (1.0 - x)) });
 }
 
-fn native_deg2rad(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = Value.toFloat(args[0]) * (std.math.pi / 180.0) };
+fn native_deg2rad(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = Value.toFloat(args[0]) * (std.math.pi / 180.0) });
 }
 
-fn native_rad2deg(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = Value.toFloat(args[0]) * (180.0 / std.math.pi) };
+fn native_rad2deg(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = Value.toFloat(args[0]) * (180.0 / std.math.pi) });
 }
 
-fn native_hypot(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .float = 0.0 };
+fn native_hypot(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .float = 0.0 });
     const x = Value.toFloat(args[0]);
     const y = Value.toFloat(args[1]);
-    return .{ .float = @sqrt(x * x + y * y) };
+    return NativeResult.scalar(.{ .float = @sqrt(x * x + y * y) });
 }
 
-fn native_is_finite(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = true };
-    return .{ .bool = switch (args[0]) {
+fn native_is_finite(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = switch (args[0]) {
         .float => |f| !std.math.isNan(f) and !std.math.isInf(f),
         .int => true,
         else => true,
-    } };
+    } });
 }
 
-fn native_is_infinite(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    return .{ .bool = switch (args[0]) {
+fn native_is_infinite(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = switch (args[0]) {
         .float => |f| std.math.isInf(f),
         else => false,
-    } };
+    } });
 }
 
-fn native_is_nan(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    return .{ .bool = switch (args[0]) {
+fn native_is_nan(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = switch (args[0]) {
         .float => |f| std.math.isNan(f),
         else => false,
-    } };
+    } });
 }
 
-fn native_fpow(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .float = 0.0 };
-    return .{ .float = std.math.pow(f64, Value.toFloat(args[0]), Value.toFloat(args[1])) };
+fn native_fpow(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = std.math.pow(f64, Value.toFloat(args[0]), Value.toFloat(args[1])) });
 }
 
-fn native_fdiv(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .float = 0.0 };
+fn native_fdiv(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .float = 0.0 });
     const num = Value.toFloat(args[0]);
     const den = Value.toFloat(args[1]);
-    return .{ .float = num / den };
+    return NativeResult.scalar(.{ .float = num / den });
 }

--- a/src/stdlib/mysqli.zig
+++ b/src/stdlib/mysqli.zig
@@ -11,6 +11,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -111,7 +112,7 @@ fn setErrorState(ctx: *NativeContext, obj: *PhpObject, conn: ?*mysql.MYSQL) !voi
 
 // ---------- procedural API ----------
 
-fn mysqliInit(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn mysqliInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("mysqli");
     if (mysql.mysql_init(null)) |c| {
         try obj.set(ctx.allocator, "__conn", .{ .int = @intCast(@intFromPtr(c)) });
@@ -121,7 +122,7 @@ fn mysqliInit(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try obj.set(ctx.allocator, "error", .{ .string = Value.String.borrowed("") });
     try obj.set(ctx.allocator, "errno", .{ .int = 0 });
     try obj.set(ctx.allocator, "__connected", .{ .bool = false });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 // shared connect path used by mysqli_connect and mysqli::__construct
@@ -180,7 +181,7 @@ fn argOptInt(args: []const Value, idx: usize, default: i64) i64 {
     };
 }
 
-fn mysqliConnect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn mysqliConnect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("mysqli");
     try obj.set(ctx.allocator, "error", .{ .string = Value.String.borrowed("") });
     try obj.set(ctx.allocator, "errno", .{ .int = 0 });
@@ -194,14 +195,14 @@ fn mysqliConnect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const socket = argOptString(args, 5);
 
     const ok = try doConnect(ctx, obj, host, user, pass, db, port, socket);
-    if (!ok) return .{ .bool = false };
-    return .{ .object = obj };
+    if (!ok) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn mysqliRealConnect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn mysqliRealConnect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // procedural variant takes the link as arg 0; the method form puts the
     // link in $this. linkObj resolves both
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     const offset: usize = if (args.len > 0 and args[0] == .object) 1 else 0;
     const host = argOptString(args, offset + 0);
     const user = argOptString(args, offset + 1);
@@ -209,11 +210,11 @@ fn mysqliRealConnect(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     const db = argOptString(args, offset + 3);
     const port: u32 = @intCast(argOptInt(args, offset + 4, 3306));
     const socket = argOptString(args, offset + 5);
-    return .{ .bool = try doConnect(ctx, link, host, user, pass, db, port, socket) };
+    return NativeResult.scalar(.{ .bool = try doConnect(ctx, link, host, user, pass, db, port, socket) });
 }
 
-fn mysqliClose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
+fn mysqliClose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     if (getConn(link)) |c| {
         // mysql_close is safe to call on a handle returned by mysql_init even
         // when never connected — releases the allocated handle either way
@@ -221,21 +222,21 @@ fn mysqliClose(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try link.set(ctx.allocator, "__conn", .{ .int = 0 });
         try link.set(ctx.allocator, "__connected", .{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
-    const conn = getConn(link) orelse return .{ .bool = false };
-    if (!isConnected(link)) return .{ .bool = false };
+fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .bool = false });
     // determine which arg holds the SQL
     const sql_arg: Value = if (args.len > 0 and args[0] == .object) (if (args.len > 1) args[1] else .null) else if (args.len > 0) args[0] else .null;
-    if (sql_arg != .string) return .{ .bool = false };
+    if (sql_arg != .string) return NativeResult.scalar(.{ .bool = false });
     const sql = sql_arg.string.bytes();
     if (mysql.mysql_real_query(conn, sql.ptr, @intCast(sql.len)) != 0) {
         try setErrorState(ctx, link, conn);
         try reportFailure(ctx, conn, "mysqli_query", false);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     try setErrorState(ctx, link, conn);
     // expose state PHP makes available as object properties on the mysqli link.
@@ -250,7 +251,7 @@ fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (res_opt == null and mysql.mysql_errno(conn) != 0) {
         try setErrorState(ctx, link, conn);
         try reportFailure(ctx, conn, "mysqli_query", false);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     // Use the installed client header rather than guessing MYSQL's ABI layout.
     if (reportMode(ctx) & 4 != 0) {
@@ -271,7 +272,7 @@ fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             ctx.vm.emitWarning(message);
         }
     }
-    const res = res_opt orelse return .{ .bool = true };
+    const res = res_opt orelse return NativeResult.scalar(.{ .bool = true });
 
     const result_obj = try ctx.createObject("mysqli_result");
     try result_obj.set(ctx.allocator, "__res", .{ .int = @intCast(@intFromPtr(res)) });
@@ -281,7 +282,7 @@ fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // mysqli_result exposes the column count as `field_count` in PHP. keep
     // both spellings populated so user code that reaches for either works
     try result_obj.set(ctx.allocator, "field_count", .{ .int = nf });
-    return .{ .object = result_obj };
+    return NativeResult.borrowed(.{ .object = result_obj });
 }
 
 // row fetch shared between fetch_array / fetch_assoc / fetch_row
@@ -319,26 +320,26 @@ fn fetchRow(ctx: *NativeContext, result_obj: *PhpObject, flags: u8) !Value {
     return .{ .array = arr };
 }
 
-fn mysqliFetchAssoc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const result_obj = linkObj(ctx, args, 0) orelse return .null;
-    return try fetchRow(ctx, result_obj, 1);
+fn mysqliFetchAssoc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const result_obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(try fetchRow(ctx, result_obj, 1));
 }
 
-fn mysqliFetchArray(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const result_obj = linkObj(ctx, args, 0) orelse return .null;
+fn mysqliFetchArray(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const result_obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.null);
     // procedural form has optional mode at args[1]; method form at args[0]
     const mode_arg: i64 = if (args.len > 0 and args[0] == .object) argOptInt(args, 1, 3) else argOptInt(args, 0, 3);
     const flags: u8 = @intCast(@as(u64, @bitCast(mode_arg)) & 3);
-    return try fetchRow(ctx, result_obj, if (flags == 0) 3 else flags);
+    return NativeResult.borrowed(try fetchRow(ctx, result_obj, if (flags == 0) 3 else flags));
 }
 
-fn mysqliFetchRow(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const result_obj = linkObj(ctx, args, 0) orelse return .null;
-    return try fetchRow(ctx, result_obj, 2);
+fn mysqliFetchRow(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const result_obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(try fetchRow(ctx, result_obj, 2));
 }
 
-fn mysqliFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const result_obj = linkObj(ctx, args, 0) orelse return .{ .array = try ctx.createArray() };
+fn mysqliFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const result_obj = linkObj(ctx, args, 0) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const mode_arg: i64 = if (args.len > 0 and args[0] == .object) argOptInt(args, 1, 2) else argOptInt(args, 0, 2);
     const flags: u8 = @intCast(@as(u64, @bitCast(mode_arg)) & 3);
     const eff: u8 = if (flags == 0) 2 else flags;
@@ -348,53 +349,53 @@ fn mysqliFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (row == .null) break;
         try out.append(ctx.allocator, row);
     }
-    return .{ .array = out };
+    return NativeResult.borrowed(.{ .array = out });
 }
 
-fn mysqliNumRows(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const result_obj = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
+fn mysqliNumRows(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const result_obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
     const v = result_obj.get("num_rows");
-    return if (v == .int) v else .{ .int = 0 };
+    return if (v == .int) NativeResult.share(v) else NativeResult.scalar(.{ .int = 0 });
 }
 
-fn mysqliAffectedRows(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
-    const c = getConn(link) orelse return .{ .int = 0 };
-    if (!isConnected(link)) return .{ .int = 0 };
+fn mysqliAffectedRows(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
+    const c = getConn(link) orelse return NativeResult.scalar(.{ .int = 0 });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .int = 0 });
     const raw = mysql.mysql_affected_rows(c);
-    return .{ .int = if (raw == std.math.maxInt(u64)) -1 else @intCast(raw) };
+    return NativeResult.scalar(.{ .int = if (raw == std.math.maxInt(u64)) -1 else @intCast(raw) });
 }
 
-fn mysqliInsertId(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
-    const c = getConn(link) orelse return .{ .int = 0 };
-    if (!isConnected(link)) return .{ .int = 0 };
-    return .{ .int = @intCast(mysql.mysql_insert_id(c)) };
+fn mysqliInsertId(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
+    const c = getConn(link) orelse return NativeResult.scalar(.{ .int = 0 });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(mysql.mysql_insert_id(c)) });
 }
 
-fn mysqliError(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .string = Value.String.borrowed("") };
-    return link.get("error");
+fn mysqliError(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.literal("");
+    return NativeResult.share(link.get("error"));
 }
 
-fn mysqliErrno(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
-    return link.get("errno");
+fn mysqliErrno(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(link.get("errno"));
 }
 
-fn mysqliConnectError(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn mysqliConnectError(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     _ = ctx;
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn mysqliConnectErrno(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn mysqliConnectErrno(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn mysqliRealEscapeString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .string = Value.String.borrowed("") };
+fn mysqliRealEscapeString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.literal("");
     const str_arg: Value = if (args.len > 0 and args[0] == .object) (if (args.len > 1) args[1] else .null) else if (args.len > 0) args[0] else .null;
-    if (str_arg != .string) return .{ .string = Value.String.borrowed("") };
+    if (str_arg != .string) return NativeResult.literal("");
     const conn = getConn(link) orelse return try fallbackEscape(ctx, str_arg.string.bytes());
     if (!isConnected(link)) return try fallbackEscape(ctx, str_arg.string.bytes());
     const src = str_arg.string.bytes();
@@ -403,11 +404,10 @@ fn mysqliRealEscapeString(ctx: *NativeContext, args: []const Value) RuntimeError
     const out = buf[0..@intCast(written)];
     const owned = try ctx.allocator.dupe(u8, out);
     ctx.allocator.free(buf);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
-fn fallbackEscape(ctx: *NativeContext, src: []const u8) !Value {
+fn fallbackEscape(ctx: *NativeContext, src: []const u8) RuntimeError!NativeResult {
     var buf = std.ArrayListUnmanaged(u8){};
     defer buf.deinit(ctx.allocator);
     for (src) |c| {
@@ -425,59 +425,53 @@ fn fallbackEscape(ctx: *NativeContext, src: []const u8) !Value {
             else => try buf.append(ctx.allocator, c),
         }
     }
-    const owned = try ctx.allocator.dupe(u8, buf.items);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, buf.items);
 }
 
-fn mysqliSelectDb(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
-    const conn = getConn(link) orelse return .{ .bool = false };
-    if (!isConnected(link)) return .{ .bool = false };
+fn mysqliSelectDb(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .bool = false });
     const db_arg: Value = if (args.len > 0 and args[0] == .object) (if (args.len > 1) args[1] else .null) else if (args.len > 0) args[0] else .null;
-    if (db_arg != .string) return .{ .bool = false };
+    if (db_arg != .string) return NativeResult.scalar(.{ .bool = false });
     const db_z = try dupZ(ctx, db_arg.string.bytes());
     const rc = mysql.mysql_select_db(conn, db_z.ptr);
     if (rc != 0) {
         try setErrorState(ctx, link, conn);
         try reportFailure(ctx, conn, "mysqli_select_db", false);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn mysqliSetCharset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
-    const conn = getConn(link) orelse return .{ .bool = false };
-    if (!isConnected(link)) return .{ .bool = false };
+fn mysqliSetCharset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .bool = false });
     const cs_arg: Value = if (args.len > 0 and args[0] == .object) (if (args.len > 1) args[1] else .null) else if (args.len > 0) args[0] else .null;
-    if (cs_arg != .string) return .{ .bool = false };
+    if (cs_arg != .string) return NativeResult.scalar(.{ .bool = false });
     const cs_z = try dupZ(ctx, cs_arg.string.bytes());
     // mysql_set_charset was removed in libmysqlclient 8.x. mysql_options
     // with MYSQL_SET_CHARSET_NAME is the supported equivalent; it accepts a
     // C string pointer (cast through anyopaque)
-    return .{ .bool = mysql.mysql_options(conn, mysql.MYSQL_SET_CHARSET_NAME, @ptrCast(cs_z.ptr)) == 0 };
+    return NativeResult.scalar(.{ .bool = mysql.mysql_options(conn, mysql.MYSQL_SET_CHARSET_NAME, @ptrCast(cs_z.ptr)) == 0 });
 }
 
-fn mysqliCharacterSetName(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .string = Value.String.borrowed("") };
-    const conn = getConn(link) orelse return .{ .string = Value.String.borrowed("") };
-    if (!isConnected(link)) return .{ .string = Value.String.borrowed("") };
+fn mysqliCharacterSetName(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.literal("");
+    const conn = getConn(link) orelse return NativeResult.literal("");
+    if (!isConnected(link)) return NativeResult.literal("");
     const name = std.mem.span(mysql.mysql_character_set_name(conn));
-    const owned = try ctx.allocator.dupe(u8, name);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, name);
 }
 
-fn mysqliGetClientInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn mysqliGetClientInfo(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const info = std.mem.span(mysql.mysql_get_client_info());
-    const owned = try ctx.allocator.dupe(u8, info);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, info);
 }
 
-fn mysqliGetClientVersion(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(mysql.mysql_get_client_version()) };
+fn mysqliGetClientVersion(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(mysql.mysql_get_client_version()) });
 }
 
 fn isConnected(link: *PhpObject) bool {
@@ -485,105 +479,101 @@ fn isConnected(link: *PhpObject) bool {
     return v == .bool and v.bool;
 }
 
-fn mysqliGetServerInfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .string = Value.String.borrowed("") };
-    const conn = getConn(link) orelse return .{ .string = Value.String.borrowed("") };
-    if (!isConnected(link)) return .{ .string = Value.String.borrowed("") };
+fn mysqliGetServerInfo(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.literal("");
+    const conn = getConn(link) orelse return NativeResult.literal("");
+    if (!isConnected(link)) return NativeResult.literal("");
     const info = std.mem.span(mysql.mysql_get_server_info(conn));
-    const owned = try ctx.allocator.dupe(u8, info);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, info);
 }
 
-fn mysqliGetServerVersion(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
-    const conn = getConn(link) orelse return .{ .int = 0 };
-    if (!isConnected(link)) return .{ .int = 0 };
-    return .{ .int = @intCast(mysql.mysql_get_server_version(conn)) };
+fn mysqliGetServerVersion(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .int = 0 });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(mysql.mysql_get_server_version(conn)) });
 }
 
-fn mysqliGetHostInfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .string = Value.String.borrowed("") };
-    const conn = getConn(link) orelse return .{ .string = Value.String.borrowed("") };
-    if (!isConnected(link)) return .{ .string = Value.String.borrowed("") };
+fn mysqliGetHostInfo(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.literal("");
+    const conn = getConn(link) orelse return NativeResult.literal("");
+    if (!isConnected(link)) return NativeResult.literal("");
     const info = std.mem.span(mysql.mysql_get_host_info(conn));
-    const owned = try ctx.allocator.dupe(u8, info);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, info);
 }
 
-fn mysqliThreadId(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
-    const conn = getConn(link) orelse return .{ .int = 0 };
-    if (!isConnected(link)) return .{ .int = 0 };
-    return .{ .int = @intCast(mysql.mysql_thread_id(conn)) };
+fn mysqliThreadId(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .int = 0 });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(mysql.mysql_thread_id(conn)) });
 }
 
-fn mysqliPing(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
-    const conn = getConn(link) orelse return .{ .bool = false };
-    if (!isConnected(link)) return .{ .bool = false };
+fn mysqliPing(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .bool = false });
     const ok = mysql.mysql_ping(conn) == 0;
     try setErrorState(ctx, link, conn);
     if (!ok) try reportFailure(ctx, conn, "mysqli_ping", false);
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-fn mysqliAutocommit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
-    const conn = getConn(link) orelse return .{ .bool = false };
-    if (!isConnected(link)) return .{ .bool = false };
+fn mysqliAutocommit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .bool = false });
     const mode_arg: Value = if (args.len > 0 and args[0] == .object) (if (args.len > 1) args[1] else .{ .bool = true }) else if (args.len > 0) args[0] else .{ .bool = true };
     const mode: u8 = if (mode_arg.isTruthy()) 1 else 0;
     const ok = mysql.mysql_autocommit(conn, mode) == 0;
     try setErrorState(ctx, link, conn);
     if (!ok) try reportFailure(ctx, conn, "mysqli_autocommit", false);
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-fn mysqliCommit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
-    const conn = getConn(link) orelse return .{ .bool = false };
-    if (!isConnected(link)) return .{ .bool = false };
+fn mysqliCommit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .bool = false });
     const ok = mysql.mysql_commit(conn) == 0;
     try setErrorState(ctx, link, conn);
     if (!ok) try reportFailure(ctx, conn, "mysqli_commit", false);
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-fn mysqliRollback(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const link = linkObj(ctx, args, 0) orelse return .{ .bool = false };
-    const conn = getConn(link) orelse return .{ .bool = false };
-    if (!isConnected(link)) return .{ .bool = false };
+fn mysqliRollback(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const link = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .bool = false });
+    const conn = getConn(link) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!isConnected(link)) return NativeResult.scalar(.{ .bool = false });
     const ok = mysql.mysql_rollback(conn) == 0;
     try setErrorState(ctx, link, conn);
     if (!ok) try reportFailure(ctx, conn, "mysqli_rollback", false);
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-fn mysqliFreeResult(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const result_obj = linkObj(ctx, args, 0) orelse return .null;
+fn mysqliFreeResult(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const result_obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.null);
     if (getRes(result_obj)) |r| {
         mysql.mysql_free_result(r);
         try result_obj.set(ctx.allocator, "__res", .{ .int = 0 });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn mysqliFieldCount(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn mysqliFieldCount(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // proc form: mysqli_field_count(link). method form: $result->field_count
-    const obj = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
+    const obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
     if (std.mem.eql(u8, obj.class_name, "mysqli_result")) {
         const v = obj.get("num_fields");
-        return if (v == .int) v else .{ .int = 0 };
+        return if (v == .int) NativeResult.share(v) else NativeResult.scalar(.{ .int = 0 });
     }
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn mysqliNumFields(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = linkObj(ctx, args, 0) orelse return .{ .int = 0 };
+fn mysqliNumFields(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.{ .int = 0 });
     const v = obj.get("num_fields");
-    return if (v == .int) v else .{ .int = 0 };
+    return if (v == .int) NativeResult.share(v) else NativeResult.scalar(.{ .int = 0 });
 }
 
 // State belongs to the VM's class registry, not a process-global variable:
@@ -592,14 +582,14 @@ fn reportMode(ctx: *NativeContext) i64 {
     return ctx.vm.classes.get("mysqli_driver").?.static_props.get("__report_mode").?.int;
 }
 
-fn mysqliReport(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn mysqliReport(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len != 1) return reportArgumentError(ctx, "ArgumentCountError", "mysqli_report() expects exactly 1 argument");
     if (args[0] == .array or args[0] == .object) return reportArgumentError(ctx, "TypeError", "mysqli_report(): Argument #1 ($flags) must be of type int");
     try ctx.vm.classes.getPtr("mysqli_driver").?.static_props.put(ctx.allocator, "__report_mode", .{ .int = args[0].toInt() });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn reportArgumentError(ctx: *NativeContext, class: []const u8, msg: []const u8) RuntimeError!Value {
+fn reportArgumentError(ctx: *NativeContext, class: []const u8, msg: []const u8) RuntimeError!NativeResult {
     const obj = try ctx.createObject(class);
     try obj.set(ctx.allocator, "message", .{ .string = Value.String.borrowed(msg) });
     try obj.set(ctx.allocator, "code", .{ .int = 0 });
@@ -607,19 +597,19 @@ fn reportArgumentError(ctx: *NativeContext, class: []const u8, msg: []const u8) 
     return error.RuntimeError;
 }
 
-fn driverGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len > 0 and args[0] == .string and std.mem.eql(u8, args[0].string.bytes(), "report_mode")) return .{ .int = reportMode(ctx) };
-    return .null;
+fn driverGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len > 0 and args[0] == .string and std.mem.eql(u8, args[0].string.bytes(), "report_mode")) return NativeResult.scalar(.{ .int = reportMode(ctx) });
+    return NativeResult.scalar(.null);
 }
 
-fn driverSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn driverSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len > 1 and args[0] == .string and std.mem.eql(u8, args[0].string.bytes(), "report_mode")) _ = try mysqliReport(ctx, args[1..2]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn exceptionSqlState(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = linkObj(ctx, args, 0) orelse return .null;
-    return obj.get("sqlstate");
+fn exceptionSqlState(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("sqlstate"));
 }
 
 fn reportFailure(ctx: *NativeContext, conn: *mysql.MYSQL, operation: []const u8, connection: bool) RuntimeError!void {
@@ -644,19 +634,19 @@ fn reportFailure(ctx: *NativeContext, conn: *mysql.MYSQL, operation: []const u8,
 
 // ---------- class constructor ----------
 
-fn mysqliConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const v = ctx.vm.currentFrame().vars.get("$this") orelse return .null;
-    if (v != .object) return .null;
+fn mysqliConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const v = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(.null);
+    if (v != .object) return NativeResult.scalar(.null);
     const obj = v.object;
     try obj.set(ctx.allocator, "error", .{ .string = Value.String.borrowed("") });
     try obj.set(ctx.allocator, "errno", .{ .int = 0 });
     try obj.set(ctx.allocator, "__connected", .{ .bool = false });
 
-    const c = mysql.mysql_init(null) orelse return .null;
+    const c = mysql.mysql_init(null) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__conn", .{ .int = @intCast(@intFromPtr(c)) });
 
     // when called with no args, leave the handle uninitialized (mirrors mysqli_init)
-    if (args.len == 0) return .null;
+    if (args.len == 0) return NativeResult.scalar(.null);
 
     const host = argOptString(args, 0);
     const user = argOptString(args, 1);
@@ -665,7 +655,7 @@ fn mysqliConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     const port: u32 = @intCast(argOptInt(args, 4, 3306));
     const socket = argOptString(args, 5);
     _ = try doConnect(ctx, obj, host, user, pass, db, port, socket);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ---------- registration ----------

--- a/src/stdlib/network.zig
+++ b/src/stdlib/network.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -42,7 +43,7 @@ fn streamFd(v: Value) ?i32 {
 // polls the underlying fds of the stream objects in each (by-ref) array and
 // rewrites each array to the ready subset, returning the number ready (false on
 // error). read=POLLIN, write=POLLOUT, except=POLLPRI. null $seconds blocks
-fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     var pollfds: std.ArrayListUnmanaged(std.posix.pollfd) = .{};
     defer pollfds.deinit(ctx.allocator);
     const Tracked = struct { slot: u8, val: Value };
@@ -72,7 +73,7 @@ fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!V
     const timeout_ms: i32 = if (block) -1 else @intCast(@max(0, sec * 1000 + @divTrunc(usec, 1000)));
 
     if (pollfds.items.len > 0) {
-        _ = std.posix.poll(pollfds.items, timeout_ms) catch return .{ .bool = false };
+        _ = std.posix.poll(pollfds.items, timeout_ms) catch return NativeResult.scalar(.{ .bool = false });
     }
 
     var out = [_]?*PhpArray{ null, null, null };
@@ -92,7 +93,7 @@ fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!V
         const arr = out[slot] orelse try ctx.createArray();
         ctx.setCallerVar(slot, args.len, .{ .array = arr });
     }
-    return .{ .int = count };
+    return NativeResult.scalar(.{ .int = count });
 }
 
 extern "c" fn socketpair(domain: c_int, sock_type: c_int, protocol: c_int, sv: *[2]c_int) c_int;
@@ -100,12 +101,12 @@ extern "c" fn socketpair(domain: c_int, sock_type: c_int, protocol: c_int, sv: *
 // stream_socket_pair(int $domain, int $type, int $protocol): array|false
 // creates a connected pair of sockets (socketpair(2)) returned as two stream
 // objects (each with __fd) usable by fread/fwrite/stream_select/fclose
-fn native_stream_socket_pair(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_stream_socket_pair(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const domain: c_int = if (args.len > 0) @intCast(Value.toInt(args[0])) else @intCast(std.posix.AF.UNIX);
     const sock_type: c_int = if (args.len > 1) @intCast(Value.toInt(args[1])) else @intCast(std.posix.SOCK.STREAM);
     const protocol: c_int = if (args.len > 2) @intCast(Value.toInt(args[2])) else 0;
     var sv: [2]c_int = undefined;
-    if (socketpair(domain, sock_type, protocol, &sv) != 0) return .{ .bool = false };
+    if (socketpair(domain, sock_type, protocol, &sv) != 0) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     for (sv) |fd| {
         const obj = try ctx.allocator.create(PhpObject);
@@ -117,10 +118,10 @@ fn native_stream_socket_pair(ctx: *NativeContext, args: []const Value) RuntimeEr
         try obj.set(ctx.allocator, "__net", .{ .bool = true });
         try arr.append(ctx.allocator, .{ .object = obj });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_stream_context_create(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_stream_context_create(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.vm.allocator.create(PhpObject);
     obj.* = .{ .class_name = "StreamContext" };
     try ctx.vm.objects.append(ctx.vm.allocator, obj);
@@ -130,23 +131,23 @@ fn native_stream_context_create(ctx: *NativeContext, args: []const Value) Runtim
     if (args.len >= 2 and args[1] == .array) {
         try obj.set(ctx.allocator, "params", args[1]);
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_stream_context_get_options(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
+fn native_stream_context_get_options(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const opts = args[0].object.get("options");
-    if (opts == .array) return opts;
-    return .{ .bool = false };
+    if (opts == .array) return NativeResult.borrowed(opts);
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_stream_context_get_params(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    return args[0].object.get("params");
+fn native_stream_context_get_params(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(args[0].object.get("params"));
 }
 
-fn native_stream_context_set_options(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object) return .{ .bool = false };
+fn native_stream_context_set_options(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     // 4-arg form: stream_context_set_option($ctx, $wrapper, $option, $value)
     // merges the (wrapper, option) into the existing options array
     if (args.len >= 4 and args[1] == .string and args[2] == .string) {
@@ -165,10 +166,10 @@ fn native_stream_context_set_options(ctx: *NativeContext, args: []const Value) R
             wrap_arr = wrap_v.array;
         } else {
             wrap_arr = try ctx.createArray();
-            try opts.set(ctx.allocator, wrap_key, .{ .array = wrap_arr });
+            try ctx.vm.arraySetOwned(opts, wrap_key, .{ .array = wrap_arr });
         }
-        try wrap_arr.set(ctx.allocator, PhpArray.Key{ .string = args[2].string }, args[3]);
-        return .{ .bool = true };
+        try ctx.vm.arraySetOwned(wrap_arr, PhpArray.Key{ .string = args[2].string }, args[3]);
+        return NativeResult.scalar(.{ .bool = true });
     }
     // 3-arg form: stream_context_set_option($ctx, $wrapper, $options_assoc) -
     // PHP also accepts this; merge per-wrapper
@@ -179,68 +180,62 @@ fn native_stream_context_set_options(ctx: *NativeContext, args: []const Value) R
             opts = try ctx.createArray();
             try args[0].object.set(ctx.allocator, "options", .{ .array = opts });
         }
-        try opts.set(ctx.allocator, PhpArray.Key{ .string = args[1].string }, args[2]);
-        return .{ .bool = true };
+        try ctx.vm.arraySetOwned(opts, PhpArray.Key{ .string = args[1].string }, args[2]);
+        return NativeResult.scalar(.{ .bool = true });
     }
     if (args[1] == .array) {
         try args[0].object.set(ctx.allocator, "options", args[1]);
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_stream_context_set_params(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object) return .{ .bool = false };
+fn native_stream_context_set_params(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     if (args[1] == .array) {
         try args[0].object.set(ctx.allocator, "params", args[1]);
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_stream_context_get_default(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_stream_context_get_default(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.vm.allocator.create(PhpObject);
     obj.* = .{ .class_name = "StreamContext" };
     try ctx.vm.objects.append(ctx.vm.allocator, obj);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_stream_context_set_default(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_stream_context_set_default(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return native_stream_context_create(ctx, args);
 }
 
-fn createString(ctx: *NativeContext, s: []const u8) ![]const u8 {
-    const copy = try ctx.allocator.dupe(u8, s);
-    try ctx.vm.strings.append(ctx.allocator, copy);
-    return copy;
-}
-
-fn native_gethostbyname(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_gethostbyname(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const host = args[0].string.bytes();
-    var list = std.net.getAddressList(ctx.allocator, host, 0) catch return args[0];
+    var list = std.net.getAddressList(ctx.allocator, host, 0) catch return NativeResult.share(args[0]);
     defer list.deinit();
-    if (list.addrs.len == 0) return args[0];
+    if (list.addrs.len == 0) return NativeResult.share(args[0]);
     for (list.addrs) |addr| {
         if (addr.any.family == std.posix.AF.INET) {
             var buf: [32]u8 = undefined;
-            const written = std.fmt.bufPrint(&buf, "{f}", .{addr}) catch return args[0];
+            const written = std.fmt.bufPrint(&buf, "{f}", .{addr}) catch return NativeResult.share(args[0]);
             // strip port if present (Address.format adds :port)
             const colon = std.mem.lastIndexOfScalar(u8, written, ':') orelse written.len;
-            return .{ .string = Value.String.borrowed(try createString(ctx, written[0..colon])) };
+            return NativeResult.copyString(ctx.allocator, written[0..colon]);
         }
     }
-    return args[0];
+    return NativeResult.share(args[0]);
 }
 
 // gethostbynamel: like gethostbyname but returns all resolved IPv4 addresses
 // as a numerically-indexed array, or false on failure
-fn native_gethostbynamel(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_gethostbynamel(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const host = args[0].string.bytes();
-    var list = std.net.getAddressList(ctx.allocator, host, 0) catch return .{ .bool = false };
+    var list = std.net.getAddressList(ctx.allocator, host, 0) catch return NativeResult.scalar(.{ .bool = false });
     defer list.deinit();
-    if (list.addrs.len == 0) return .{ .bool = false };
+    if (list.addrs.len == 0) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     var seen = std.StringHashMapUnmanaged(void){};
     defer seen.deinit(ctx.allocator);
@@ -252,88 +247,89 @@ fn native_gethostbynamel(ctx: *NativeContext, args: []const Value) RuntimeError!
         const ip_str = written[0..colon];
         // dedup - the same IP can come back multiple times for different ports
         if (seen.contains(ip_str)) continue;
-        const owned = try createString(ctx, ip_str);
-        try seen.put(ctx.allocator, owned, {});
-        try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(owned) });
+        const owned = try Value.String.create(ctx.allocator, ip_str);
+        defer owned.release();
+        try seen.put(ctx.allocator, owned.bytes(), {});
+        try arr.append(ctx.allocator, .{ .string = owned });
     }
-    if (arr.entries.items.len == 0) return .{ .bool = false };
-    return .{ .array = arr };
+    if (arr.entries.items.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_gethostbyaddr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_gethostbyaddr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     // best-effort: just echo back the IP if we can't reverse-resolve
-    return .{ .string = Value.String.borrowed(try createString(ctx, args[0].string.bytes())) };
+    return NativeResult.copyString(ctx.allocator, args[0].string.bytes());
 }
 
-fn native_gethostname(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_gethostname(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var buf: [std.posix.HOST_NAME_MAX]u8 = undefined;
-    const name = std.posix.gethostname(&buf) catch return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(try createString(ctx, name)) };
+    const name = std.posix.gethostname(&buf) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.copyString(ctx.allocator, name);
 }
 
-fn native_inet_pton(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_inet_pton(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     // try IPv4
     if (std.net.Address.parseIp4(s, 0)) |addr| {
         const bytes = std.mem.toBytes(addr.in.sa.addr);
-        return .{ .string = Value.String.borrowed(try createString(ctx, &bytes)) };
+        return NativeResult.copyString(ctx.allocator, &bytes);
     } else |_| {}
     // try IPv6
     if (std.net.Address.parseIp6(s, 0)) |addr| {
-        return .{ .string = Value.String.borrowed(try createString(ctx, &addr.in6.sa.addr)) };
+        return NativeResult.copyString(ctx.allocator, &addr.in6.sa.addr);
     } else |_| {}
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_inet_ntop(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_inet_ntop(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const bytes = args[0].string.bytes();
     if (bytes.len == 4) {
         var buf: [32]u8 = undefined;
-        const out = std.fmt.bufPrint(&buf, "{d}.{d}.{d}.{d}", .{ bytes[0], bytes[1], bytes[2], bytes[3] }) catch return .{ .bool = false };
-        return .{ .string = Value.String.borrowed(try createString(ctx, out)) };
+        const out = std.fmt.bufPrint(&buf, "{d}.{d}.{d}.{d}", .{ bytes[0], bytes[1], bytes[2], bytes[3] }) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.copyString(ctx.allocator, out);
     }
     if (bytes.len == 16) {
         var addr: [16]u8 = undefined;
         @memcpy(&addr, bytes);
         const ip = std.net.Address.initIp6(addr, 0, 0, 0);
         var buf: [64]u8 = undefined;
-        const out = std.fmt.bufPrint(&buf, "{f}", .{ip}) catch return .{ .bool = false };
+        const out = std.fmt.bufPrint(&buf, "{f}", .{ip}) catch return NativeResult.scalar(.{ .bool = false });
         // strip [...]:port wrapping
         var s = out;
         if (s.len > 0 and s[0] == '[') {
-            const close = std.mem.indexOfScalar(u8, s, ']') orelse return .{ .bool = false };
+            const close = std.mem.indexOfScalar(u8, s, ']') orelse return NativeResult.scalar(.{ .bool = false });
             s = s[1..close];
         }
-        return .{ .string = Value.String.borrowed(try createString(ctx, s)) };
+        return NativeResult.copyString(ctx.allocator, s);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_ip2long(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_ip2long(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     var parts: [4]u32 = undefined;
     var idx: usize = 0;
     var it = std.mem.splitScalar(u8, args[0].string.bytes(), '.');
     while (it.next()) |part| {
-        if (idx >= 4) return .{ .bool = false };
-        parts[idx] = std.fmt.parseUnsigned(u8, part, 10) catch return .{ .bool = false };
+        if (idx >= 4) return NativeResult.scalar(.{ .bool = false });
+        parts[idx] = std.fmt.parseUnsigned(u8, part, 10) catch return NativeResult.scalar(.{ .bool = false });
         idx += 1;
     }
-    if (idx != 4) return .{ .bool = false };
+    if (idx != 4) return NativeResult.scalar(.{ .bool = false });
     const long: i64 = @intCast((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]);
-    return .{ .int = long };
+    return NativeResult.scalar(.{ .int = long });
 }
 
-fn native_long2ip(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_long2ip(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const n = Value.toInt(args[0]);
     const u: u32 = @truncate(@as(u64, @bitCast(n)));
     var buf: [32]u8 = undefined;
-    const out = std.fmt.bufPrint(&buf, "{d}.{d}.{d}.{d}", .{ (u >> 24) & 0xff, (u >> 16) & 0xff, (u >> 8) & 0xff, u & 0xff }) catch return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(try createString(ctx, out)) };
+    const out = std.fmt.bufPrint(&buf, "{d}.{d}.{d}.{d}", .{ (u >> 24) & 0xff, (u >> 16) & 0xff, (u >> 8) & 0xff, u & 0xff }) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.copyString(ctx.allocator, out);
 }
 
 fn parseHostPort(target: []const u8) ?struct { host: []const u8, port: u16, scheme: []const u8 } {
@@ -367,49 +363,47 @@ fn openTcpHandle(ctx: *NativeContext, host: []const u8, port: u16) !*PhpObject {
     return obj;
 }
 
-fn native_fsockopen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_fsockopen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const host = args[0].string.bytes();
     const port: u16 = if (args.len >= 2) @intCast(@max(0, Value.toInt(args[1]))) else 80;
-    if (port == 0) return .{ .bool = false };
-    const obj = openTcpHandle(ctx, host, port) catch return .{ .bool = false };
-    return .{ .object = obj };
+    if (port == 0) return NativeResult.scalar(.{ .bool = false });
+    const obj = openTcpHandle(ctx, host, port) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_stream_socket_client(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const target = parseHostPort(args[0].string.bytes()) orelse return .{ .bool = false };
-    if (target.port == 0) return .{ .bool = false };
-    const obj = openTcpHandle(ctx, target.host, target.port) catch return .{ .bool = false };
-    return .{ .object = obj };
+fn native_stream_socket_client(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const target = parseHostPort(args[0].string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
+    if (target.port == 0) return NativeResult.scalar(.{ .bool = false });
+    const obj = openTcpHandle(ctx, target.host, target.port) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn native_checkdnsrr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    var list = std.net.getAddressList(ctx.allocator, args[0].string.bytes(), 0) catch return .{ .bool = false };
+fn native_checkdnsrr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    var list = std.net.getAddressList(ctx.allocator, args[0].string.bytes(), 0) catch return NativeResult.scalar(.{ .bool = false });
     defer list.deinit();
-    return .{ .bool = list.addrs.len > 0 };
+    return NativeResult.scalar(.{ .bool = list.addrs.len > 0 });
 }
 
-fn native_dns_get_record(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const result = try ctx.allocator.create(PhpArray);
-    result.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, result);
-    var list = std.net.getAddressList(ctx.allocator, args[0].string.bytes(), 0) catch return .{ .array = result };
+fn native_dns_get_record(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const result = try ctx.createArray();
+    var list = std.net.getAddressList(ctx.allocator, args[0].string.bytes(), 0) catch return NativeResult.borrowed(.{ .array = result });
     defer list.deinit();
     for (list.addrs) |addr| {
-        const entry = try ctx.allocator.create(PhpArray);
-        entry.* = .{};
-        try ctx.vm.arrays.append(ctx.allocator, entry);
-        try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("host") }, .{ .string = Value.String.borrowed(try createString(ctx, args[0].string.bytes())) });
+        const entry = try ctx.createArray();
+        try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("host") }, args[0]);
         try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("class") }, .{ .string = Value.String.borrowed("IN") });
         if (addr.any.family == std.posix.AF.INET) {
             const bytes = std.mem.toBytes(addr.in.sa.addr);
             var buf: [32]u8 = undefined;
             const ip = std.fmt.bufPrint(&buf, "{d}.{d}.{d}.{d}", .{ bytes[0], bytes[1], bytes[2], bytes[3] }) catch continue;
             try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("type") }, .{ .string = Value.String.borrowed("A") });
-            try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("ip") }, .{ .string = Value.String.borrowed(try createString(ctx, ip)) });
+            const owned = try Value.String.create(ctx.allocator, ip);
+            defer owned.release();
+            try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("ip") }, .{ .string = owned });
         } else if (addr.any.family == std.posix.AF.INET6) {
             try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("type") }, .{ .string = Value.String.borrowed("AAAA") });
             var buf: [64]u8 = undefined;
@@ -418,9 +412,11 @@ fn native_dns_get_record(ctx: *NativeContext, args: []const Value) RuntimeError!
             if (out.len > 0 and out[0] == '[') {
                 if (std.mem.indexOfScalar(u8, out, ']')) |ci| out = out[1..ci];
             }
-            try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("ipv6") }, .{ .string = Value.String.borrowed(try createString(ctx, out)) });
+            const owned = try Value.String.create(ctx.allocator, out);
+            defer owned.release();
+            try entry.set(ctx.allocator, .{ .string = Value.String.borrowed("ipv6") }, .{ .string = owned });
         }
         try result.append(ctx.allocator, .{ .array = entry });
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }

--- a/src/stdlib/openssl.zig
+++ b/src/stdlib/openssl.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
 const c = @cImport({
@@ -20,8 +21,8 @@ pub const entries = .{
     .{ "openssl_pbkdf2", opensslPbkdf2 },
 };
 
-fn opensslPbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 4 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn opensslPbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 4 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const password = args[0].string.bytes();
     const salt = args[1].string.bytes();
     const key_length: usize = @intCast(@max(0, Value.toInt(args[2])));
@@ -29,11 +30,11 @@ fn opensslPbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const digest_algo = if (args.len >= 5 and args[4] == .string) args[4].string.bytes() else "sha1";
 
     var name_buf: [64]u8 = undefined;
-    if (digest_algo.len >= name_buf.len) return .{ .bool = false };
+    if (digest_algo.len >= name_buf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(name_buf[0..digest_algo.len], digest_algo);
     name_buf[digest_algo.len] = 0;
 
-    const md = c.EVP_MD_fetch(null, &name_buf, null) orelse return .{ .bool = false };
+    const md = c.EVP_MD_fetch(null, &name_buf, null) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.EVP_MD_free(md);
 
     const out = try ctx.allocator.alloc(u8, key_length);
@@ -49,40 +50,37 @@ fn opensslPbkdf2(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     );
     if (rc != 1) {
         ctx.allocator.free(out);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn opensslDigest(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn opensslDigest(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const data = args[0].string.bytes();
     const algo = args[1].string.bytes();
     const raw_output = args.len >= 3 and args[2].isTruthy();
 
     var name_buf: [64]u8 = undefined;
-    if (algo.len >= name_buf.len) return .{ .bool = false };
+    if (algo.len >= name_buf.len) return NativeResult.scalar(.{ .bool = false });
     @memcpy(name_buf[0..algo.len], algo);
     name_buf[algo.len] = 0;
 
-    const md = c.EVP_MD_fetch(null, &name_buf, null) orelse return .{ .bool = false };
+    const md = c.EVP_MD_fetch(null, &name_buf, null) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.EVP_MD_free(md);
 
-    const ctx_md = c.EVP_MD_CTX_new() orelse return .{ .bool = false };
+    const ctx_md = c.EVP_MD_CTX_new() orelse return NativeResult.scalar(.{ .bool = false });
     defer c.EVP_MD_CTX_free(ctx_md);
 
-    if (c.EVP_DigestInit_ex(ctx_md, md, null) != 1) return .{ .bool = false };
-    if (data.len > 0 and c.EVP_DigestUpdate(ctx_md, data.ptr, data.len) != 1) return .{ .bool = false };
+    if (c.EVP_DigestInit_ex(ctx_md, md, null) != 1) return NativeResult.scalar(.{ .bool = false });
+    if (data.len > 0 and c.EVP_DigestUpdate(ctx_md, data.ptr, data.len) != 1) return NativeResult.scalar(.{ .bool = false });
 
     var out_buf: [c.EVP_MAX_MD_SIZE]u8 = undefined;
     var out_len: c_uint = 0;
-    if (c.EVP_DigestFinal_ex(ctx_md, &out_buf, &out_len) != 1) return .{ .bool = false };
+    if (c.EVP_DigestFinal_ex(ctx_md, &out_buf, &out_len) != 1) return NativeResult.scalar(.{ .bool = false });
 
     if (raw_output) {
-        const dup = try ctx.allocator.dupe(u8, out_buf[0..out_len]);
-        try ctx.vm.strings.append(ctx.allocator, dup);
-        return .{ .string = Value.String.borrowed(dup) };
+        return try NativeResult.copyString(ctx.allocator, out_buf[0..out_len]);
     }
     const hex = try ctx.allocator.alloc(u8, out_len * 2);
     const hex_chars = "0123456789abcdef";
@@ -90,18 +88,17 @@ fn opensslDigest(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         hex[i * 2] = hex_chars[b >> 4];
         hex[i * 2 + 1] = hex_chars[b & 0xf];
     }
-    try ctx.vm.strings.append(ctx.allocator, hex);
-    return .{ .string = Value.String.borrowed(hex) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, hex));
 }
 
-fn opensslGetMdMethods(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn opensslGetMdMethods(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var arr = try ctx.createArray();
     const names = [_][]const u8{ "md5", "sha1", "sha224", "sha256", "sha384", "sha512", "sha3-224", "sha3-256", "sha3-384", "sha3-512" };
     for (names) |n| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(n) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn opensslRandomPseudoBytes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn opensslRandomPseudoBytes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0 or args[0] != .int or args[0].int <= 0) {
         try ctx.vm.setPendingException("ValueError", "openssl_random_pseudo_bytes(): Argument #1 ($length) must be greater than 0");
         return error.RuntimeError;
@@ -110,11 +107,10 @@ fn opensslRandomPseudoBytes(ctx: *NativeContext, args: []const Value) RuntimeErr
     const buf = try ctx.allocator.alloc(u8, n);
     if (c.RAND_bytes(buf.ptr, @intCast(n)) != 1) {
         ctx.allocator.free(buf);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    try ctx.vm.strings.append(ctx.allocator, buf);
     if (args.len >= 2) ctx.setCallerVar(1, args.len, .{ .bool = true });
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
 fn fetchCipher(name: []const u8) ?*const c.EVP_CIPHER {
@@ -129,23 +125,23 @@ fn freeCipher(cipher: *const c.EVP_CIPHER) void {
     c.EVP_CIPHER_free(@constCast(cipher));
 }
 
-fn cipherIvLength(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const cipher = fetchCipher(args[0].string.bytes()) orelse return .{ .bool = false };
+fn cipherIvLength(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const cipher = fetchCipher(args[0].string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
     defer freeCipher(cipher);
-    return .{ .int = c.EVP_CIPHER_iv_length(cipher) };
+    return NativeResult.scalar(.{ .int = c.EVP_CIPHER_iv_length(cipher) });
 }
 
-fn cipherKeyLength(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    const cipher = fetchCipher(args[0].string.bytes()) orelse return .{ .bool = false };
+fn cipherKeyLength(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const cipher = fetchCipher(args[0].string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
     defer freeCipher(cipher);
-    return .{ .int = c.EVP_CIPHER_key_length(cipher) };
+    return NativeResult.scalar(.{ .int = c.EVP_CIPHER_key_length(cipher) });
 }
 
-fn opensslEncrypt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn opensslEncrypt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     const data = args[0].string.bytes();
     const cipher_name = args[1].string.bytes();
@@ -153,64 +149,64 @@ fn opensslEncrypt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const options: i64 = if (args.len > 3 and args[3] == .int) args[3].int else 0;
     const iv: []const u8 = if (args.len > 4 and args[4] == .string) args[4].string.bytes() else "";
 
-    const cipher = fetchCipher(cipher_name) orelse return .{ .bool = false };
+    const cipher = fetchCipher(cipher_name) orelse return NativeResult.scalar(.{ .bool = false });
     defer freeCipher(cipher);
 
-    const evp_ctx = c.EVP_CIPHER_CTX_new() orelse return .{ .bool = false };
+    const evp_ctx = c.EVP_CIPHER_CTX_new() orelse return NativeResult.scalar(.{ .bool = false });
     defer c.EVP_CIPHER_CTX_free(evp_ctx);
 
     const is_aead = isAeadCipher(cipher);
     const aad: []const u8 = if (args.len > 6 and args[6] == .string) args[6].string.bytes() else "";
 
     if (c.EVP_EncryptInit_ex(evp_ctx, cipher, null, null, null) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     if (is_aead) {
         if (c.EVP_CIPHER_CTX_ctrl(evp_ctx, c.EVP_CTRL_AEAD_SET_IVLEN, @intCast(iv.len), null) != 1)
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
     }
 
     if (c.EVP_EncryptInit_ex(evp_ctx, null, null, key.ptr, if (iv.len > 0) iv.ptr else null) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     var written: c_int = 0;
     if (is_aead and aad.len > 0) {
         if (c.EVP_EncryptUpdate(evp_ctx, null, &written, aad.ptr, @intCast(aad.len)) != 1)
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
     }
 
     const block_size: usize = @intCast(c.EVP_CIPHER_block_size(cipher));
     const out_len = data.len + block_size;
-    const out_buf = ctx.allocator.alloc(u8, out_len) catch return .{ .bool = false };
+    const out_buf = ctx.allocator.alloc(u8, out_len) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(out_buf);
 
     if (c.EVP_EncryptUpdate(evp_ctx, out_buf.ptr, &written, data.ptr, @intCast(data.len)) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     var total: usize = @intCast(written);
     if (c.EVP_EncryptFinal_ex(evp_ctx, out_buf.ptr + total, &written) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     total += @intCast(written);
 
     if (is_aead and args.len > 5) {
         var tag_buf: [16]u8 = undefined;
         const tag_len: usize = if (args.len > 7 and args[7] == .int and args[7].int > 0) @intCast(@min(args[7].int, 16)) else 16;
         if (c.EVP_CIPHER_CTX_ctrl(evp_ctx, c.EVP_CTRL_AEAD_GET_TAG, @intCast(tag_len), &tag_buf) != 1)
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         const tag_str = try ctx.createString(tag_buf[0..tag_len]);
         ctx.setCallerVar(5, args.len, .{ .string = Value.String.borrowed(tag_str) });
     }
 
     const raw = out_buf[0..total];
     if (options & 1 != 0) {
-        return .{ .string = Value.String.borrowed(try ctx.createString(raw)) };
+        return try NativeResult.copyString(ctx.allocator, raw);
     }
-    return .{ .string = Value.String.borrowed(try base64Encode(ctx, raw)) };
+    return NativeResult.takeString(try base64Encode(ctx, raw));
 }
 
-fn opensslDecrypt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn opensslDecrypt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     const raw_data = args[0].string.bytes();
     const cipher_name = args[1].string.bytes();
@@ -218,75 +214,75 @@ fn opensslDecrypt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const options: i64 = if (args.len > 3 and args[3] == .int) args[3].int else 0;
     const iv: []const u8 = if (args.len > 4 and args[4] == .string) args[4].string.bytes() else "";
 
-    const cipher = fetchCipher(cipher_name) orelse return .{ .bool = false };
+    const cipher = fetchCipher(cipher_name) orelse return NativeResult.scalar(.{ .bool = false });
     defer freeCipher(cipher);
 
     var decoded_buf: [8192]u8 = undefined;
     const data = if (options & 1 != 0) raw_data else blk: {
-        const len = std.base64.standard.Decoder.calcSizeForSlice(raw_data) catch return .{ .bool = false };
-        if (len > decoded_buf.len) return .{ .bool = false };
-        std.base64.standard.Decoder.decode(decoded_buf[0..len], raw_data) catch return .{ .bool = false };
+        const len = std.base64.standard.Decoder.calcSizeForSlice(raw_data) catch return NativeResult.scalar(.{ .bool = false });
+        if (len > decoded_buf.len) return NativeResult.scalar(.{ .bool = false });
+        std.base64.standard.Decoder.decode(decoded_buf[0..len], raw_data) catch return NativeResult.scalar(.{ .bool = false });
         break :blk decoded_buf[0..len];
     };
 
-    const evp_ctx = c.EVP_CIPHER_CTX_new() orelse return .{ .bool = false };
+    const evp_ctx = c.EVP_CIPHER_CTX_new() orelse return NativeResult.scalar(.{ .bool = false });
     defer c.EVP_CIPHER_CTX_free(evp_ctx);
 
     const is_aead = isAeadCipher(cipher);
     const aad: []const u8 = if (args.len > 6 and args[6] == .string) args[6].string.bytes() else "";
 
     if (c.EVP_DecryptInit_ex(evp_ctx, cipher, null, null, null) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     if (is_aead) {
         if (c.EVP_CIPHER_CTX_ctrl(evp_ctx, c.EVP_CTRL_AEAD_SET_IVLEN, @intCast(iv.len), null) != 1)
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
     }
 
     if (c.EVP_DecryptInit_ex(evp_ctx, null, null, key.ptr, if (iv.len > 0) iv.ptr else null) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     if (is_aead and args.len > 5 and args[5] == .string) {
         const tag = args[5].string.bytes();
         if (tag.len > 0) {
             if (c.EVP_CIPHER_CTX_ctrl(evp_ctx, c.EVP_CTRL_AEAD_SET_TAG, @intCast(tag.len), @constCast(tag.ptr)) != 1)
-                return .{ .bool = false };
+                return NativeResult.scalar(.{ .bool = false });
         }
     }
 
     var written: c_int = 0;
     if (is_aead and aad.len > 0) {
         if (c.EVP_DecryptUpdate(evp_ctx, null, &written, aad.ptr, @intCast(aad.len)) != 1)
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
     }
 
-    const out_buf = ctx.allocator.alloc(u8, data.len + 128) catch return .{ .bool = false };
+    const out_buf = ctx.allocator.alloc(u8, data.len + 128) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(out_buf);
 
     if (c.EVP_DecryptUpdate(evp_ctx, out_buf.ptr, &written, data.ptr, @intCast(data.len)) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
 
     var total: usize = @intCast(written);
     if (c.EVP_DecryptFinal_ex(evp_ctx, out_buf.ptr + total, &written) != 1)
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     total += @intCast(written);
 
-    return .{ .string = Value.String.borrowed(try ctx.createString(out_buf[0..total])) };
+    return try NativeResult.copyString(ctx.allocator, out_buf[0..total]);
 }
 
 fn isAeadCipher(cipher: *const c.EVP_CIPHER) bool {
     return (c.EVP_CIPHER_flags(cipher) & c.EVP_CIPH_FLAG_AEAD_CIPHER) != 0;
 }
 
-fn base64Encode(ctx: *NativeContext, data: []const u8) ![]const u8 {
+fn base64Encode(ctx: *NativeContext, data: []const u8) !Value.String {
     const len = std.base64.standard.Encoder.calcSize(data.len);
     const buf = try ctx.allocator.alloc(u8, len);
-    const result = std.base64.standard.Encoder.encode(buf, data);
-    try ctx.strings.append(ctx.allocator, buf);
-    return result;
+    errdefer ctx.allocator.free(buf);
+    _ = std.base64.standard.Encoder.encode(buf, data);
+    return Value.String.adopt(ctx.allocator, buf);
 }
 
-fn getCipherMethods(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn getCipherMethods(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const methods = [_][]const u8{
         "aes-128-cbc",  "aes-192-cbc",       "aes-256-cbc",
         "aes-128-gcm",  "aes-192-gcm",       "aes-256-gcm",
@@ -298,5 +294,5 @@ fn getCipherMethods(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     for (methods) |name| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(name) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }

--- a/src/stdlib/output.zig
+++ b/src/stdlib/output.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
@@ -20,7 +21,7 @@ pub const entries = .{
     .{ "var_export", var_export },
 };
 
-fn var_dump(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn var_dump(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     visited_ptrs.deinit(ctx.allocator);
     visited_ptrs = .{};
     defer {
@@ -28,7 +29,7 @@ fn var_dump(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         visited_ptrs = .{};
     }
     for (args) |arg| try varDumpValue(ctx, arg, 0);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn varDumpValue(ctx: *NativeContext, val: Value, depth: usize) !void {
@@ -251,8 +252,8 @@ fn varDumpValue(ctx: *NativeContext, val: Value, depth: usize) !void {
     }
 }
 
-fn print_r(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn print_r(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     const return_str = args.len >= 2 and args[1].isTruthy();
     visited_ptrs.deinit(ctx.allocator);
     visited_ptrs = .{};
@@ -262,13 +263,13 @@ fn print_r(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     if (return_str) {
         var buf = std.ArrayListUnmanaged(u8){};
+        defer buf.deinit(ctx.allocator);
         try printRValueImpl(ctx.allocator, &buf, args[0], 0, ctx.vm);
         const s = try buf.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, s);
-        return .{ .string = Value.String.borrowed(s) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
     }
     try printRValueImpl(ctx.allocator, &ctx.vm.output, args[0], 0, ctx.vm);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn printRValue(a: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), val: Value, depth: usize) !void {
@@ -450,8 +451,8 @@ fn printRValueImpl(a: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), val: 
     }
 }
 
-fn var_export(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn var_export(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     const return_str = args.len >= 2 and args[1].isTruthy();
     visited_ptrs.deinit(ctx.allocator);
     visited_ptrs = .{};
@@ -460,15 +461,14 @@ fn var_export(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         visited_ptrs = .{};
     }
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     try varExportValue(ctx.allocator, &buf, args[0], 0, ctx);
     if (return_str) {
         const s = try buf.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, s);
-        return .{ .string = Value.String.borrowed(s) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
     }
     try ctx.vm.output.appendSlice(ctx.allocator, buf.items);
-    buf.deinit(ctx.allocator);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn varExportString(a: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), s: []const u8) !void {

--- a/src/stdlib/pack.zig
+++ b/src/stdlib/pack.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -88,11 +89,11 @@ fn formatByteSize(code: u8) ?usize {
     };
 }
 
-fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const fmt = switch (args[0]) {
         .string => |s| s.bytes(),
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
 
     var buf = std.ArrayListUnmanaged(u8){};
@@ -104,7 +105,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     while (parser.next()) |entry| {
         switch (entry.code) {
             'a', 'A', 'Z' => {
-                if (arg_idx >= args.len) return .{ .bool = false };
+                if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                 const s = switch (args[arg_idx]) {
                     .string => |v| v.bytes(),
                     else => "",
@@ -128,7 +129,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 }
             },
             'H', 'h' => {
-                if (arg_idx >= args.len) return .{ .bool = false };
+                if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                 const s = switch (args[arg_idx]) {
                     .string => |v| v.bytes(),
                     else => "",
@@ -159,7 +160,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .exact => |n| n,
                 };
                 for (0..repeat) |_| {
-                    if (arg_idx >= args.len) return .{ .bool = false };
+                    if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                     const val: u8 = @truncate(@as(u64, @bitCast(Value.toInt(args[arg_idx]))));
                     arg_idx += 1;
                     try buf.append(ctx.allocator, val);
@@ -171,7 +172,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .exact => |n| n,
                 };
                 for (0..repeat) |_| {
-                    if (arg_idx >= args.len) return .{ .bool = false };
+                    if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                     const val: u16 = @truncate(@as(u64, @bitCast(Value.toInt(args[arg_idx]))));
                     arg_idx += 1;
                     const bytes = switch (entry.code) {
@@ -188,7 +189,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .exact => |n| n,
                 };
                 for (0..repeat) |_| {
-                    if (arg_idx >= args.len) return .{ .bool = false };
+                    if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                     const val: u32 = @truncate(@as(u64, @bitCast(Value.toInt(args[arg_idx]))));
                     arg_idx += 1;
                     const bytes = switch (entry.code) {
@@ -205,7 +206,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .exact => |n| n,
                 };
                 for (0..repeat) |_| {
-                    if (arg_idx >= args.len) return .{ .bool = false };
+                    if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                     const int_val = Value.toInt(args[arg_idx]);
                     arg_idx += 1;
                     if (entry.code == 'i') {
@@ -223,7 +224,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .exact => |n| n,
                 };
                 for (0..repeat) |_| {
-                    if (arg_idx >= args.len) return .{ .bool = false };
+                    if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                     const val: u64 = @bitCast(Value.toInt(args[arg_idx]));
                     arg_idx += 1;
                     const bytes = switch (entry.code) {
@@ -240,7 +241,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .exact => |n| n,
                 };
                 for (0..repeat) |_| {
-                    if (arg_idx >= args.len) return .{ .bool = false };
+                    if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                     const val: f32 = @floatCast(Value.toFloat(args[arg_idx]));
                     arg_idx += 1;
                     const bits: u32 = @bitCast(val);
@@ -258,7 +259,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .exact => |n| n,
                 };
                 for (0..repeat) |_| {
-                    if (arg_idx >= args.len) return .{ .bool = false };
+                    if (arg_idx >= args.len) return NativeResult.scalar(.{ .bool = false });
                     const val: f64 = Value.toFloat(args[arg_idx]);
                     arg_idx += 1;
                     const bits: u64 = @bitCast(val);
@@ -287,7 +288,7 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             },
             '@' => {
                 const pos = switch (entry.count) {
-                    .star => return .{ .bool = false },
+                    .star => return NativeResult.scalar(.{ .bool = false }),
                     .exact => |n| n,
                 };
                 if (pos > buf.items.len) {
@@ -296,46 +297,43 @@ fn native_pack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     buf.items.len = pos;
                 }
             },
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         }
     }
 
-    const result = try ctx.allocator.alloc(u8, buf.items.len);
-    @memcpy(result, buf.items);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator)));
 }
 
 // emit PHP's 'not enough input values' warning and return false. PHP's
 // unpack reports the per-element byte size as 'need N values' and the bytes
 // still available as 'only M were provided'
-fn unpackShort(ctx: *NativeContext, code: u8, need: usize, have: usize) RuntimeError!Value {
+fn unpackShort(ctx: *NativeContext, code: u8, need: usize, have: usize) RuntimeError!NativeResult {
     // PHP pluralizes the trailing verb: '1 was provided' vs 'N were provided'
     const verb: []const u8 = if (have == 1) "was" else "were";
-    const msg = std.fmt.allocPrint(ctx.allocator, "unpack(): Type {c}: not enough input values, need {d} values but only {d} {s} provided", .{ code, need, have, verb }) catch return .{ .bool = false };
+    const msg = std.fmt.allocPrint(ctx.allocator, "unpack(): Type {c}: not enough input values, need {d} values but only {d} {s} provided", .{ code, need, have, verb }) catch return NativeResult.scalar(.{ .bool = false });
     try ctx.strings.append(ctx.allocator, msg);
     ctx.vm.emitWarning(msg);
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const fmt = switch (args[0]) {
         .string => |s| s.bytes(),
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     const data = switch (args[1]) {
         .string => |s| s.bytes(),
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
     var offset: usize = 0;
     if (args.len >= 3) {
         const off_val = Value.toInt(args[2]);
-        if (off_val < 0) return .{ .bool = false };
+        if (off_val < 0) return NativeResult.scalar(.{ .bool = false });
         offset = @intCast(off_val);
     }
 
-    var arr = try ctx.createArray();
+    const arr = try ctx.createArray();
     var parser = parseFormat(fmt, true);
 
     while (parser.next()) |entry| {
@@ -359,9 +357,11 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     }
                 }
 
-                const owned = try ctx.createString(slice);
+                const owned = try Value.String.create(ctx.allocator, slice);
+                defer owned.release();
                 const key = try makeKey(ctx, entry.name, 0, 1);
-                try arr.set(ctx.allocator, key, .{ .string = Value.String.borrowed(owned) });
+                defer if (key == .string) key.string.release();
+                try ctx.vm.arraySetOwned(arr, key, .{ .string = owned });
             },
             'H', 'h' => {
                 const nibbles = switch (entry.count) {
@@ -372,7 +372,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 if (offset + bytes_needed > data.len) return try unpackShort(ctx, entry.code, bytes_needed, if (data.len > offset) data.len - offset else 0);
 
                 const hex_buf = try ctx.allocator.alloc(u8, nibbles);
-                try ctx.strings.append(ctx.allocator, hex_buf);
+                const hex_owned = try Value.String.adopt(ctx.allocator, hex_buf);
+                defer hex_owned.release();
 
                 for (0..nibbles) |i| {
                     const byte = data[offset + i / 2];
@@ -385,7 +386,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 offset += bytes_needed;
 
                 const key = try makeKey(ctx, entry.name, 0, 1);
-                try arr.set(ctx.allocator, key, .{ .string = Value.String.borrowed(hex_buf) });
+                defer if (key == .string) key.string.release();
+                try ctx.vm.arraySetOwned(arr, key, .{ .string = hex_owned });
             },
             'c' => {
                 const repeat = resolveRepeat(entry.count, 1, data.len, offset);
@@ -394,7 +396,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: i8 = @bitCast(data[offset]);
                     offset += 1;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'C' => {
@@ -404,7 +407,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val = data[offset];
                     offset += 1;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             's' => {
@@ -414,7 +418,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: i16 = @bitCast(data[offset..][0..2].*);
                     offset += 2;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'S' => {
@@ -424,7 +429,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: u16 = @bitCast(data[offset..][0..2].*);
                     offset += 2;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'n' => {
@@ -434,7 +440,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val = std.mem.bigToNative(u16, @bitCast(data[offset..][0..2].*));
                     offset += 2;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'v' => {
@@ -444,7 +451,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val = std.mem.littleToNative(u16, @bitCast(data[offset..][0..2].*));
                     offset += 2;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'l' => {
@@ -454,7 +462,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: i32 = @bitCast(data[offset..][0..4].*);
                     offset += 4;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'L' => {
@@ -464,7 +473,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: u32 = @bitCast(data[offset..][0..4].*);
                     offset += 4;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'N' => {
@@ -474,7 +484,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val = std.mem.bigToNative(u32, @bitCast(data[offset..][0..4].*));
                     offset += 4;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'V' => {
@@ -484,7 +495,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val = std.mem.littleToNative(u32, @bitCast(data[offset..][0..4].*));
                     offset += 4;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'i' => {
@@ -497,7 +509,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: c_int = @bitCast(bytes);
                     offset += sz;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'I' => {
@@ -510,7 +523,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: c_uint = @bitCast(bytes);
                     offset += sz;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = @intCast(val) });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = @intCast(val) });
                 }
             },
             'q' => {
@@ -520,7 +534,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: i64 = @bitCast(data[offset..][0..8].*);
                     offset += 8;
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .int = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = val });
                 }
             },
             'Q' => {
@@ -530,8 +545,9 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val: u64 = @bitCast(data[offset..][0..8].*);
                     offset += 8;
                     const key = try makeKey(ctx, entry.name, i, repeat);
+                    defer if (key == .string) key.string.release();
                     const int_val: i64 = if (val > std.math.maxInt(i64)) @bitCast(val) else @intCast(val);
-                    try arr.set(ctx.allocator, key, .{ .int = int_val });
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = int_val });
                 }
             },
             'J' => {
@@ -541,8 +557,9 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val = std.mem.bigToNative(u64, @bitCast(data[offset..][0..8].*));
                     offset += 8;
                     const key = try makeKey(ctx, entry.name, i, repeat);
+                    defer if (key == .string) key.string.release();
                     const int_val: i64 = if (val > std.math.maxInt(i64)) @bitCast(val) else @intCast(val);
-                    try arr.set(ctx.allocator, key, .{ .int = int_val });
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = int_val });
                 }
             },
             'P' => {
@@ -552,8 +569,9 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     const val = std.mem.littleToNative(u64, @bitCast(data[offset..][0..8].*));
                     offset += 8;
                     const key = try makeKey(ctx, entry.name, i, repeat);
+                    defer if (key == .string) key.string.release();
                     const int_val: i64 = if (val > std.math.maxInt(i64)) @bitCast(val) else @intCast(val);
-                    try arr.set(ctx.allocator, key, .{ .int = int_val });
+                    try ctx.vm.arraySetOwned(arr, key, .{ .int = int_val });
                 }
             },
             'f', 'g', 'G' => {
@@ -569,7 +587,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     };
                     const val: f32 = @bitCast(bits);
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .float = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .float = val });
                 }
             },
             'd', 'e', 'E' => {
@@ -585,7 +604,8 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     };
                     const val: f64 = @bitCast(bits);
                     const key = try makeKey(ctx, entry.name, i, repeat);
-                    try arr.set(ctx.allocator, key, .{ .float = val });
+                    defer if (key == .string) key.string.release();
+                    try ctx.vm.arraySetOwned(arr, key, .{ .float = val });
                 }
             },
             'x' => {
@@ -600,21 +620,21 @@ fn native_unpack(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     .star => offset,
                     .exact => |n| n,
                 };
-                if (count > offset) return .{ .bool = false };
+                if (count > offset) return NativeResult.scalar(.{ .bool = false });
                 offset -= count;
             },
             '@' => {
                 const pos = switch (entry.count) {
-                    .star => return .{ .bool = false },
+                    .star => return NativeResult.scalar(.{ .bool = false }),
                     .exact => |n| n,
                 };
                 offset = pos;
             },
-            else => return .{ .bool = false },
+            else => return NativeResult.scalar(.{ .bool = false }),
         }
     }
 
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn resolveRepeat(count: FormatEntry.Count, byte_size: usize, data_len: usize, offset: usize) usize {
@@ -626,10 +646,9 @@ fn resolveRepeat(count: FormatEntry.Count, byte_size: usize, data_len: usize, of
 
 fn makeKey(ctx: *NativeContext, name: ?[]const u8, i: usize, repeat: usize) !PhpArray.Key {
     if (name) |n| {
-        if (repeat <= 1) return .{ .string = Value.String.borrowed(n) };
+        if (repeat <= 1) return .{ .string = try Value.String.create(ctx.allocator, n) };
         const buf = try std.fmt.allocPrint(ctx.allocator, "{s}{d}", .{ n, i + 1 });
-        try ctx.strings.append(ctx.allocator, buf);
-        return .{ .string = Value.String.borrowed(buf) };
+        return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
     }
     return .{ .int = @intCast(i + 1) };
 }

--- a/src/stdlib/pcntl.zig
+++ b/src/stdlib/pcntl.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const posix = std.posix;
 const Value = @import("../runtime/value.zig").Value;
@@ -54,7 +55,7 @@ fn cHandler(sig: c_int) callconv(.c) void {
     if (idx < MAX_SIG) _ = pending_signals[idx].fetchAdd(1, .seq_cst);
 }
 
-fn native_pcntl_fork(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_pcntl_fork(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // flush any buffered output BEFORE fork so the parent's stdout isn't
     // re-emitted by every child when they exit
     if (ctx.vm.output.items.len > 0) {
@@ -64,12 +65,12 @@ fn native_pcntl_fork(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const pid = std.c.fork();
     if (pid < 0) {
         last_errno = std.c._errno().*;
-        return .{ .int = -1 };
+        return NativeResult.scalar(.{ .int = -1 });
     }
-    return .{ .int = @intCast(pid) };
+    return NativeResult.scalar(.{ .int = @intCast(pid) });
 }
 
-fn native_pcntl_wait(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pcntl_wait(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     var status: c_int = 0;
     const options: c_int = if (args.len > 1 and args[1] == .int) @intCast(args[1].int) else 0;
     const rc = std.c.waitpid(-1, &status, options);
@@ -77,11 +78,11 @@ fn native_pcntl_wait(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         ctx.setCallerVar(0, args.len, .{ .int = @intCast(status) });
     }
     if (rc < 0) last_errno = std.c._errno().*;
-    return .{ .int = @intCast(rc) };
+    return NativeResult.scalar(.{ .int = @intCast(rc) });
 }
 
-fn native_pcntl_waitpid(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .int = -1 };
+fn native_pcntl_waitpid(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .int = -1 });
     var status: c_int = 0;
     const options: c_int = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else 0;
     const rc = std.c.waitpid(@intCast(args[0].int), &status, options);
@@ -89,11 +90,11 @@ fn native_pcntl_waitpid(ctx: *NativeContext, args: []const Value) RuntimeError!V
         ctx.setCallerVar(1, args.len, .{ .int = @intCast(status) });
     }
     if (rc < 0) last_errno = std.c._errno().*;
-    return .{ .int = @intCast(rc) };
+    return NativeResult.scalar(.{ .int = @intCast(rc) });
 }
 
-fn native_pcntl_exec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_pcntl_exec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try ctx.allocator.dupeZ(u8, args[0].string.bytes());
     defer ctx.allocator.free(path_z);
 
@@ -142,13 +143,13 @@ fn native_pcntl_exec(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
 
     const rc = execve(path_z, argv.items.ptr, envp.items.ptr);
     last_errno = std.c._errno().*;
-    return .{ .bool = rc == 0 };
+    return NativeResult.scalar(.{ .bool = rc == 0 });
 }
 
-fn native_pcntl_alarm(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .int = 0 };
+fn native_pcntl_alarm(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .int = 0 });
     const prev = alarm(@intCast(args[0].int));
-    return .{ .int = @intCast(prev) };
+    return NativeResult.scalar(.{ .int = @intCast(prev) });
 }
 
 pub fn releaseHandlers(vm: *VM) void {
@@ -158,10 +159,10 @@ pub fn releaseHandlers(vm: *VM) void {
     }
 }
 
-fn native_pcntl_signal(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int) return .{ .bool = false };
+fn native_pcntl_signal(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
     const sig: usize = @intCast(args[0].int);
-    if (sig == 0 or sig >= MAX_SIG) return .{ .bool = false };
+    if (sig == 0 or sig >= MAX_SIG) return NativeResult.scalar(.{ .bool = false });
 
     // SIG_DFL (0), SIG_IGN (1) are the only special int values PHP uses
     if (args[1] == .int and (args[1].int == 0 or args[1].int == 1)) {
@@ -178,7 +179,7 @@ fn native_pcntl_signal(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         posix.sigaction(@intCast(sig), &sa, null);
         ctx.vm.releaseValue(signal_handlers[sig]);
         signal_handlers[sig] = .null;
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
 
     // the handler table owns its callables
@@ -192,24 +193,26 @@ fn native_pcntl_signal(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         .flags = 0,
     };
     posix.sigaction(@intCast(sig), &sa, null);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_pcntl_signal_get_handler(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .int = 0 };
+fn native_pcntl_signal_get_handler(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .int = 0 });
     const sig: usize = @intCast(args[0].int);
-    if (sig >= MAX_SIG) return .{ .int = 0 };
-    if (signal_handlers[sig] == .null) return .{ .int = 0 }; // SIG_DFL
-    return signal_handlers[sig];
+    if (sig >= MAX_SIG) return NativeResult.scalar(.{ .int = 0 });
+    if (signal_handlers[sig] == .null) return NativeResult.scalar(.{ .int = 0 }); // SIG_DFL
+    return NativeResult.share(signal_handlers[sig]);
 }
 
-fn native_pcntl_signal_dispatch(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_pcntl_signal_dispatch(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var i: usize = 1;
     while (i < MAX_SIG) : (i += 1) {
         const pending = pending_signals[i].swap(0, .seq_cst);
         if (pending == 0) continue;
         const cb = signal_handlers[i];
         if (cb == .null) continue;
+        if (cb == .string) cb.string.retain();
+        defer if (cb == .string) cb.string.release();
         const sig_val = Value{ .int = @intCast(i) };
         const sigi_val = Value{ .int = @intCast(i) };
         const info_arr = try ctx.createArray();
@@ -217,13 +220,13 @@ fn native_pcntl_signal_dispatch(ctx: *NativeContext, _: []const Value) RuntimeEr
         const argv = [_]Value{ sig_val, .{ .array = info_arr } };
         _ = ctx.invokeCallable(cb, &argv) catch continue;
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_pcntl_async_signals(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pcntl_async_signals(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const prev = async_enabled;
     if (args.len > 0 and args[0] == .bool) async_enabled = args[0].bool;
-    return .{ .bool = prev };
+    return NativeResult.scalar(.{ .bool = prev });
 }
 
 inline fn wifexited(st: c_int) bool {
@@ -251,37 +254,35 @@ fn intArg(args: []const Value) c_int {
     return @intCast(args[0].int);
 }
 
-fn native_pcntl_wifexited(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = wifexited(intArg(args)) };
+fn native_pcntl_wifexited(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = wifexited(intArg(args)) });
 }
-fn native_pcntl_wexitstatus(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(wexitstatus(intArg(args))) };
+fn native_pcntl_wexitstatus(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(wexitstatus(intArg(args))) });
 }
-fn native_pcntl_wifsignaled(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = wifsignaled(intArg(args)) };
+fn native_pcntl_wifsignaled(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = wifsignaled(intArg(args)) });
 }
-fn native_pcntl_wtermsig(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(wtermsig(intArg(args))) };
+fn native_pcntl_wtermsig(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(wtermsig(intArg(args))) });
 }
-fn native_pcntl_wifstopped(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = wifstopped(intArg(args)) };
+fn native_pcntl_wifstopped(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = wifstopped(intArg(args)) });
 }
-fn native_pcntl_wstopsig(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(wstopsig(intArg(args))) };
-}
-
-fn native_pcntl_get_last_error(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(last_errno) };
+fn native_pcntl_wstopsig(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(wstopsig(intArg(args))) });
 }
 
-fn native_pcntl_strerror(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .string = Value.String.borrowed("") };
-    const s = strerror(@intCast(args[0].int)) orelse return .{ .string = Value.String.borrowed("") };
+fn native_pcntl_get_last_error(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(last_errno) });
+}
+
+fn native_pcntl_strerror(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.literal("");
+    const s = strerror(@intCast(args[0].int)) orelse return NativeResult.literal("");
     var i: usize = 0;
     while (s[i] != 0) : (i += 1) {}
-    const owned = try ctx.allocator.dupe(u8, s[0..i]);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.copyString(ctx.allocator, s[0..i]);
 }
 
 fn maskFailure() Value {
@@ -289,33 +290,33 @@ fn maskFailure() Value {
     return .{ .bool = false };
 }
 
-fn native_pcntl_sigprocmask(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pcntl_sigprocmask(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2 or args[0] != .int or args[1] != .array) {
         last_errno = @intFromEnum(posix.E.INVAL);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const how = std.math.cast(c_int, args[0].int) orelse {
         last_errno = @intFromEnum(posix.E.INVAL);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     // Use libc's sigset_t and helpers: Darwin's set is a scalar, Linux's
     // is an array, and the libc ABI need not match the kernel syscall ABI.
     var set: std.c.sigset_t = undefined;
-    if (std.c.sigemptyset(&set) != 0) return maskFailure();
+    if (std.c.sigemptyset(&set) != 0) return NativeResult.scalar(maskFailure());
     for (args[1].array.entries.items) |entry| {
         const sig = std.math.cast(c_int, entry.value.toInt()) orelse {
             last_errno = @intFromEnum(posix.E.INVAL);
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         };
         // Darwin's libc helpers do not reject every out-of-range signal.
         if (sig <= 0 or sig >= std.c.NSIG) {
             last_errno = @intFromEnum(posix.E.INVAL);
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         }
-        if (std.c.sigaddset(&set, sig) != 0) return maskFailure();
+        if (std.c.sigaddset(&set, sig) != 0) return NativeResult.scalar(maskFailure());
     }
     var old: std.c.sigset_t = undefined;
-    if (std.c.sigprocmask(how, &set, &old) != 0) return maskFailure();
+    if (std.c.sigprocmask(how, &set, &old) != 0) return NativeResult.scalar(maskFailure());
     if (args.len > 2) {
         const result = try ctx.createArray();
         var sig: c_int = 1;
@@ -325,7 +326,7 @@ fn native_pcntl_sigprocmask(ctx: *NativeContext, args: []const Value) RuntimeErr
         }
         ctx.setCallerVar(2, args.len, .{ .array = result });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 pub fn isAsyncEnabled() bool {

--- a/src/stdlib/pcre.zig
+++ b/src/stdlib/pcre.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
 // coerce to string with __toString support. preg functions previously
@@ -325,25 +326,25 @@ fn emitCompileWarning(ctx: *NativeContext, fn_name: []const u8, pattern: []const
     ctx.vm.emitWarning(msg);
 }
 
-fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
-    const pat_str = coerceStrArg(ctx, args[0]) orelse return .{ .bool = false };
-    const subj_str = coerceStrArg(ctx, args[1]) orelse return .{ .bool = false };
+fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    const pat_str = coerceStrArg(ctx, args[0]) orelse return NativeResult.scalar(.{ .bool = false });
+    const subj_str = coerceStrArg(ctx, args[1]) orelse return NativeResult.scalar(.{ .bool = false });
     setPregError(0);
     const info = parsePattern(pat_str) orelse {
         setPregError(1);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     const subject = subj_str;
 
     const code = compilePattern(info.pattern, info.flags) orelse {
         setPregError(1);
         emitCompileWarning(ctx, "preg_match", info.pattern, info.flags);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return Value{ .bool = false };
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return NativeResult.scalar(.{ .bool = false });
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     const flags: u32 = if (args.len >= 4) @intCast(@max(0, Value.toInt(args[3]))) else 0;
@@ -361,7 +362,7 @@ fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 ctx.setCallerVar(2, args.len, .{ .array = matches_arr });
             }
         }
-        return .{ .int = 0 };
+        return NativeResult.scalar(.{ .int = 0 });
     }
 
     if (args.len >= 3) {
@@ -406,7 +407,7 @@ fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
 
-    return .{ .int = 1 };
+    return NativeResult.scalar(.{ .int = 1 });
 }
 
 fn addNamedGroupsInterleaved(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.Code, ovector: [*]usize, subject: []const u8, count: usize, offset_capture: bool, unmatched_as_null: bool) !void {
@@ -523,12 +524,12 @@ fn addNamedGroups(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.Code, ovecto
     }
 }
 
-fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     setPregError(0);
     const info = parsePattern(args[0].string.bytes()) orelse {
         setPregError(1);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     const subject = args[1].string.bytes();
 
@@ -540,11 +541,11 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const code = compilePattern(info.pattern, info.flags) orelse {
         setPregError(1);
         emitCompileWarning(ctx, "preg_match_all", info.pattern, info.flags);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return Value{ .int = 0 };
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return NativeResult.scalar(.{ .int = 0 });
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     var capture_count: u32 = 0;
@@ -687,7 +688,7 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         ctx.setCallerVar(2, args.len, .{ .array = out });
     }
 
-    return .{ .int = total_matches };
+    return NativeResult.scalar(.{ .int = total_matches });
 }
 
 fn matchGroupValue(ctx: *NativeContext, subject: []const u8, ovector: [*]usize, count: usize, i: usize, offset_capture: bool) RuntimeError!Value {
@@ -829,8 +830,8 @@ fn translateReplacement(allocator: std.mem.Allocator, src: []const u8) ![]u8 {
     return out.toOwnedSlice(allocator);
 }
 
-fn preg_filter(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .null;
+fn preg_filter(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.null);
     if (args[2] == .array) {
         const subj_arr = args[2].array;
         const out = try ctx.allocator.create(@import("../runtime/value.zig").PhpArray);
@@ -838,7 +839,7 @@ fn preg_filter(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.arrays.append(ctx.allocator, out);
         for (subj_arr.entries.items) |se| {
             var sub_args: [3]Value = .{ args[0], args[1], se.value };
-            const replaced = try preg_replace(ctx, sub_args[0..3]);
+            const replaced = (try preg_replace(ctx, sub_args[0..3])).value;
             defer if (replaced == .string) replaced.string.release();
             // PHP preg_filter keeps only entries where the replacement actually
             // changed the string (i.e. at least one match)
@@ -846,16 +847,33 @@ fn preg_filter(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 try out.set(ctx.allocator, se.key, replaced);
             }
         }
-        return .{ .array = out };
+        return NativeResult.borrowed(.{ .array = out });
     }
     const replaced = try preg_replace(ctx, args);
-    if (replaced == .string and args[2] == .string and !std.mem.eql(u8, replaced.string.bytes(), args[2].string.bytes())) return replaced;
-    if (replaced == .string) replaced.string.release();
-    return .null;
+    if (replaced.value == .string and args[2] == .string and !std.mem.eql(u8, replaced.value.string.bytes(), args[2].string.bytes())) return replaced;
+    if (replaced.value == .string) replaced.value.string.release();
+    return NativeResult.scalar(.null);
 }
 
-fn preg_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .null;
+// PHP coerces a scalar subject to string before matching, so a scalar
+// always comes back as a string even when nothing matched
+fn replaceWithCoercedSubject(ctx: *NativeContext, args: []const Value, comptime idx: usize, comptime native: anytype) RuntimeError!?NativeResult {
+    if (args.len <= idx or args[idx] == .string or args[idx] == .array or args[idx] == .object) return null;
+    var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
+    try args[idx].format(&buf, ctx.allocator);
+    const subject = try Value.String.create(ctx.allocator, buf.items);
+    defer subject.release();
+    var coerced: [5]Value = undefined;
+    if (args.len > coerced.len) return null;
+    @memcpy(coerced[0..args.len], args);
+    coerced[idx] = .{ .string = subject };
+    return try native(ctx, coerced[0..args.len]);
+}
+
+fn preg_replace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.null);
+    if (try replaceWithCoercedSubject(ctx, args, 2, preg_replace)) |coerced| return coerced;
     // subject can be an array - apply replacements element-wise and return array
     if (args[2] == .array) {
         const subj_arr = args[2].array;
@@ -872,38 +890,38 @@ fn preg_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 sub_args[3] = args[3];
                 n = 4;
             }
-            const replaced = try preg_replace(ctx, sub_args[0..n]);
+            const replaced = (try preg_replace(ctx, sub_args[0..n])).value;
             defer if (replaced == .string) replaced.string.release();
             try result_arr.set(ctx.allocator, se.key, replaced);
         }
-        return .{ .array = result_arr };
+        return NativeResult.borrowed(.{ .array = result_arr });
     }
     // pattern can be array - call recursively for each (pattern, replacement) pair
     if (args[0] == .array) {
         return try pregReplaceArrayPattern(ctx, args);
     }
-    if (args[0] != .string or args[2] != .string) return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+    if (args[0] != .string or args[2] != .string) return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     const info = parsePattern(args[0].string.bytes()) orelse {
         setPregError(1);
-        return .null;
+        return NativeResult.scalar(.null);
     };
-    const replacement = if (args[1] == .string) args[1].string.bytes() else return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+    const replacement = if (args[1] == .string) args[1].string.bytes() else return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     const subject = args[2].string.bytes();
     const limit: i64 = if (args.len >= 4 and args[3] != .null) Value.toInt(args[3]) else -1;
 
     if (limit == 0) {
         if (args.len >= 5) ctx.setCallerVar(4, args.len, .{ .int = 0 });
-        return .{ .string = try Value.String.create(ctx.allocator, subject) };
+        return NativeResult.takeString(try Value.String.create(ctx.allocator, subject));
     }
 
     const code = compilePattern(info.pattern, info.flags) orelse {
         setPregError(1);
         emitCompileWarning(ctx, "preg_replace", info.pattern, info.flags);
-        return .null;
+        return NativeResult.scalar(.null);
     };
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     if (limit > 0) {
@@ -932,11 +950,11 @@ fn preg_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     if (rc >= 0) {
         ctx.setCallerVar(4, args.len, .{ .int = @intCast(rc) });
-        return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+        return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     }
     if (rc != pcre2.ERROR_NOMEMORY) {
         ctx.setCallerVar(4, args.len, .{ .int = 0 });
-        return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+        return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     }
 
     const buf = try ctx.allocator.alloc(u8, out_len);
@@ -957,18 +975,18 @@ fn preg_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (rc < 0) {
         ctx.allocator.free(buf);
         ctx.setCallerVar(4, args.len, .{ .int = 0 });
-        return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+        return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     }
 
     ctx.setCallerVar(4, args.len, .{ .int = @intCast(rc) });
     const result = try Value.String.adopt(ctx.allocator, buf);
-    return .{ .string = result.borrowedSlice(0, out_len) };
+    return NativeResult.takeString(result.borrowedSlice(0, out_len));
 }
 
-fn pregReplaceArrayPattern(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn pregReplaceArrayPattern(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const patterns = args[0].array;
-    var current: Value = if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
-    errdefer if (current == .string) current.string.release();
+    var current: NativeResult = if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
+    errdefer if (current.value == .string) current.value.string.release();
     var total_count: i64 = 0;
     const limit_per: i64 = if (args.len >= 4) Value.toInt(args[3]) else -1;
     for (patterns.entries.items, 0..) |pe, idx| {
@@ -981,8 +999,8 @@ fn pregReplaceArrayPattern(ctx: *NativeContext, args: []const Value) RuntimeErro
             }
         }
         // count matches against the current subject (respecting limit)
-        if (current == .string) {
-            const before = current.string.bytes();
+        if (current.value == .string) {
+            const before = current.value.string.bytes();
             if (parsePattern(pe.value.string.bytes())) |info| {
                 if (compilePattern(info.pattern, info.flags)) |code| {
                     defer pcre2.pcre2_code_free_8(code);
@@ -1007,7 +1025,7 @@ fn pregReplaceArrayPattern(ctx: *NativeContext, args: []const Value) RuntimeErro
         var rest: [3]Value = undefined;
         rest[0] = pe.value;
         rest[1] = replacement;
-        rest[2] = current;
+        rest[2] = current.value;
         var single_args: [4]Value = undefined;
         single_args[0] = rest[0];
         single_args[1] = rest[1];
@@ -1018,14 +1036,14 @@ fn pregReplaceArrayPattern(ctx: *NativeContext, args: []const Value) RuntimeErro
             n = 4;
         }
         const next = try preg_replace(ctx, single_args[0..n]);
-        if (current == .string) current.string.release();
+        if (current.value == .string) current.value.string.release();
         current = next;
     }
     ctx.setCallerVar(4, args.len, .{ .int = total_count });
     return current;
 }
 
-fn pregReplaceLimited(ctx: *NativeContext, code: *pcre2.Code, match_data: *pcre2.MatchData, subject: []const u8, replacement: []const u8, limit: usize, args: []const Value) RuntimeError!Value {
+fn pregReplaceLimited(ctx: *NativeContext, code: *pcre2.Code, match_data: *pcre2.MatchData, subject: []const u8, replacement: []const u8, limit: usize, args: []const Value) RuntimeError!NativeResult {
     var parts = std.ArrayListUnmanaged(u8){};
     defer parts.deinit(ctx.allocator);
     var offset: usize = 0;
@@ -1092,11 +1110,12 @@ fn pregReplaceLimited(ctx: *NativeContext, code: *pcre2.Code, match_data: *pcre2
     const buf = try ctx.allocator.alloc(u8, parts.items.len);
     @memcpy(buf, parts.items);
     ctx.setCallerVar(4, args.len, .{ .int = @intCast(count) });
-    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn preg_replace_callback(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .null;
+fn preg_replace_callback(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.null);
+    if (try replaceWithCoercedSubject(ctx, args, 2, preg_replace_callback)) |coerced| return coerced;
     if (args[2] == .array) {
         const result = try ctx.createArray();
         for (args[2].array.entries.items) |entry| {
@@ -1105,37 +1124,37 @@ fn preg_replace_callback(ctx: *NativeContext, args: []const Value) RuntimeError!
             sub_args[1] = args[1];
             sub_args[2] = entry.value;
             if (args.len >= 4) sub_args[3] = args[3];
-            const replaced = try preg_replace_callback(ctx, sub_args[0..@min(args.len, 4)]);
+            const replaced = (try preg_replace_callback(ctx, sub_args[0..@min(args.len, 4)])).value;
             defer if (replaced == .string) replaced.string.release();
             try result.set(ctx.allocator, entry.key, replaced);
         }
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
     if (args[0] == .array) {
-        var current: Value = if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
-        errdefer if (current == .string) current.string.release();
+        var current: NativeResult = if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
+        errdefer if (current.value == .string) current.value.string.release();
         for (args[0].array.entries.items) |pat_entry| {
             if (pat_entry.value != .string) continue;
             var sub_args: [5]Value = undefined;
             sub_args[0] = pat_entry.value;
             sub_args[1] = args[1];
-            sub_args[2] = current;
+            sub_args[2] = current.value;
             if (args.len >= 4) sub_args[3] = args[3];
             const next = try preg_replace_callback(ctx, sub_args[0..@min(args.len, 4)]);
-            if (current == .string) current.string.release();
+            if (current.value == .string) current.value.string.release();
             current = next;
         }
         return current;
     }
-    if (args[0] != .string or args[2] != .string) return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
-    const info = parsePattern(args[0].string.bytes()) orelse return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+    if (args[0] != .string or args[2] != .string) return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
+    const info = parsePattern(args[0].string.bytes()) orelse return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     const callback = args[1];
     const subject = args[2].string.bytes();
 
-    const code = compilePattern(info.pattern, info.flags) orelse return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+    const code = compilePattern(info.pattern, info.flags) orelse return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return if (args[2] == .string) .{ .string = try Value.String.create(ctx.allocator, args[2].string.bytes()) } else args[2];
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return if (args[2] == .string) NativeResult.takeString(try Value.String.create(ctx.allocator, args[2].string.bytes())) else NativeResult.share(args[2]);
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     var capture_count: u32 = 0;
@@ -1222,11 +1241,12 @@ fn preg_replace_callback(ctx: *NativeContext, args: []const Value) RuntimeError!
     if (args.len >= 5) ctx.setCallerVar(4, args.len, .{ .int = replace_count });
 
     const s = try result.toOwnedSlice(ctx.allocator);
-    return .{ .string = try Value.String.adopt(ctx.allocator, s) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
 }
 
-fn preg_replace_callback_array(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array) return if (args.len >= 2) args[1] else Value.null;
+fn preg_replace_callback_array(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array) return if (args.len >= 2) NativeResult.share(args[1]) else NativeResult.scalar(.null);
+    if (try replaceWithCoercedSubject(ctx, args, 1, preg_replace_callback_array)) |coerced| return coerced;
     const map = args[0].array;
     if (args[1] == .array) {
         const result = try ctx.createArray();
@@ -1235,23 +1255,23 @@ fn preg_replace_callback_array(ctx: *NativeContext, args: []const Value) Runtime
             sub_args[0] = args[0];
             sub_args[1] = entry.value;
             if (args.len >= 3) sub_args[2] = args[2];
-            const replaced = try preg_replace_callback_array(ctx, sub_args[0..args.len]);
+            const replaced = (try preg_replace_callback_array(ctx, sub_args[0..args.len])).value;
             defer if (replaced == .string) replaced.string.release();
             try result.set(ctx.allocator, entry.key, replaced);
         }
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
-    if (args[1] != .string) return args[1];
-    var current: Value = .{ .string = try Value.String.create(ctx.allocator, args[1].string.bytes()) };
-    errdefer if (current == .string) current.string.release();
+    if (args[1] != .string) return NativeResult.share(args[1]);
+    var current = NativeResult.takeString(try Value.String.create(ctx.allocator, args[1].string.bytes()));
+    errdefer current.value.string.release();
     var total_count: i64 = 0;
     const limit: i64 = if (args.len >= 3) Value.toInt(args[2]) else -1;
 
     for (map.entries.items) |entry| {
         if (entry.key != .string) continue;
         // count matches in current subject for this pattern
-        if (current == .string) {
-            const subject = current.string.bytes();
+        if (current.value == .string) {
+            const subject = current.value.string.bytes();
             if (parsePattern(entry.key.string.bytes())) |info| {
                 if (compilePattern(info.pattern, info.flags)) |code| {
                     defer pcre2.pcre2_code_free_8(code);
@@ -1276,15 +1296,15 @@ fn preg_replace_callback_array(ctx: *NativeContext, args: []const Value) Runtime
         var sub_args: [4]Value = undefined;
         sub_args[0] = .{ .string = entry.key.string };
         sub_args[1] = entry.value;
-        sub_args[2] = current;
+        sub_args[2] = current.value;
         var n: usize = 3;
         if (args.len >= 3) {
             sub_args[3] = args[2];
             n = 4;
         }
         const r = try preg_replace_callback(ctx, sub_args[0..n]);
-        if (r == .string) {
-            current.string.release();
+        if (r.value == .string) {
+            current.value.string.release();
             current = r;
         }
     }
@@ -1300,11 +1320,11 @@ fn utf8SeqLen(lead: u8) usize {
     return 1; // continuation byte / invalid - treat as single byte
 }
 
-fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const info = parsePattern(args[0].string.bytes()) orelse {
         setPregError(1);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     const subject = args[1].string.bytes();
     const limit: i64 = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else -1;
@@ -1313,10 +1333,10 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const no_empty = (flags & 1) != 0;
     const offset_capture = (flags & 4) != 0;
 
-    const code = compilePattern(info.pattern, info.flags) orelse return Value.null;
+    const code = compilePattern(info.pattern, info.flags) orelse return NativeResult.scalar(.null);
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return Value.null;
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return NativeResult.scalar(.null);
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     var result = try ctx.createArray();
@@ -1426,11 +1446,11 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
 
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn preg_quote(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn preg_quote(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const input = args[0].string.bytes();
     const delimiter: ?u8 = if (args.len >= 2 and args[1] == .string and args[1].string.bytes().len > 0) args[1].string.bytes()[0] else null;
 
@@ -1447,23 +1467,22 @@ fn preg_quote(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try buf.append(ctx.allocator, c);
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn preg_grep(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .array) return .{ .bool = false };
+fn preg_grep(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .array) return NativeResult.scalar(.{ .bool = false });
     const info = parsePattern(args[0].string.bytes()) orelse {
         setPregError(1);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     const input = args[1].array;
     const invert = args.len >= 3 and Value.toInt(args[2]) == 1;
 
-    const code = compilePattern(info.pattern, info.flags) orelse return Value.null;
+    const code = compilePattern(info.pattern, info.flags) orelse return NativeResult.scalar(.null);
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return Value.null;
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return NativeResult.scalar(.null);
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     var result = try ctx.createArray();
@@ -1475,7 +1494,7 @@ fn preg_grep(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try result.set(ctx.allocator, entry.key, entry.value);
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 // global preg_last_error state - mirrors PHP's per-thread last error
@@ -1485,11 +1504,11 @@ fn setPregError(code: i64) void {
     preg_last_error_code = code;
 }
 
-fn preg_last_error(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = preg_last_error_code };
+fn preg_last_error(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = preg_last_error_code });
 }
 
-fn preg_last_error_msg(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn preg_last_error_msg(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const msg: []const u8 = switch (preg_last_error_code) {
         0 => "No error",
         1 => "Internal error",
@@ -1500,19 +1519,19 @@ fn preg_last_error_msg(_: *NativeContext, _: []const Value) RuntimeError!Value {
         6 => "JIT stack limit exhausted",
         else => "Unknown error",
     };
-    return .{ .string = Value.String.borrowed(msg) };
+    return try NativeResult.copyString(ctx.allocator, msg);
 }
 
-fn mb_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .null;
+fn mb_split(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
     const pattern = args[0].string.bytes();
     const subject = args[1].string.bytes();
     const limit: i64 = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else -1;
 
-    const code = compilePattern(pattern, pcre2.UTF) orelse return Value.null;
+    const code = compilePattern(pattern, pcre2.UTF) orelse return NativeResult.scalar(.null);
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return Value.null;
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return NativeResult.scalar(.null);
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     var result = try ctx.createArray();
@@ -1546,20 +1565,20 @@ fn mb_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try result.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(subject[offset..])) });
     }
 
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn mb_ereg_match(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn mb_ereg_match(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const pattern = args[0].string.bytes();
     const subject = args[1].string.bytes();
 
-    const code = compilePattern(pattern, pcre2.UTF | pcre2.ANCHORED) orelse return .{ .bool = false };
+    const code = compilePattern(pattern, pcre2.UTF | pcre2.ANCHORED) orelse return NativeResult.scalar(.{ .bool = false });
     defer pcre2.pcre2_code_free_8(code);
 
-    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return .{ .bool = false };
+    const match_data = pcre2.pcre2_match_data_create_from_pattern_8(code, null) orelse return NativeResult.scalar(.{ .bool = false });
     defer pcre2.pcre2_match_data_free_8(match_data);
 
     const rc = pcre2.pcre2_match_8(code, subject.ptr, subject.len, 0, 0, match_data, null);
-    return .{ .bool = rc >= 0 };
+    return NativeResult.scalar(.{ .bool = rc >= 0 });
 }

--- a/src/stdlib/pcre.zig
+++ b/src/stdlib/pcre.zig
@@ -383,10 +383,12 @@ fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const end = ovector[i * 2 + 1];
             if (start == pcre2.UNSET or end == pcre2.UNSET) {
                 const val: Value = if (unmatched_as_null) .null else if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
+                defer if (val == .string) val.string.release();
                 try matches_arr.append(ctx.allocator, val);
             } else {
-                const str = try ctx.createString(subject[start..end]);
-                const val = if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = Value.String.borrowed(str) };
+                const str = subject[start..end];
+                const val = if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, str) };
+                defer if (val == .string) val.string.release();
                 try matches_arr.append(ctx.allocator, val);
             }
         }
@@ -394,7 +396,9 @@ fn preg_match(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (pcre2.pcre2_get_mark_8(match_data)) |mark_ptr| {
             const mark = std.mem.sliceTo(mark_ptr, 0);
             if (mark.len > 0) {
-                try matches_arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString("MARK")) }, .{ .string = Value.String.borrowed(try ctx.createString(mark)) });
+                const owned = try Value.String.create(ctx.allocator, mark);
+                defer owned.release();
+                try matches_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("MARK") }, .{ .string = owned });
             }
         }
         if (args[2] != .array) {
@@ -474,11 +478,13 @@ fn addNamedGroupsInterleaved(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.C
             if (unmatched_as_null) break :blk .null;
             break :blk if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
         } else blk: {
-            const s = try ctx.createString(subject[start..end]);
-            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = Value.String.borrowed(s) };
+            const s = subject[start..end];
+            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, s) };
         };
         const insert_pos = lowest;
-        const named_entry = PhpArray.Entry{ .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) }, .value = val };
+        const named_entry = PhpArray.Entry{ .key = .{ .string = try Value.String.create(ctx.allocator, ng.name) }, .value = val };
+        defer named_entry.key.string.release();
+        defer if (val == .string) val.string.release();
         try insertNamedMatch(ctx, arr, insert_pos, named_entry);
         arr.rebuildStringIndexAssumeCapacity();
         inserted_names[inserted_count] = ng.name;
@@ -508,8 +514,11 @@ fn addNamedGroups(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.Code, ovecto
             const val: Value = if (start == pcre2.UNSET or end == pcre2.UNSET)
                 .{ .string = Value.String.borrowed("") }
             else
-                .{ .string = Value.String.borrowed(try ctx.createString(subject[start..end])) };
-            try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(name)) }, val);
+                .{ .string = try Value.String.create(ctx.allocator, subject[start..end]) };
+            defer if (val == .string) val.string.release();
+            const key = try Value.String.create(ctx.allocator, name);
+            defer key.release();
+            try arr.set(ctx.allocator, .{ .string = key }, val);
         }
     }
 }
@@ -584,6 +593,7 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             };
             for (0..last_idx + 1) |i| {
                 const val = try matchGroupValue(ctx, subject, ovector, count, i, offset_capture);
+                defer if (val == .string) val.string.release();
                 try match_arr.append(ctx.allocator, val);
             }
             try addNamedGroupsToMatch(ctx, match_arr, code, ovector, subject, count, offset_capture);
@@ -591,6 +601,7 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         } else {
             for (0..group_count) |i| {
                 const val = try matchGroupValue(ctx, subject, ovector, count, i, offset_capture);
+                defer if (val == .string) val.string.release();
                 try group_arrays.?.items[i].append(ctx.allocator, val);
             }
         }
@@ -661,9 +672,10 @@ fn preg_match_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
             const insert_pos = lowest;
             const named_entry = PhpArray.Entry{
-                .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) },
+                .key = .{ .string = try Value.String.create(ctx.allocator, ng.name) },
                 .value = .{ .array = group_arrays.?.items[ng.group_num] },
             };
+            defer named_entry.key.string.release();
             try insertNamedMatch(ctx, out, insert_pos, named_entry);
             inserted_names[inserted_count] = ng.name;
             inserted_count += 1;
@@ -685,15 +697,17 @@ fn matchGroupValue(ctx: *NativeContext, subject: []const u8, ovector: [*]usize, 
         if (start == pcre2.UNSET or end == pcre2.UNSET) {
             return if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
         }
-        const str = try ctx.createString(subject[start..end]);
-        return if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = Value.String.borrowed(str) };
+        const str = subject[start..end];
+        return if (offset_capture) try makeOffsetPair(ctx, str, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, str) };
     }
     return if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
 }
 
 fn makeOffsetPair(ctx: *NativeContext, str: []const u8, offset: i64) RuntimeError!Value {
     const pair = try ctx.createArray();
-    try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(str) });
+    const owned = try Value.String.create(ctx.allocator, str);
+    defer owned.release();
+    try pair.append(ctx.allocator, .{ .string = owned });
     try pair.append(ctx.allocator, .{ .int = offset });
     return Value{ .array = pair };
 }
@@ -734,11 +748,13 @@ fn addNamedGroupsToMatch(ctx: *NativeContext, arr: *PhpArray, code: *pcre2.Code,
         const val: Value = if (start == pcre2.UNSET or end == pcre2.UNSET) blk: {
             break :blk if (offset_capture) try makeOffsetPair(ctx, "", -1) else Value{ .string = Value.String.borrowed("") };
         } else blk: {
-            const s = try ctx.createString(subject[start..end]);
-            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = Value.String.borrowed(s) };
+            const s = subject[start..end];
+            break :blk if (offset_capture) try makeOffsetPair(ctx, s, @intCast(start)) else Value{ .string = try Value.String.create(ctx.allocator, s) };
         };
         const insert_pos = ng.group_num;
-        const named_entry = PhpArray.Entry{ .key = .{ .string = Value.String.borrowed(try ctx.createString(ng.name)) }, .value = val };
+        const named_entry = PhpArray.Entry{ .key = .{ .string = try Value.String.create(ctx.allocator, ng.name) }, .value = val };
+        defer named_entry.key.string.release();
+        defer if (val == .string) val.string.release();
         try insertNamedMatch(ctx, arr, insert_pos, named_entry);
     }
     arr.rebuildStringIndexAssumeCapacity();
@@ -1337,15 +1353,16 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             continue;
         }
 
-        const piece = try ctx.createString(subject[prev_end..match_start]);
+        const piece = try Value.String.create(ctx.allocator, subject[prev_end..match_start]);
+        defer piece.release();
         if (!no_empty or piece.len > 0) {
             if (offset_capture) {
                 var pair = try ctx.createArray();
-                try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(piece) });
+                try pair.append(ctx.allocator, .{ .string = piece });
                 try pair.append(ctx.allocator, .{ .int = @intCast(prev_end) });
                 try result.append(ctx.allocator, .{ .array = pair });
             } else {
-                try result.append(ctx.allocator, .{ .string = Value.String.borrowed(piece) });
+                try result.append(ctx.allocator, .{ .string = piece });
             }
         }
         splits += 1;
@@ -1356,15 +1373,16 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 const gs = ovector[2 * i];
                 const ge = ovector[2 * i + 1];
                 if (gs <= subject.len and ge <= subject.len) {
-                    const cap = try ctx.createString(subject[gs..ge]);
+                    const cap = try Value.String.create(ctx.allocator, subject[gs..ge]);
+                    defer cap.release();
                     if (!no_empty or cap.len > 0) {
                         if (offset_capture) {
                             var pair = try ctx.createArray();
-                            try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(cap) });
+                            try pair.append(ctx.allocator, .{ .string = cap });
                             try pair.append(ctx.allocator, .{ .int = @intCast(gs) });
                             try result.append(ctx.allocator, .{ .array = pair });
                         } else {
-                            try result.append(ctx.allocator, .{ .string = Value.String.borrowed(cap) });
+                            try result.append(ctx.allocator, .{ .string = cap });
                         }
                     }
                 } else if (!no_empty) {
@@ -1395,15 +1413,16 @@ fn preg_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
 
-    const tail = try ctx.createString(subject[prev_end..]);
+    const tail = try Value.String.create(ctx.allocator, subject[prev_end..]);
+    defer tail.release();
     if (!no_empty or tail.len > 0) {
         if (offset_capture) {
             var pair = try ctx.createArray();
-            try pair.append(ctx.allocator, .{ .string = Value.String.borrowed(tail) });
+            try pair.append(ctx.allocator, .{ .string = tail });
             try pair.append(ctx.allocator, .{ .int = @intCast(prev_end) });
             try result.append(ctx.allocator, .{ .array = pair });
         } else {
-            try result.append(ctx.allocator, .{ .string = Value.String.borrowed(tail) });
+            try result.append(ctx.allocator, .{ .string = tail });
         }
     }
 

--- a/src/stdlib/pdo.zig
+++ b/src/stdlib/pdo.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -238,7 +239,7 @@ fn pdoSqlMsg(ctx: *NativeContext, db: *sqlite.Db, raw: []const u8) ![]const u8 {
     return m;
 }
 
-pub fn throwPdo(ctx: *NativeContext, msg: []const u8) RuntimeError!Value {
+pub fn throwPdo(ctx: *NativeContext, msg: []const u8) RuntimeError!NativeResult {
     if (ctx.vm.pending_exception != null) return error.RuntimeError;
     // honor ATTR_ERRMODE: silent (0) returns false, warning (1) returns false,
     // exception (2) throws PDOException. default in PHP 8 is exception, but for
@@ -251,7 +252,7 @@ pub fn throwPdo(ctx: *NativeContext, msg: []const u8) RuntimeError!Value {
             try obj.set(ctx.allocator, "__error_message", .{ .string = Value.String.borrowed(owned) });
             const mode = obj.get("__errmode");
             const m: i64 = if (mode == .int) mode.int else 2;
-            if (m != 2) return .{ .bool = false };
+            if (m != 2) return NativeResult.scalar(.{ .bool = false });
         }
     }
     _ = try ctx.vm.throwBuiltinException("PDOException", msg);
@@ -475,45 +476,45 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "PDOStatement::valid", stmtIterValid);
 }
 
-fn stmtIterRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtIterRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__iter_key", .{ .int = 0 });
     // fetch the first row
-    const row = try stmtFetch(ctx, &.{});
+    const row = (try stmtFetch(ctx, &.{})).value;
     try obj.set(ctx.allocator, "__iter_current", row);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stmtIterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return retainReturned(obj.get("__iter_current"));
+fn stmtIterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__iter_current"));
 }
 
-fn stmtIterKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return retainReturned(obj.get("__iter_key"));
+fn stmtIterKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(obj.get("__iter_key"));
 }
 
-fn stmtIterNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtIterNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur_key = Value.toInt(obj.get("__iter_key"));
     try obj.set(ctx.allocator, "__iter_key", .{ .int = cur_key + 1 });
-    const row = try stmtFetch(ctx, &.{});
+    const row = (try stmtFetch(ctx, &.{})).value;
     try obj.set(ctx.allocator, "__iter_current", row);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stmtIterValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn stmtIterValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const cur = obj.get("__iter_current");
     // FETCH_CLASS / FETCH_OBJ produce objects; FETCH_ASSOC etc produce arrays.
     // either type is a valid row - only null/false means no more rows
-    return .{ .bool = cur == .array or cur == .object };
+    return NativeResult.scalar(.{ .bool = cur == .array or cur == .object });
 }
 
-fn stmtFetchObject(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const row = try stmtFetch(ctx, &.{.{ .int = 2 }}); // FETCH_ASSOC
-    if (row != .array) return .{ .bool = false };
+fn stmtFetchObject(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const row = (try stmtFetch(ctx, &.{.{ .int = 2 }})).value; // FETCH_ASSOC
+    if (row != .array) return NativeResult.scalar(.{ .bool = false });
     var class_name: []const u8 = "stdClass";
     if (args.len >= 1 and args[0] == .string) class_name = args[0].string.bytes();
     const obj = try ctx.vm.allocator.create(PhpObject);
@@ -525,7 +526,7 @@ fn stmtFetchObject(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     for (row.array.entries.items) |entry| {
         if (entry.key == .string) try obj.set(ctx.allocator, entry.key.string.bytes(), entry.value);
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 fn cleanupStatement(obj: *PhpObject) bool {
@@ -600,7 +601,7 @@ fn getDriver(obj: *PhpObject) []const u8 {
     return "sqlite";
 }
 
-fn pdoConnect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn pdoConnect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("PDO");
     const prev_this = ctx.vm.currentFrame().vars.get("$this");
     try ctx.vm.currentFrame().vars.put(ctx.vm.allocator, "$this", .{ .object = obj });
@@ -612,17 +613,17 @@ fn pdoConnect(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
     _ = try pdoConstruct(ctx, args);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 // PDO\Sqlite::createFunction(string $name, callable $callback, int $numArgs = -1)
 // registers a PHP callable as a SQLite scalar function. wires the trampoline
 // so SQLite actually invokes the PHP code on every call.
-fn pdoSqliteCreateFunction(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
-    if (args[0] != .string) return .{ .bool = false };
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const db = getDbPtr(this) orelse return .{ .bool = false };
+fn pdoSqliteCreateFunction(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const db = getDbPtr(this) orelse return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     const num_args: c_int = if (args.len >= 3 and args[2] == .int) @intCast(args[2].int) else -1;
 
@@ -649,8 +650,8 @@ fn pdoSqliteCreateFunction(ctx: *NativeContext, args: []const Value) RuntimeErro
         null,
         sqliteFuncDestroy,
     );
-    if (rc != 0) return .{ .bool = false };
-    return .{ .bool = true };
+    if (rc != 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // SQLite owns registrations; each aggregate group owns an independent PHP
@@ -770,8 +771,8 @@ fn aggregateFinal(ctx: *sqlite.Context) callconv(.c) void {
     }
 }
 
-fn pdoSqliteCreateAggregate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string) return .{ .bool = false };
+fn pdoSqliteCreateAggregate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     for (args[1..3], 2..) |callback, position| {
         const valid = try ctx.callFunction("is_callable", &.{callback});
         if (!valid.isTruthy()) {
@@ -781,10 +782,10 @@ fn pdoSqliteCreateAggregate(ctx: *NativeContext, args: []const Value) RuntimeErr
             return error.RuntimeError;
         }
     }
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const db = getDbPtr(this) orelse return .{ .bool = false };
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const db = getDbPtr(this) orelse return NativeResult.scalar(.{ .bool = false });
     const count = if (args.len > 3) args[3].toInt() else -1;
-    const num_args = std.math.cast(c_int, count) orelse return .{ .bool = false };
+    const num_args = std.math.cast(c_int, count) orelse return NativeResult.scalar(.{ .bool = false });
     const name = try ctx.allocator.dupeZ(u8, args[0].string.bytes());
     defer ctx.allocator.free(name);
     const reg = try ctx.allocator.create(UserSqlAggregate);
@@ -793,14 +794,14 @@ fn pdoSqliteCreateAggregate(ctx: *NativeContext, args: []const Value) RuntimeErr
     VM.retainValue(reg.final);
     // v2 invokes the destructor even when registration fails.
     const rc = sqlite.sqlite3_create_function_v2(db, name, num_args, sqlite.UTF8, reg, null, aggregateStep, aggregateFinal, aggregateDestroy);
-    return .{ .bool = rc == sqlite.OK };
+    return NativeResult.scalar(.{ .bool = rc == sqlite.OK });
 }
 
-fn pdoSqliteCreateCollation(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
-    if (args[0] != .string) return .{ .bool = false };
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const db = getDbPtr(this) orelse return .{ .bool = false };
+fn pdoSqliteCreateCollation(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const db = getDbPtr(this) orelse return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
 
     const state = try ctx.vm.allocator.create(UserSqlFn);
@@ -815,13 +816,13 @@ fn pdoSqliteCreateCollation(ctx: *NativeContext, args: []const Value) RuntimeErr
     const rc = sqlite.sqlite3_create_collation_v2(db, @ptrCast(name_buf.ptr), sqlite.UTF8, @ptrCast(state), sqliteCollationTrampoline, sqliteFuncDestroy);
     if (rc != 0) {
         sqliteFuncDestroy(state);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn pdoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len < 1 or args[0] != .string) return throwPdo(ctx, "PDO::__construct() expects a DSN string");
 
     const dsn = args[0].string.bytes();
@@ -838,7 +839,7 @@ fn pdoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (rc != sqlite.OK or db == null) return throwPdo(ctx, "Failed to open database");
         try obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(db.?)) });
         try applyOptionsArray(ctx, obj, args);
-        return .null;
+        return NativeResult.scalar(.null);
     }
 
     if (std.mem.eql(u8, driver, "mysql")) {
@@ -869,8 +870,8 @@ fn applyOptionsArray(ctx: *NativeContext, obj: *PhpObject, args: []const Value) 
     }
 }
 
-fn pdoExec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoExec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len < 1 or args[0] != .string) return throwPdo(ctx, "PDO::exec() expects a SQL string");
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.exec(ctx, obj, args[0].string.bytes());
@@ -884,14 +885,14 @@ fn pdoExec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (rc != sqlite.OK) {
         const raw = if (errmsg) |e| std.mem.span(e) else "SQL execution error";
         const result = try throwPdo(ctx, try pdoSqlMsg(ctx, db, raw));
-        if (result == .bool and !result.bool) return .{ .bool = false };
+        if (result.value == .bool and !result.value.bool) return NativeResult.scalar(.{ .bool = false });
         return result;
     }
-    return .{ .int = sqlite.sqlite3_changes(db) };
+    return NativeResult.scalar(.{ .int = sqlite.sqlite3_changes(db) });
 }
 
-fn pdoQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoQuery(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len < 1 or args[0] != .string) return throwPdo(ctx, "PDO::query() expects a SQL string");
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.query(ctx, obj, args[0].string.bytes());
@@ -917,11 +918,11 @@ fn pdoQuery(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = step_rc == sqlite.ROW });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = true });
 
-    return .{ .object = stmt_obj };
+    return NativeResult.borrowed(.{ .object = stmt_obj });
 }
 
-fn pdoPrepare(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoPrepare(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len < 1 or args[0] != .string) return throwPdo(ctx, "PDO::prepare() expects a SQL string");
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.prepare(ctx, obj, args[0].string.bytes());
@@ -943,23 +944,23 @@ fn pdoPrepare(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = false });
 
-    return .{ .object = stmt_obj };
+    return NativeResult.borrowed(.{ .object = stmt_obj });
 }
 
-fn pdoLastInsertId(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoLastInsertId(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.lastInsertId(ctx, obj);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.lastInsertId(ctx, obj);
-    const db = getDbPtr(obj) orelse return .{ .string = Value.String.borrowed("0") };
+    const db = getDbPtr(obj) orelse return NativeResult.literal("0");
     const id = sqlite.sqlite3_last_insert_rowid(db);
     var buf: [32]u8 = undefined;
     const s = std.fmt.bufPrint(&buf, "{d}", .{id}) catch "0";
-    return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+    return try NativeResult.copyString(ctx.allocator, s);
 }
 
-fn pdoBeginTransaction(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoBeginTransaction(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const in_tx = obj.get("__in_transaction");
     if (in_tx == .bool and in_tx.bool) {
         try ctx.vm.setPendingException("PDOException", "There is already an active transaction");
@@ -968,40 +969,40 @@ fn pdoBeginTransaction(ctx: *NativeContext, _: []const Value) RuntimeError!Value
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.beginTransaction(ctx, obj);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.beginTransaction(ctx, obj);
-    const db = getDbPtr(obj) orelse return .{ .bool = false };
+    const db = getDbPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const rc = sqlite.sqlite3_exec(db, "BEGIN", null, null, null);
     if (rc == sqlite.OK) try obj.set(ctx.allocator, "__in_transaction", .{ .bool = true });
-    return .{ .bool = rc == sqlite.OK };
+    return NativeResult.scalar(.{ .bool = rc == sqlite.OK });
 }
 
-fn pdoCommit(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoCommit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.commit(ctx, obj);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.commit(ctx, obj);
-    const db = getDbPtr(obj) orelse return .{ .bool = false };
+    const db = getDbPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const rc = sqlite.sqlite3_exec(db, "COMMIT", null, null, null);
     if (rc == sqlite.OK) try obj.set(ctx.allocator, "__in_transaction", .{ .bool = false });
-    return .{ .bool = rc == sqlite.OK };
+    return NativeResult.scalar(.{ .bool = rc == sqlite.OK });
 }
 
-fn pdoRollBack(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoRollBack(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.rollBack(ctx, obj);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.rollBack(ctx, obj);
-    const db = getDbPtr(obj) orelse return .{ .bool = false };
+    const db = getDbPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const rc = sqlite.sqlite3_exec(db, "ROLLBACK", null, null, null);
     if (rc == sqlite.OK) try obj.set(ctx.allocator, "__in_transaction", .{ .bool = false });
-    return .{ .bool = rc == sqlite.OK };
+    return NativeResult.scalar(.{ .bool = rc == sqlite.OK });
 }
 
-fn pdoErrorInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoErrorInfo(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.errorInfo(ctx, obj);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.errorInfo(ctx, obj);
-    const db = getDbPtr(obj) orelse return .null;
+    const db = getDbPtr(obj) orelse return NativeResult.scalar(.null);
     var arr = try ctx.createArray();
     const msg = std.mem.span(sqlite.sqlite3_errmsg(db));
     const has_err = !std.mem.eql(u8, msg, "not an error") and msg.len > 0;
@@ -1013,13 +1014,13 @@ fn pdoErrorInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try arr.append(ctx.allocator, .null);
         try arr.append(ctx.allocator, .null);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn pdoSetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 2) return .{ .bool = false };
-    const attr = if (args[0] == .int) args[0].int else return .{ .bool = false };
+fn pdoSetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    const attr = if (args[0] == .int) args[0].int else return NativeResult.scalar(.{ .bool = false });
     if (attr == 19) {
         try obj.set(ctx.allocator, "__default_fetch_mode", args[1]);
     } else if (attr == 3) {
@@ -1028,50 +1029,50 @@ fn pdoSetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     // general attribute storage so subsequent getAttribute() reads return the
     // last value set even for attributes that don't influence native behavior
     var key_buf: [32]u8 = undefined;
-    const key = std.fmt.bufPrint(&key_buf, "__attr_{d}", .{attr}) catch return .{ .bool = true };
+    const key = std.fmt.bufPrint(&key_buf, "__attr_{d}", .{attr}) catch return NativeResult.scalar(.{ .bool = true });
     const owned_key = try ctx.allocator.dupe(u8, key);
     try ctx.vm.strings.append(ctx.allocator, owned_key);
     try obj.set(ctx.allocator, owned_key, args[1]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn pdoGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .int) return .null;
+fn pdoGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.null);
     const attr = args[0].int;
     if (attr == 19) {
         const mode = obj.get("__default_fetch_mode");
-        if (mode == .int) return mode;
-        return .{ .int = 4 };
+        if (mode == .int) return NativeResult.share(mode);
+        return NativeResult.scalar(.{ .int = 4 });
     }
     if (attr == 3) {
         const m = obj.get("__errmode");
-        if (m == .int) return m;
-        return .{ .int = 2 };
+        if (m == .int) return NativeResult.share(m);
+        return NativeResult.scalar(.{ .int = 2 });
     }
-    if (attr == 16) return .{ .string = Value.String.borrowed(getDriver(obj)) };
+    if (attr == 16) return try NativeResult.copyString(ctx.allocator, getDriver(obj));
     // ATTR_SERVER_VERSION / ATTR_CLIENT_VERSION just need to return a string;
     // most callers only test is_string. zphp links sqlite at build time so a
     // generic placeholder is fine
     if (attr == 4 or attr == 5) {
-        return .{ .string = Value.String.borrowed("0") };
+        return NativeResult.literal("0");
     }
     // fall back to the generic attribute store populated by setAttribute
     var key_buf: [32]u8 = undefined;
-    const key = std.fmt.bufPrint(&key_buf, "__attr_{d}", .{attr}) catch return .null;
+    const key = std.fmt.bufPrint(&key_buf, "__attr_{d}", .{attr}) catch return NativeResult.scalar(.null);
     const stored = obj.get(key);
-    if (stored != .null) return stored;
-    return .null;
+    if (stored != .null) return NativeResult.share(stored);
+    return NativeResult.scalar(.null);
 }
 
 // PDOStatement methods
 
-fn stmtExecute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtExecute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.stmtExecute(ctx, obj, args);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.stmtExecute(ctx, obj, args);
-    const stmt = getStmtPtr(obj) orelse return .{ .bool = false };
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     _ = sqlite.sqlite3_reset(stmt);
 
@@ -1091,7 +1092,7 @@ fn stmtExecute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const msg = std.mem.span(sqlite.sqlite3_errmsg(db));
             return throwPdo(ctx, try pdoSqlMsg(ctx, db, msg));
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     // store affected rows
@@ -1101,15 +1102,15 @@ fn stmtExecute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try obj.set(ctx.allocator, "__row_count", .{ .int = sqlite.sqlite3_changes(db) });
     }
 
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.stmtFetch(ctx, obj, args);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.stmtFetch(ctx, obj, args);
-    const stmt = getStmtPtr(obj) orelse return .{ .bool = false };
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     const has_row = obj.get("__has_row");
     const stepped = obj.get("__stepped");
@@ -1119,9 +1120,9 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = rc == sqlite.ROW });
         try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
-        if (rc != sqlite.ROW) return .{ .bool = false };
+        if (rc != sqlite.ROW) return NativeResult.scalar(.{ .bool = false });
     } else if (has_row != .bool or !has_row.bool) {
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     const mode: i64 = if (args.len >= 1 and args[0] == .int) args[0].int else getDefaultFetchMode(obj);
@@ -1130,7 +1131,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const row = try fetchRowAsObject(ctx, stmt);
         const next_rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
-        return row;
+        return NativeResult.borrowed(row);
     }
 
     if (mode == 8) {
@@ -1144,7 +1145,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         const next_rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
-        return inst;
+        return NativeResult.borrowed(inst);
     }
 
     if (mode == 9) {
@@ -1152,7 +1153,7 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (target_v == .object) try populateObjectFromRow(ctx, target_v.object, stmt);
         const next_rc = try stepSqlite(ctx, stmt);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
-        return target_v;
+        return NativeResult.share(target_v);
     }
 
     const row = try fetchRow(ctx, stmt, mode);
@@ -1161,15 +1162,15 @@ fn stmtFetch(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const next_rc = try stepSqlite(ctx, stmt);
     try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
 
-    return .{ .array = row };
+    return NativeResult.borrowed(.{ .array = row });
 }
 
-fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.stmtFetchAll(ctx, obj, args);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.stmtFetchAll(ctx, obj, args);
-    const stmt = getStmtPtr(obj) orelse return .{ .bool = false };
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     const mode: i64 = if (args.len >= 1 and args[0] == .int) args[0].int else getDefaultFetchMode(obj);
     const FETCH_GROUP_FLAG: i64 = 65536;
@@ -1194,6 +1195,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             first = false;
             // first column is the group/unique key
             const key_v = try columnToValue(ctx, stmt, 0);
+            defer if (key_v == .string) key_v.string.release();
             const ak: PhpArray.Key = switch (key_v) {
                 .string => |s| .{ .string = s },
                 .int => |n| .{ .int = n },
@@ -1203,6 +1205,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             // for FETCH_COLUMN the per-row value is the next column scalar;
             // for FETCH_NUM/ASSOC/BOTH the per-row value is a row array
             var row_value: Value = .null;
+            defer if (row_value == .string) row_value.string.release();
             if (row_mode == 7) {
                 const col_count_c = sqlite.sqlite3_column_count(stmt);
                 row_value = if (col_count_c > 1) try columnToValue(ctx, stmt, 1) else .null;
@@ -1212,11 +1215,13 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 var i: c_int = 1;
                 while (i < col_count) : (i += 1) {
                     const v = try columnToValue(ctx, stmt, i);
+                    defer if (v == .string) v.string.release();
                     if (row_mode == 3 or row_mode == 4) try inner.append(ctx.allocator, v);
                     if (row_mode == 2 or row_mode == 4) {
                         if (sqlite.sqlite3_column_name(stmt, i)) |np| {
-                            const name = try ctx.createString(std.mem.span(np));
-                            try inner.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, v);
+                            const name = try Value.String.create(ctx.allocator, std.mem.span(np));
+                            defer name.release();
+                            try inner.set(ctx.allocator, .{ .string = name }, v);
                         }
                     }
                 }
@@ -1240,13 +1245,13 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     if (mode == 5) {
         try fetchAllAsObjects(ctx, stmt, result, obj);
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     const has_row_pre = obj.get("__has_row");
@@ -1277,7 +1282,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     // FETCH_INTO (9): populate the previously-set fetch-into target
@@ -1285,7 +1290,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const target_v = obj.get("__fetch_into");
         if (target_v != .object) {
             try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-            return .{ .array = result };
+            return NativeResult.borrowed(.{ .array = result });
         }
         const target = target_v.object;
         if (start_with_row) {
@@ -1299,13 +1304,13 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     // FETCH_FUNC (10): pass each row's columns as args to a callable, collect
     // the return value as the row in the result array
     if (mode == 10) {
-        if (args.len < 2) return .{ .bool = false };
+        if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
         const callable = args[1];
         const col_count = sqlite.sqlite3_column_count(stmt);
         if (start_with_row) {
@@ -1313,6 +1318,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             defer ctx.allocator.free(call_args);
             var i: c_int = 0;
             while (i < col_count) : (i += 1) call_args[@intCast(i)] = try columnToValue(ctx, stmt, i);
+            defer for (call_args) |a| if (a == .string) a.string.release();
             const r = try ctx.invokeCallable(callable, call_args);
             try result.append(ctx.allocator, r);
         }
@@ -1322,19 +1328,22 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             defer ctx.allocator.free(call_args);
             var i: c_int = 0;
             while (i < col_count) : (i += 1) call_args[@intCast(i)] = try columnToValue(ctx, stmt, i);
+            defer for (call_args) |a| if (a == .string) a.string.release();
             const r = try ctx.invokeCallable(callable, call_args);
             try result.append(ctx.allocator, r);
             rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     // FETCH_KEY_PAIR (12): col 0 = key, col 1 = value
     if (mode == 12) {
         if (start_with_row) {
             const key_v = try columnToValue(ctx, stmt, 0);
+            defer if (key_v == .string) key_v.string.release();
             const val_v = try columnToValue(ctx, stmt, 1);
+            defer if (val_v == .string) val_v.string.release();
             const ak: PhpArray.Key = switch (key_v) {
                 .string => |s| .{ .string = s },
                 .int => |n| .{ .int = n },
@@ -1345,7 +1354,9 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             const key_v = try columnToValue(ctx, stmt, 0);
+            defer if (key_v == .string) key_v.string.release();
             const val_v = try columnToValue(ctx, stmt, 1);
+            defer if (val_v == .string) val_v.string.release();
             const ak: PhpArray.Key = switch (key_v) {
                 .string => |s| .{ .string = s },
                 .int => |n| .{ .int = n },
@@ -1355,7 +1366,7 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     // FETCH_COLUMN (7): single column from each row, default col 0
@@ -1363,16 +1374,18 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const col_idx: c_int = if (args.len >= 2 and args[1] == .int) @intCast(args[1].int) else 0;
         if (start_with_row) {
             const val_v = try columnToValue(ctx, stmt, col_idx);
+            defer if (val_v == .string) val_v.string.release();
             try result.append(ctx.allocator, val_v);
         }
         var rc = try stepSqlite(ctx, stmt);
         while (rc == sqlite.ROW) {
             const val_v = try columnToValue(ctx, stmt, col_idx);
+            defer if (val_v == .string) val_v.string.release();
             try result.append(ctx.allocator, val_v);
             rc = try stepSqlite(ctx, stmt);
         }
         try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
 
     const has_row = obj.get("__has_row");
@@ -1399,15 +1412,15 @@ fn stmtFetchAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn stmtFetchColumn(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtFetchColumn(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.stmtFetchColumn(ctx, obj, args);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.stmtFetchColumn(ctx, obj, args);
-    const stmt = getStmtPtr(obj) orelse return .{ .bool = false };
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     const col: c_int = if (args.len >= 1 and args[0] == .int) @intCast(args[0].int) else 0;
 
@@ -1416,9 +1429,9 @@ fn stmtFetchColumn(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
 
     if (stepped != .bool or !stepped.bool) {
         const rc = try stepSqlite(ctx, stmt);
-        if (rc != sqlite.ROW) return .{ .bool = false };
+        if (rc != sqlite.ROW) return NativeResult.scalar(.{ .bool = false });
     } else if (has_row != .bool or !has_row.bool) {
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     const val = try columnToValue(ctx, stmt, col);
@@ -1427,48 +1440,49 @@ fn stmtFetchColumn(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     try obj.set(ctx.allocator, "__has_row", .{ .bool = next_rc == sqlite.ROW });
     try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
 
-    return val;
+    if (val == .string) return NativeResult.takeString(val.string);
+    return NativeResult.scalar(val);
 }
 
-fn stmtRowCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtRowCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = getDriver(obj);
     // for SELECT statements, sqlite doesn't track row count
     const stmt = getStmtPtr(obj);
     if (stmt) |s| {
-        if (sqlite.sqlite3_stmt_readonly(s) != 0) return .{ .int = 0 };
+        if (sqlite.sqlite3_stmt_readonly(s) != 0) return NativeResult.scalar(.{ .int = 0 });
     }
     const rc = obj.get("__row_count");
-    if (rc == .int) return rc;
-    return .{ .int = 0 };
+    if (rc == .int) return NativeResult.share(rc);
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn stmtColumnCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtColumnCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.stmtColumnCount(obj);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.stmtColumnCount(obj);
     // PHP returns 0 before execute
     const stepped = obj.get("__stepped");
-    if (stepped != .bool or !stepped.bool) return .{ .int = 0 };
-    const stmt = getStmtPtr(obj) orelse return .{ .int = 0 };
-    return .{ .int = sqlite.sqlite3_column_count(stmt) };
+    if (stepped != .bool or !stepped.bool) return NativeResult.scalar(.{ .int = 0 });
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = sqlite.sqlite3_column_count(stmt) });
 }
 
-fn stmtCloseCursor(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtCloseCursor(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const drv = getDriver(obj);
     if (std.mem.eql(u8, drv, "mysql")) return pdo_mysql.stmtCloseCursor(ctx, obj);
     if (std.mem.eql(u8, drv, "pgsql")) return pdo_pgsql.stmtCloseCursor(ctx, obj);
-    const stmt = getStmtPtr(obj) orelse return .{ .bool = true };
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .bool = true });
     _ = sqlite.sqlite3_reset(stmt);
     try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     try obj.set(ctx.allocator, "__stepped", .{ .bool = false });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn stmtSetFetchMode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn stmtSetFetchMode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const mode: Value = if (args.len >= 1) args[0] else .{ .int = 4 };
     try obj.set(ctx.allocator, "__fetch_mode", mode);
     if (mode == .int and mode.int == 9 and args.len >= 2 and args[1] == .object) {
@@ -1478,7 +1492,7 @@ fn stmtSetFetchMode(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         try obj.set(ctx.allocator, "__fetch_class", args[1]);
         if (args.len >= 3 and args[2] == .array) try obj.set(ctx.allocator, "__fetch_class_args", args[2]);
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn invokeCtorWithArgs(ctx: *NativeContext, inst_val: Value, class_name: []const u8, ctor_args: ?*PhpArray) !void {
@@ -1505,80 +1519,81 @@ fn populateObjectFromRow(ctx: *NativeContext, obj: *PhpObject, stmt: *sqlite.Stm
             const name = std.mem.span(name_ptr);
             const owned = try ctx.createString(name);
             const val = try columnToValue(ctx, stmt, i);
+            defer if (val == .string) val.string.release();
             try obj.set(ctx.allocator, owned, val);
         }
     }
 }
 
-fn pdoQuote(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
+fn pdoQuote(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     var s_buf: [4096]u8 = undefined;
     const v = args[0];
     var input: []const u8 = "";
     var fallback: [32]u8 = undefined;
     switch (v) {
         .string => |s| input = s.bytes(),
-        .int => |n| input = std.fmt.bufPrint(&fallback, "{d}", .{n}) catch return .{ .bool = false },
-        .float => |f| input = std.fmt.bufPrint(&fallback, "{d}", .{f}) catch return .{ .bool = false },
+        .int => |n| input = std.fmt.bufPrint(&fallback, "{d}", .{n}) catch return NativeResult.scalar(.{ .bool = false }),
+        .float => |f| input = std.fmt.bufPrint(&fallback, "{d}", .{f}) catch return NativeResult.scalar(.{ .bool = false }),
         .bool => |b| input = if (b) "1" else "",
         .null => input = "",
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     }
     // single-quote and double internal quotes per SQL standard
     var w: usize = 0;
-    if (w + 1 >= s_buf.len) return .{ .bool = false };
+    if (w + 1 >= s_buf.len) return NativeResult.scalar(.{ .bool = false });
     s_buf[w] = '\'';
     w += 1;
     for (input) |c| {
         if (c == '\'') {
-            if (w + 2 >= s_buf.len) return .{ .bool = false };
+            if (w + 2 >= s_buf.len) return NativeResult.scalar(.{ .bool = false });
             s_buf[w] = '\'';
             w += 1;
             s_buf[w] = '\'';
             w += 1;
         } else {
-            if (w + 1 >= s_buf.len) return .{ .bool = false };
+            if (w + 1 >= s_buf.len) return NativeResult.scalar(.{ .bool = false });
             s_buf[w] = c;
             w += 1;
         }
     }
-    if (w + 1 >= s_buf.len) return .{ .bool = false };
+    if (w + 1 >= s_buf.len) return NativeResult.scalar(.{ .bool = false });
     s_buf[w] = '\'';
     w += 1;
-    const result = try ctx.createString(s_buf[0..w]);
-    return .{ .string = Value.String.borrowed(result) };
+    const result = try Value.String.create(ctx.allocator, s_buf[0..w]);
+    return NativeResult.takeString(result);
 }
 
-fn pdoInTransaction(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn pdoInTransaction(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const t = obj.get("__in_transaction");
-    return .{ .bool = t == .bool and t.bool };
+    return NativeResult.scalar(.{ .bool = t == .bool and t.bool });
 }
 
-fn pdoGetAvailableDrivers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn pdoGetAvailableDrivers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("sqlite") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("mysql") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("pgsql") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn pdoErrorCode(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pdoErrorCode(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const code = obj.get("__error_code");
-    if (code == .string) return code;
-    return .{ .string = Value.String.borrowed("00000") };
+    if (code == .string) return NativeResult.share(code);
+    return NativeResult.literal("00000");
 }
 
-fn stmtErrorCode(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtErrorCode(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const code = obj.get("__error_code");
-    if (code == .string) return code;
-    return .{ .string = Value.String.borrowed("00000") };
+    if (code == .string) return NativeResult.share(code);
+    return NativeResult.literal("00000");
 }
 
-fn stmtErrorInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stmtErrorInfo(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ctx.createArray();
     const code = obj.get("__error_code");
     try arr.append(ctx.allocator, if (code == .string) code else .{ .string = Value.String.borrowed("00000") });
@@ -1586,36 +1601,36 @@ fn stmtErrorInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try arr.append(ctx.allocator, if (driver_code == .int) driver_code else .null);
     const msg = obj.get("__error_message");
     try arr.append(ctx.allocator, if (msg == .string) msg else .null);
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn stmtDebugDumpParams(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn stmtDebugDumpParams(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn stmtGetColumnMeta(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const stmt = getStmtPtr(obj) orelse return .{ .bool = false };
+fn stmtGetColumnMeta(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const col: c_int = @intCast(args[0].int);
     const arr = try ctx.createArray();
     if (sqlite.sqlite3_column_name(stmt, col)) |np| {
         const n = std.mem.span(np);
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = Value.String.borrowed(try ctx.createString(n)) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn stmtNextRowset(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = false };
+fn stmtNextRowset(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn stmtBindValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 2) return .{ .bool = false };
+fn stmtBindValue(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const drv = getDriver(obj);
-    if (std.mem.eql(u8, drv, "mysql") or std.mem.eql(u8, drv, "pgsql")) return .{ .bool = true };
-    const stmt = getStmtPtr(obj) orelse return .{ .bool = false };
+    if (std.mem.eql(u8, drv, "mysql") or std.mem.eql(u8, drv, "pgsql")) return NativeResult.scalar(.{ .bool = true });
+    const stmt = getStmtPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const param = args[0];
     const val = args[1];
     const idx: c_int = if (param == .int) @intCast(param.int) else blk: {
@@ -1634,7 +1649,7 @@ fn stmtBindValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         break :blk sqlite.sqlite3_bind_parameter_index(stmt, @ptrCast(buf.ptr));
     };
-    if (idx == 0) return .{ .bool = false };
+    if (idx == 0) return NativeResult.scalar(.{ .bool = false });
     const rc = switch (val) {
         .int => sqlite.sqlite3_bind_int64(stmt, idx, val.int),
         .float => sqlite.sqlite3_bind_double(stmt, idx, val.float),
@@ -1643,7 +1658,7 @@ fn stmtBindValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         .bool => sqlite.sqlite3_bind_int64(stmt, idx, if (val.bool) 1 else 0),
         else => sqlite.sqlite3_bind_null(stmt, idx),
     };
-    return .{ .bool = rc == sqlite.OK };
+    return NativeResult.scalar(.{ .bool = rc == sqlite.OK });
 }
 
 fn getDefaultFetchMode(obj: *PhpObject) i64 {
@@ -1668,6 +1683,7 @@ fn fetchRowAsObject(ctx: *NativeContext, stmt: *sqlite.Stmt) !Value {
     var i: c_int = 0;
     while (i < col_count) : (i += 1) {
         const val = try columnToValue(ctx, stmt, i);
+        defer if (val == .string) val.string.release();
         if (sqlite.sqlite3_column_name(stmt, i)) |name_ptr| {
             const name = std.mem.span(name_ptr);
             try obj.set(ctx.allocator, try ctx.createString(name), val);
@@ -1688,6 +1704,7 @@ fn fetchRowAsClass(ctx: *NativeContext, stmt: *sqlite.Stmt, class_name: []const 
             const name = std.mem.span(name_ptr);
             const owned = try ctx.createString(name);
             const val = try columnToValue(ctx, stmt, i);
+            defer if (val == .string) val.string.release();
             try obj.set(ctx.allocator, owned, val);
         }
     }
@@ -1725,26 +1742,30 @@ fn fetchRow(ctx: *NativeContext, stmt: *sqlite.Stmt, mode: i64) !*PhpArray {
     var i: c_int = 0;
     while (i < col_count) : (i += 1) {
         const val = try columnToValue(ctx, stmt, i);
+        defer if (val == .string) val.string.release();
         // FETCH_BOTH places named key before numeric per column to match php
         if (mode == 4) {
             if (sqlite.sqlite3_column_name(stmt, i)) |name_ptr| {
-                const name = std.mem.span(name_ptr);
-                try row.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(name)) }, val);
+                const key = try Value.String.create(ctx.allocator, std.mem.span(name_ptr));
+                defer key.release();
+                try row.set(ctx.allocator, .{ .string = key }, val);
             }
             try row.append(ctx.allocator, val);
         } else if (mode == 3) {
             try row.append(ctx.allocator, val);
         } else if (mode == 2) {
             if (sqlite.sqlite3_column_name(stmt, i)) |name_ptr| {
-                const name = std.mem.span(name_ptr);
-                try row.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(name)) }, val);
+                const key = try Value.String.create(ctx.allocator, std.mem.span(name_ptr));
+                defer key.release();
+                try row.set(ctx.allocator, .{ .string = key }, val);
             }
         } else if (mode == 11) {
             // FETCH_NAMED: same as FETCH_ASSOC, but duplicate column names
             // collapse into an array of values rather than overwriting
             if (sqlite.sqlite3_column_name(stmt, i)) |name_ptr| {
-                const name = std.mem.span(name_ptr);
-                const key = PhpArray.Key{ .string = Value.String.borrowed(try ctx.createString(name)) };
+                const key_s = try Value.String.create(ctx.allocator, std.mem.span(name_ptr));
+                defer key_s.release();
+                const key = PhpArray.Key{ .string = key_s };
                 const existing = row.get(key);
                 if (existing == .null) {
                     try row.set(ctx.allocator, key, val);
@@ -1769,10 +1790,9 @@ fn columnToValue(ctx: *NativeContext, stmt: *sqlite.Stmt, col: c_int) !Value {
         sqlite.INTEGER => .{ .int = sqlite.sqlite3_column_int64(stmt, col) },
         sqlite.FLOAT => .{ .float = sqlite.sqlite3_column_double(stmt, col) },
         sqlite.TEXT, sqlite.BLOB => blk: {
-            const text = sqlite.sqlite3_column_text(stmt, col) orelse break :blk Value{ .string = Value.String.borrowed("") };
+            const text = sqlite.sqlite3_column_text(stmt, col) orelse break :blk Value{ .string = try Value.String.create(ctx.allocator, "") };
             const len: usize = @intCast(sqlite.sqlite3_column_bytes(stmt, col));
-            const s = try ctx.createString(text[0..len]);
-            break :blk Value{ .string = Value.String.borrowed(s) };
+            break :blk Value{ .string = try Value.String.create(ctx.allocator, text[0..len]) };
         },
         else => .null,
     };

--- a/src/stdlib/pdo_mysql.zig
+++ b/src/stdlib/pdo_mysql.zig
@@ -5,6 +5,7 @@ const PhpObject = @import("../runtime/value.zig").PhpObject;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 const pdo = @import("pdo.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 
 const mysql = struct {
     const MYSQL = opaque {};
@@ -68,7 +69,7 @@ fn parseDsnParams(rest: []const u8) struct { host: ?[]const u8, port: u16, dbnam
     return .{ .host = host, .port = port, .dbname = dbname, .unix_socket = unix_socket };
 }
 
-pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []const Value) RuntimeError!Value {
+pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []const Value) RuntimeError!NativeResult {
     const params = parseDsnParams(rest);
     const user = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else null;
     const pass = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else null;
@@ -88,20 +89,20 @@ pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []c
     }
 
     try obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-pub fn exec(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!Value {
+pub fn exec(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!NativeResult {
     const conn = getConn(obj) orelse return pdo.throwPdo(ctx, "Database not connected");
     if (mysql.mysql_real_query(conn, sql.ptr, @intCast(sql.len)) != 0) {
         return pdo.throwPdo(ctx, std.mem.span(mysql.mysql_error(conn)));
     }
     // consume result if any (for non-SELECT)
     if (mysql.mysql_store_result(conn)) |res| mysql.mysql_free_result(res);
-    return .{ .int = @intCast(mysql.mysql_affected_rows(conn)) };
+    return NativeResult.scalar(.{ .int = @intCast(mysql.mysql_affected_rows(conn)) });
 }
 
-pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!Value {
+pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!NativeResult {
     const conn = getConn(obj) orelse return pdo.throwPdo(ctx, "Database not connected");
     if (mysql.mysql_real_query(conn, sql.ptr, @intCast(sql.len)) != 0) {
         return pdo.throwPdo(ctx, std.mem.span(mysql.mysql_error(conn)));
@@ -115,10 +116,10 @@ pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError
     try stmt_obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = true });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = true });
-    return .{ .object = stmt_obj };
+    return NativeResult.borrowed(.{ .object = stmt_obj });
 }
 
-pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!Value {
+pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!NativeResult {
     const conn = getConn(obj) orelse return pdo.throwPdo(ctx, "Database not connected");
 
     // rewrite named params to positional ? and build param map
@@ -167,13 +168,13 @@ pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeErr
     }
     param_names.deinit(ctx.allocator);
 
-    return .{ .object = stmt_obj };
+    return NativeResult.borrowed(.{ .object = stmt_obj });
 }
 
-pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
+pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const sql_val = obj.get("__sql");
-    if (sql_val != .string) return .{ .bool = false };
+    if (sql_val != .string) return NativeResult.scalar(.{ .bool = false });
     var sql = sql_val.string.bytes();
 
     // if params provided, escape and interpolate
@@ -203,7 +204,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
     try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
     try obj.set(ctx.allocator, "__row_count", .{ .int = @intCast(mysql.mysql_affected_rows(conn)) });
 
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn interpolateParams(ctx: *NativeContext, conn: *mysql.MYSQL, sql: []const u8, params: *PhpArray, param_map: ?*PhpArray) ![]const u8 {
@@ -284,10 +285,10 @@ fn valueToSqlString(ctx: *NativeContext, conn: *mysql.MYSQL, val: Value) ![]cons
     }
 }
 
-pub fn stmtFetch(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
-    const res = getRes(obj) orelse return .{ .bool = false };
-    const row_ptrs = mysql.mysql_fetch_row(res) orelse return .{ .bool = false };
-    const lengths = mysql.mysql_fetch_lengths(res) orelse return .{ .bool = false };
+pub fn stmtFetch(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
+    const res = getRes(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const row_ptrs = mysql.mysql_fetch_row(res) orelse return NativeResult.scalar(.{ .bool = false });
+    const lengths = mysql.mysql_fetch_lengths(res) orelse return NativeResult.scalar(.{ .bool = false });
     const num_fields = mysql.mysql_num_fields(res);
 
     const mode: i64 = if (args.len >= 1 and args[0] == .int) args[0].int else 4;
@@ -323,86 +324,86 @@ pub fn stmtFetch(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Runt
 
     const cur = obj.get("__current_row");
     if (cur == .int) try obj.set(ctx.allocator, "__current_row", .{ .int = cur.int + 1 });
-    return .{ .array = row };
+    return NativeResult.borrowed(.{ .array = row });
 }
 
-pub fn stmtFetchAll(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
+pub fn stmtFetchAll(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
     var result = try ctx.createArray();
     while (true) {
-        const row = try stmtFetch(ctx, obj, args);
+        const row = (try stmtFetch(ctx, obj, args)).value;
         if (row == .bool and !row.bool) break;
         try result.append(ctx.allocator, row);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-pub fn stmtFetchColumn(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
-    const res = getRes(obj) orelse return .{ .bool = false };
+pub fn stmtFetchColumn(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
+    const res = getRes(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const col_idx: usize = if (args.len >= 1 and args[0] == .int) @intCast(args[0].int) else 0;
-    const row_ptrs = mysql.mysql_fetch_row(res) orelse return .{ .bool = false };
-    const lengths = mysql.mysql_fetch_lengths(res) orelse return .{ .bool = false };
+    const row_ptrs = mysql.mysql_fetch_row(res) orelse return NativeResult.scalar(.{ .bool = false });
+    const lengths = mysql.mysql_fetch_lengths(res) orelse return NativeResult.scalar(.{ .bool = false });
     const num_fields = mysql.mysql_num_fields(res);
-    if (col_idx >= num_fields) return .{ .bool = false };
+    if (col_idx >= num_fields) return NativeResult.scalar(.{ .bool = false });
 
     if (row_ptrs[col_idx]) |ptr| {
         const len = lengths[col_idx];
-        return .{ .string = Value.String.borrowed(try ctx.createString(ptr[0..len])) };
+        return try NativeResult.copyString(ctx.allocator, ptr[0..len]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-pub fn stmtColumnCount(obj: *PhpObject) RuntimeError!Value {
-    const res = getRes(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(mysql.mysql_num_fields(res)) };
+pub fn stmtColumnCount(obj: *PhpObject) RuntimeError!NativeResult {
+    const res = getRes(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(mysql.mysql_num_fields(res)) });
 }
 
-pub fn stmtCloseCursor(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
+pub fn stmtCloseCursor(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
     if (getRes(obj)) |res| {
         mysql.mysql_free_result(res);
         try obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
     }
     try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-pub fn lastInsertId(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .string = Value.String.borrowed("0") };
+pub fn lastInsertId(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.literal("0");
     const id = mysql.mysql_insert_id(conn);
     var buf: [32]u8 = undefined;
     const s = std.fmt.bufPrint(&buf, "{d}", .{id}) catch "0";
-    return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+    return try NativeResult.copyString(ctx.allocator, s);
 }
 
-pub fn beginTransaction(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
+pub fn beginTransaction(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
     _ = ctx;
-    return .{ .bool = mysql.mysql_autocommit(conn, 0) == 0 };
+    return NativeResult.scalar(.{ .bool = mysql.mysql_autocommit(conn, 0) == 0 });
 }
 
-pub fn commit(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
+pub fn commit(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
     _ = ctx;
     const ok = mysql.mysql_commit(conn) == 0;
     _ = mysql.mysql_autocommit(conn, 1);
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-pub fn rollBack(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
+pub fn rollBack(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
     _ = ctx;
     const ok = mysql.mysql_rollback(conn) == 0;
     _ = mysql.mysql_autocommit(conn, 1);
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-pub fn errorInfo(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .null;
+pub fn errorInfo(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.null);
     var arr = try ctx.createArray();
     const msg = std.mem.span(mysql.mysql_error(conn));
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("00000") });
     try arr.append(ctx.allocator, .null);
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(msg)) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 pub fn cleanupStatement(obj: *PhpObject) void {

--- a/src/stdlib/pdo_pgsql.zig
+++ b/src/stdlib/pdo_pgsql.zig
@@ -5,6 +5,7 @@ const PhpObject = @import("../runtime/value.zig").PhpObject;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 const pdo = @import("pdo.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 
 const pg = struct {
     const PGconn = opaque {};
@@ -39,7 +40,7 @@ fn getRes(obj: *PhpObject) ?*pg.PGresult {
     return pdo.getOpaquePtr(pg.PGresult, obj, "__res_ptr");
 }
 
-pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []const Value) RuntimeError!Value {
+pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []const Value) RuntimeError!NativeResult {
     // build libpq connection string from DSN params
     // pgsql:host=localhost;port=5432;dbname=test -> "host=localhost port=5432 dbname=test user=X password=Y"
     var conninfo = std.ArrayListUnmanaged(u8){};
@@ -79,10 +80,10 @@ pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []c
     }
 
     try obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-pub fn exec(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!Value {
+pub fn exec(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!NativeResult {
     const conn = getConn(obj) orelse return pdo.throwPdo(ctx, "Database not connected");
     const sql_z = try pdo.dupeZ(ctx, sql);
     const res = pg.PQexec(conn, sql_z) orelse return pdo.throwPdo(ctx, std.mem.span(pg.PQerrorMessage(conn)));
@@ -94,10 +95,10 @@ pub fn exec(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!
     }
     const affected = std.fmt.parseInt(i64, std.mem.span(pg.PQcmdTuples(res)), 10) catch 0;
     pg.PQclear(res);
-    return .{ .int = affected };
+    return NativeResult.scalar(.{ .int = affected });
 }
 
-pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!Value {
+pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!NativeResult {
     const conn = getConn(obj) orelse return pdo.throwPdo(ctx, "Database not connected");
     const sql_z = try pdo.dupeZ(ctx, sql);
     const res = pg.PQexec(conn, sql_z) orelse return pdo.throwPdo(ctx, std.mem.span(pg.PQerrorMessage(conn)));
@@ -115,10 +116,10 @@ pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError
     try stmt_obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = pg.PQntuples(res) > 0 });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = true });
-    return .{ .object = stmt_obj };
+    return NativeResult.borrowed(.{ .object = stmt_obj });
 }
 
-pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!Value {
+pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError!NativeResult {
     const conn = getConn(obj) orelse return pdo.throwPdo(ctx, "Database not connected");
 
     // rewrite ? and :name to $1, $2, ... for postgres
@@ -179,13 +180,13 @@ pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeErr
     }
     param_names.deinit(ctx.allocator);
 
-    return .{ .object = stmt_obj };
+    return NativeResult.borrowed(.{ .object = stmt_obj });
 }
 
-pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
+pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const sql_val = obj.get("__sql");
-    if (sql_val != .string) return .{ .bool = false };
+    if (sql_val != .string) return NativeResult.scalar(.{ .bool = false });
     const sql_z = try pdo.dupeZ(ctx, sql_val.string.bytes());
 
     // free previous result
@@ -236,7 +237,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
             }
         }
 
-        const res = pg.PQexecParams(conn, sql_z, @intCast(param_count), null, param_values.ptr, null, null, 0) orelse return .{ .bool = false };
+        const res = pg.PQexecParams(conn, sql_z, @intCast(param_count), null, param_values.ptr, null, null, 0) orelse return NativeResult.scalar(.{ .bool = false });
         const status = pg.PQresultStatus(res);
         if (status != pg.PGRES_TUPLES_OK and status != pg.PGRES_COMMAND_OK) {
             const msg = std.mem.span(pg.PQresultErrorMessage(res));
@@ -248,7 +249,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
         try obj.set(ctx.allocator, "__has_row", .{ .bool = pg.PQntuples(res) > 0 });
         try obj.set(ctx.allocator, "__row_count", .{ .int = std.fmt.parseInt(i64, std.mem.span(pg.PQcmdTuples(res)), 10) catch @intCast(pg.PQntuples(res)) });
     } else {
-        const res = pg.PQexec(conn, sql_z) orelse return .{ .bool = false };
+        const res = pg.PQexec(conn, sql_z) orelse return NativeResult.scalar(.{ .bool = false });
         const status = pg.PQresultStatus(res);
         if (status != pg.PGRES_TUPLES_OK and status != pg.PGRES_COMMAND_OK) {
             const msg = std.mem.span(pg.PQresultErrorMessage(res));
@@ -261,7 +262,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
         try obj.set(ctx.allocator, "__row_count", .{ .int = std.fmt.parseInt(i64, std.mem.span(pg.PQcmdTuples(res)), 10) catch @intCast(pg.PQntuples(res)) });
     }
     try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn valueToZ(ctx: *NativeContext, val: Value) !?[*:0]const u8 {
@@ -288,12 +289,12 @@ fn valueToZ(ctx: *NativeContext, val: Value) !?[*:0]const u8 {
     }
 }
 
-pub fn stmtFetch(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
-    const res = getRes(obj) orelse return .{ .bool = false };
+pub fn stmtFetch(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
+    const res = getRes(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cur_val = obj.get("__current_row");
     const current_row: c_int = if (cur_val == .int) @intCast(cur_val.int) else 0;
     const total_rows = pg.PQntuples(res);
-    if (current_row >= total_rows) return .{ .bool = false };
+    if (current_row >= total_rows) return NativeResult.scalar(.{ .bool = false });
 
     const mode: i64 = if (args.len >= 1 and args[0] == .int) args[0].int else 4;
     const num_fields = pg.PQnfields(res);
@@ -316,96 +317,96 @@ pub fn stmtFetch(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Runt
     }
 
     try obj.set(ctx.allocator, "__current_row", .{ .int = current_row + 1 });
-    return .{ .array = row };
+    return NativeResult.borrowed(.{ .array = row });
 }
 
-pub fn stmtFetchAll(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
+pub fn stmtFetchAll(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
     var result = try ctx.createArray();
     while (true) {
-        const row = try stmtFetch(ctx, obj, args);
+        const row = (try stmtFetch(ctx, obj, args)).value;
         if (row == .bool and !row.bool) break;
         try result.append(ctx.allocator, row);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-pub fn stmtFetchColumn(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!Value {
-    const res = getRes(obj) orelse return .{ .bool = false };
+pub fn stmtFetchColumn(ctx: *NativeContext, obj: *PhpObject, args: []const Value) RuntimeError!NativeResult {
+    const res = getRes(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cur_val = obj.get("__current_row");
     const current_row: c_int = if (cur_val == .int) @intCast(cur_val.int) else 0;
-    if (current_row >= pg.PQntuples(res)) return .{ .bool = false };
+    if (current_row >= pg.PQntuples(res)) return NativeResult.scalar(.{ .bool = false });
 
     const col: c_int = if (args.len >= 1 and args[0] == .int) @intCast(args[0].int) else 0;
-    if (col >= pg.PQnfields(res)) return .{ .bool = false };
+    if (col >= pg.PQnfields(res)) return NativeResult.scalar(.{ .bool = false });
 
     try obj.set(ctx.allocator, "__current_row", .{ .int = current_row + 1 });
 
-    if (pg.PQgetisnull(res, current_row, col) != 0) return .null;
+    if (pg.PQgetisnull(res, current_row, col) != 0) return NativeResult.scalar(.null);
     const s = std.mem.span(pg.PQgetvalue(res, current_row, col));
-    return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+    return try NativeResult.copyString(ctx.allocator, s);
 }
 
-pub fn stmtColumnCount(obj: *PhpObject) RuntimeError!Value {
-    const res = getRes(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(pg.PQnfields(res)) };
+pub fn stmtColumnCount(obj: *PhpObject) RuntimeError!NativeResult {
+    const res = getRes(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(pg.PQnfields(res)) });
 }
 
-pub fn stmtCloseCursor(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
+pub fn stmtCloseCursor(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
     if (getRes(obj)) |res| {
         pg.PQclear(res);
         try obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
     }
     try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     try obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-pub fn lastInsertId(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
+pub fn lastInsertId(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
     // postgres uses RETURNING or lastval() for insert IDs
-    const conn = getConn(obj) orelse return .{ .string = Value.String.borrowed("0") };
+    const conn = getConn(obj) orelse return NativeResult.literal("0");
     const sql_z: [*:0]const u8 = "SELECT lastval()";
-    const res = pg.PQexec(conn, sql_z) orelse return .{ .string = Value.String.borrowed("0") };
+    const res = pg.PQexec(conn, sql_z) orelse return NativeResult.literal("0");
     defer pg.PQclear(res);
-    if (pg.PQresultStatus(res) != pg.PGRES_TUPLES_OK or pg.PQntuples(res) == 0) return .{ .string = Value.String.borrowed("0") };
+    if (pg.PQresultStatus(res) != pg.PGRES_TUPLES_OK or pg.PQntuples(res) == 0) return NativeResult.literal("0");
     const s = std.mem.span(pg.PQgetvalue(res, 0, 0));
-    return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+    return try NativeResult.copyString(ctx.allocator, s);
 }
 
-pub fn beginTransaction(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
-    const res = pg.PQexec(conn, "BEGIN") orelse return .{ .bool = false };
+pub fn beginTransaction(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const res = pg.PQexec(conn, "BEGIN") orelse return NativeResult.scalar(.{ .bool = false });
     const ok = pg.PQresultStatus(res) == pg.PGRES_COMMAND_OK;
     pg.PQclear(res);
     _ = ctx;
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-pub fn commit(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
-    const res = pg.PQexec(conn, "COMMIT") orelse return .{ .bool = false };
+pub fn commit(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const res = pg.PQexec(conn, "COMMIT") orelse return NativeResult.scalar(.{ .bool = false });
     const ok = pg.PQresultStatus(res) == pg.PGRES_COMMAND_OK;
     pg.PQclear(res);
     _ = ctx;
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-pub fn rollBack(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .{ .bool = false };
-    const res = pg.PQexec(conn, "ROLLBACK") orelse return .{ .bool = false };
+pub fn rollBack(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const res = pg.PQexec(conn, "ROLLBACK") orelse return NativeResult.scalar(.{ .bool = false });
     const ok = pg.PQresultStatus(res) == pg.PGRES_COMMAND_OK;
     pg.PQclear(res);
     _ = ctx;
-    return .{ .bool = ok };
+    return NativeResult.scalar(.{ .bool = ok });
 }
 
-pub fn errorInfo(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const conn = getConn(obj) orelse return .null;
+pub fn errorInfo(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const conn = getConn(obj) orelse return NativeResult.scalar(.null);
     var arr = try ctx.createArray();
     const msg = std.mem.span(pg.PQerrorMessage(conn));
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("00000") });
     try arr.append(ctx.allocator, .null);
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(msg)) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 pub fn cleanupStatement(obj: *PhpObject) void {

--- a/src/stdlib/phar_class.zig
+++ b/src/stdlib/phar_class.zig
@@ -4,6 +4,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -145,9 +146,9 @@ fn dupString(ctx: *NativeContext, s: []const u8) ![]const u8 {
     return owned;
 }
 
-fn phConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
+fn phConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const filename = try dupString(ctx, args[0].string.bytes());
     try obj.set(ctx.allocator, "__filename", .{ .string = Value.String.borrowed(filename) });
     try obj.set(ctx.allocator, "__stub", .{ .string = Value.String.borrowed(phar.default_stub) });
@@ -159,16 +160,16 @@ fn phConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // if file exists, parse it and load entries
     const cwd = std.fs.cwd();
     const file = cwd.openFile(filename, .{}) catch |e| switch (e) {
-        error.FileNotFound => return .null,
-        else => return .null,
+        error.FileNotFound => return NativeResult.scalar(.null),
+        else => return NativeResult.scalar(.null),
     };
     defer file.close();
-    const stat = file.stat() catch return .null;
-    const bytes = ctx.allocator.alloc(u8, @intCast(stat.size)) catch return .null;
+    const stat = file.stat() catch return NativeResult.scalar(.null);
+    const bytes = ctx.allocator.alloc(u8, @intCast(stat.size)) catch return NativeResult.scalar(.null);
     defer ctx.allocator.free(bytes);
-    _ = file.readAll(bytes) catch return .null;
+    _ = file.readAll(bytes) catch return NativeResult.scalar(.null);
 
-    var parsed = phar.parse(ctx.allocator, bytes) catch return .null;
+    var parsed = phar.parse(ctx.allocator, bytes) catch return NativeResult.scalar(.null);
     defer parsed.deinit(ctx.allocator);
 
     // capture stub: bytes before manifest start
@@ -191,35 +192,35 @@ fn phConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const name_copy = try dupString(ctx, kv.key_ptr.*);
         try entries_arr.set(ctx.allocator, .{ .string = Value.String.borrowed(name_copy) }, .{ .string = Value.String.borrowed(data) });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phAddFromString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2) return .null;
-    if (args[0] != .string) return .null;
+fn phAddFromString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.scalar(.null);
+    if (args[0] != .string) return NativeResult.scalar(.null);
     const name_str = try dupString(ctx, args[0].string.bytes());
     const content = if (args[1] == .string) try dupString(ctx, args[1].string.bytes()) else "";
     const arr = try ensureEntries(ctx, obj);
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(name_str) }, .{ .string = Value.String.borrowed(content) });
     try saveIfNotBuffering(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phAddFile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
+fn phAddFile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const path = args[0].string.bytes();
     const local_name = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else std.fs.path.basename(path);
 
     const cwd = std.fs.cwd();
-    const file = cwd.openFile(path, .{}) catch return .null;
+    const file = cwd.openFile(path, .{}) catch return NativeResult.scalar(.null);
     defer file.close();
-    const stat = file.stat() catch return .null;
-    const buf = ctx.allocator.alloc(u8, @intCast(stat.size)) catch return .null;
+    const stat = file.stat() catch return NativeResult.scalar(.null);
+    const buf = ctx.allocator.alloc(u8, @intCast(stat.size)) catch return NativeResult.scalar(.null);
     _ = file.readAll(buf) catch {
         ctx.allocator.free(buf);
-        return .null;
+        return NativeResult.scalar(.null);
     };
     try ctx.strings.append(ctx.allocator, buf);
 
@@ -227,231 +228,231 @@ fn phAddFile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const name_str = try dupString(ctx, local_name);
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(name_str) }, .{ .string = Value.String.borrowed(buf) });
     try saveIfNotBuffering(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phSetStub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn phSetStub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const stub = try dupString(ctx, args[0].string.bytes());
     try obj.set(ctx.allocator, "__stub", .{ .string = Value.String.borrowed(stub) });
     try saveIfNotBuffering(ctx, obj);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn phGetStub(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
-    return obj.get("__stub");
+fn phGetStub(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
+    return NativeResult.share(obj.get("__stub"));
 }
 
-fn phGetAlias(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn phGetAlias(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const v = obj.get("__alias");
-    if (v == .string and v.string.bytes().len == 0) return .null;
-    return v;
+    if (v == .string and v.string.bytes().len == 0) return NativeResult.scalar(.null);
+    return NativeResult.share(v);
 }
 
-fn phSetAlias(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn phSetAlias(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const alias = try dupString(ctx, args[0].string.bytes());
     try obj.set(ctx.allocator, "__alias", .{ .string = Value.String.borrowed(alias) });
     try saveIfNotBuffering(ctx, obj);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn phCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getEntries(obj) orelse return .{ .int = 0 };
-    return .{ .int = arr.length() };
+fn phCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getEntries(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = arr.length() });
 }
 
-fn phOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const arr = getEntries(obj) orelse return .{ .bool = false };
-    if (arr.string_index.contains(args[0].string.bytes())) return .{ .bool = true };
-    return .{ .bool = false };
+fn phOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const arr = getEntries(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (arr.string_index.contains(args[0].string.bytes())) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn phOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
-    const arr = getEntries(obj) orelse return .null;
-    return arr.get(.{ .string = args[0].string });
+fn phOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const arr = getEntries(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(arr.get(.{ .string = args[0].string }));
 }
 
-fn phOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2 or args[0] != .string) return .null;
+fn phOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.null);
     const name = try dupString(ctx, args[0].string.bytes());
     const content = if (args[1] == .string) try dupString(ctx, args[1].string.bytes()) else "";
     const arr = try ensureEntries(ctx, obj);
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, .{ .string = Value.String.borrowed(content) });
     try saveIfNotBuffering(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
-    const arr = getEntries(obj) orelse return .null;
+fn phOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const arr = getEntries(obj) orelse return NativeResult.scalar(.null);
     arr.remove(.{ .string = args[0].string });
     try saveIfNotBuffering(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phStartBuffering(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn phStartBuffering(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__buffering", .{ .bool = true });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phStopBuffering(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn phStopBuffering(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__buffering", .{ .bool = false });
     try saveAll(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phGetPath(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
-    return obj.get("__filename");
+fn phGetPath(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
+    return NativeResult.share(obj.get("__filename"));
 }
 
-fn phIsWritable(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn phIsWritable(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn phRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn phRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn phValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = obj.get("__cursor");
-    const arr = getEntries(obj) orelse return .{ .bool = false };
-    if (cursor != .int) return .{ .bool = false };
-    return .{ .bool = cursor.int >= 0 and cursor.int < arr.length() };
+    const arr = getEntries(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (cursor != .int) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = cursor.int >= 0 and cursor.int < arr.length() });
 }
 
-fn phKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn phKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = obj.get("__cursor");
-    const arr = getEntries(obj) orelse return .null;
-    if (cursor != .int) return .null;
+    const arr = getEntries(obj) orelse return NativeResult.scalar(.null);
+    if (cursor != .int) return NativeResult.scalar(.null);
     const idx: usize = @intCast(cursor.int);
-    if (idx >= arr.entries.items.len) return .null;
+    if (idx >= arr.entries.items.len) return NativeResult.scalar(.null);
     const key = arr.entries.items[idx].key;
     return switch (key) {
-        .string => |s| .{ .string = s },
-        .int => |i| .{ .int = i },
+        .string => |s| NativeResult.shareString(s),
+        .int => |i| NativeResult.scalar(.{ .int = i }),
     };
 }
 
-fn phCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn phCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = obj.get("__cursor");
-    const arr = getEntries(obj) orelse return .null;
-    if (cursor != .int) return .null;
+    const arr = getEntries(obj) orelse return NativeResult.scalar(.null);
+    if (cursor != .int) return NativeResult.scalar(.null);
     const idx: usize = @intCast(cursor.int);
-    if (idx >= arr.entries.items.len) return .null;
-    return arr.entries.items[idx].value;
+    if (idx >= arr.entries.items.len) return NativeResult.scalar(.null);
+    return NativeResult.share(arr.entries.items[idx].value);
 }
 
-fn phNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn phNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = obj.get("__cursor");
     const next_val: i64 = if (cursor == .int) cursor.int + 1 else 0;
     try obj.set(ctx.allocator, "__cursor", .{ .int = next_val });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phGetMetadata(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__metadata");
+fn phGetMetadata(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__metadata"));
 }
 
-fn phSetMetadata(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn phSetMetadata(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__metadata", args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn phHasMetadata(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn phHasMetadata(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const v = obj.get("__metadata");
-    return .{ .bool = v != .null };
+    return NativeResult.scalar(.{ .bool = v != .null });
 }
 
-fn phCanWrite(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn phCanWrite(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // Phar::canWrite() reports whether the phar.readonly ini setting allows
     // writing. zphp doesn't enforce that flag and always writes
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn phCanCompress(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = true };
-    if (args[0] != .int) return .{ .bool = false };
+fn phCanCompress(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = true });
+    if (args[0] != .int) return NativeResult.scalar(.{ .bool = false });
     // 4096 = Phar::GZ (we support), 8192 = Phar::BZ2 (we don't)
-    return .{ .bool = args[0].int == 0 or args[0].int == 4096 };
+    return NativeResult.scalar(.{ .bool = args[0].int == 0 or args[0].int == 4096 });
 }
 
-fn phRunning(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn phRunning(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // returns the path to the currently-executing phar, or "" when not running from one
     _ = ctx;
-    return .{ .string = Value.String.borrowed("") };
+    return NativeResult.literal("");
 }
 
-fn phLoadPhar(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn phLoadPhar(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn phGetSupportedCompression(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn phGetSupportedCompression(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("GZ") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn phGetSupportedSignatures(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn phGetSupportedSignatures(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("MD5") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("SHA-1") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("SHA-256") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("SHA-512") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn phIsValidPharFilename(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn phIsValidPharFilename(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
-    return .{ .bool = std.mem.endsWith(u8, name, ".phar") or std.mem.endsWith(u8, name, ".phar.gz") };
+    return NativeResult.scalar(.{ .bool = std.mem.endsWith(u8, name, ".phar") or std.mem.endsWith(u8, name, ".phar.gz") });
 }
 
-fn phMungServer(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn phMungServer(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn phUnlinkArchive(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    std.fs.cwd().deleteFile(args[0].string.bytes()) catch return .{ .bool = false };
-    return .{ .bool = true };
+fn phUnlinkArchive(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    std.fs.cwd().deleteFile(args[0].string.bytes()) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn phInterceptFileFuncs(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn phInterceptFileFuncs(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn phMapPhar(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn phMapPhar(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // `Phar::mapPhar('alias')` registers an alias for the currently-running
     // phar file so subsequent `phar://alias/...` reads resolve to it
-    if (args.len < 1 or args[0] != .string) return .{ .bool = true };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = true });
     const alias = args[0].string.bytes();
     const fp = ctx.vm.file_path;
-    if (fp.len == 0) return .{ .bool = true };
+    if (fp.len == 0) return NativeResult.scalar(.{ .bool = true });
     const resolved_fp = std.fs.cwd().realpathAlloc(ctx.allocator, fp) catch try ctx.allocator.dupe(u8, fp);
     defer ctx.allocator.free(resolved_fp);
     const alias_dup = try ctx.allocator.dupe(u8, alias);
@@ -459,7 +460,7 @@ fn phMapPhar(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try ctx.vm.strings.append(ctx.allocator, alias_dup);
     try ctx.vm.strings.append(ctx.allocator, fp_dup);
     try ctx.vm.phar_aliases.put(ctx.allocator, alias_dup, fp_dup);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn saveIfNotBuffering(ctx: *NativeContext, obj: *PhpObject) !void {

--- a/src/stdlib/random.zig
+++ b/src/stdlib/random.zig
@@ -10,6 +10,7 @@ const ClassDef = vm_mod.ClassDef;
 const Mt19937 = @import("mt19937.zig").Mt19937;
 const Xoshiro256ss = @import("xoshiro256ss.zig").Xoshiro256ss;
 const PcgOneseq128 = @import("pcg_oneseq_128.zig").PcgOneseq128;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
@@ -84,8 +85,8 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "Random\\Engine\\Secure::generate", secureGenerate);
 }
 
-fn noopConstruct(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn noopConstruct(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
 fn getThis(ctx: *NativeContext) ?*PhpObject {
@@ -117,8 +118,8 @@ fn loadState(obj: *PhpObject, comptime T: type) ?T {
 
 // ---- Mt19937 ----
 
-fn mtConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn mtConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const seed_int: u32 = if (args.len >= 1 and args[0] != .null)
         @as(u32, @truncate(@as(u64, @bitCast(Value.toInt(args[0])))))
     else
@@ -131,25 +132,23 @@ fn mtConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     var m = Mt19937{};
     m.seed(seed_int);
     try storeState(ctx, this, std.mem.asBytes(&m));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn mtGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    var m = loadState(this, Mt19937) orelse return .null;
+fn mtGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    var m = loadState(this, Mt19937) orelse return NativeResult.scalar(.null);
     const v = m.nextU32();
     try storeState(ctx, this, std.mem.asBytes(&m));
     var bytes: [4]u8 = undefined;
     std.mem.writeInt(u32, &bytes, v, .little);
-    const owned = try ctx.allocator.dupe(u8, &bytes);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, &bytes);
 }
 
 // ---- PCG OneSeq 128 XSL RR 64 ----
 
-fn pcgConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn pcgConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     var p = PcgOneseq128{};
     if (args.len >= 1 and args[0] != .null) {
         if (args[0] == .string) {
@@ -165,25 +164,23 @@ fn pcgConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         p.seedInt(freshU64FromCrypto());
     }
     try storeState(ctx, this, std.mem.asBytes(&p));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn pcgGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    var p = loadState(this, PcgOneseq128) orelse return .null;
+fn pcgGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    var p = loadState(this, PcgOneseq128) orelse return NativeResult.scalar(.null);
     const v = p.next();
     try storeState(ctx, this, std.mem.asBytes(&p));
     var bytes: [8]u8 = undefined;
     std.mem.writeInt(u64, &bytes, v, .little);
-    const owned = try ctx.allocator.dupe(u8, &bytes);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, &bytes);
 }
 
 // ---- Xoshiro256** ----
 
-fn xoshConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn xoshConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     var x = Xoshiro256ss{};
     if (args.len >= 1 and args[0] != .null) {
         if (args[0] == .string) {
@@ -199,27 +196,23 @@ fn xoshConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         x.seedInt(freshU64FromCrypto());
     }
     try storeState(ctx, this, std.mem.asBytes(&x));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn xoshGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    var x = loadState(this, Xoshiro256ss) orelse return .null;
+fn xoshGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    var x = loadState(this, Xoshiro256ss) orelse return NativeResult.scalar(.null);
     const v = x.next();
     try storeState(ctx, this, std.mem.asBytes(&x));
     var bytes: [8]u8 = undefined;
     std.mem.writeInt(u64, &bytes, v, .little);
-    const owned = try ctx.allocator.dupe(u8, &bytes);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, &bytes);
 }
 
-fn secureGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn secureGenerate(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var bytes: [8]u8 = undefined;
     std.crypto.random.bytes(&bytes);
-    const owned = try ctx.allocator.dupe(u8, &bytes);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, &bytes);
 }
 
 // ---- Randomizer dispatch ----
@@ -280,8 +273,8 @@ fn engine(ctx: *NativeContext) ?*PhpObject {
     return v.object;
 }
 
-fn rzConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rzConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and args[0] != .null) {
         if (args[0] != .object) {
             try ctx.vm.setPendingException("TypeError", "Random\\Randomizer::__construct(): Argument #1 ($engine) must be of type ?Random\\Engine");
@@ -289,7 +282,7 @@ fn rzConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         try this.set(ctx.allocator, "_engine", args[0]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // PHP's range32 with rejection sampling, using whatever engine is attached
@@ -327,27 +320,27 @@ fn rangeU64(ctx: *NativeContext, eng_opt: ?*PhpObject, umax: u64) u64 {
     }
 }
 
-fn rzGetInt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int or args[1] != .int) return .{ .int = 0 };
+fn rzGetInt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int or args[1] != .int) return NativeResult.scalar(.{ .int = 0 });
     const lo = args[0].int;
     const hi = args[1].int;
     if (hi < lo) {
         try ctx.vm.setPendingException("ValueError", "Random\\Randomizer::getInt(): Argument #2 ($max) must be greater than or equal to argument #1 ($min)");
         return error.RuntimeError;
     }
-    if (hi == lo) return .{ .int = lo };
+    if (hi == lo) return NativeResult.scalar(.{ .int = lo });
     const eng_opt = engine(ctx);
     const range: u64 = @intCast(hi - lo);
     if (range <= 0xffffffff) {
         const r: u32 = rangeU32(ctx, eng_opt, @intCast(range));
-        return .{ .int = lo + @as(i64, r) };
+        return NativeResult.scalar(.{ .int = lo + @as(i64, r) });
     }
     const r: u64 = rangeU64(ctx, eng_opt, range);
-    return .{ .int = lo + @as(i64, @intCast(r)) };
+    return NativeResult.scalar(.{ .int = lo + @as(i64, @intCast(r)) });
 }
 
-fn rzGetBytes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int or args[0].int < 1) return .{ .bool = false };
+fn rzGetBytes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int or args[0].int < 1) return NativeResult.scalar(.{ .bool = false });
     const n: usize = @intCast(args[0].int);
     const buf = try ctx.allocator.alloc(u8, n);
     const eng_opt = engine(ctx);
@@ -360,36 +353,35 @@ fn rzGetBytes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         @memcpy(buf[written .. written + take], chunk[0..take]);
         written += take;
     }
-    try ctx.vm.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn rzNextInt(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rzNextInt(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const eng_opt = engine(ctx);
     const v = if (eng_opt) |e| engineNextU64(ctx, e) else freshU64FromCrypto();
     // PHP's nextInt returns a non-negative 63-bit integer
-    return .{ .int = @as(i64, @intCast(v >> 1)) };
+    return NativeResult.scalar(.{ .int = @as(i64, @intCast(v >> 1)) });
 }
 
-fn rzGetFloat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rzGetFloat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     var lo: f64 = 0.0;
     var hi: f64 = 1.0;
     if (args.len >= 2 and args[0] != .null) lo = Value.toFloat(args[0]);
     if (args.len >= 2 and args[1] != .null) hi = Value.toFloat(args[1]);
-    if (hi <= lo) return .{ .float = lo };
+    if (hi <= lo) return NativeResult.scalar(.{ .float = lo });
     const eng_opt = engine(ctx);
     const v = if (eng_opt) |e| engineNextU64(ctx, e) else freshU64FromCrypto();
     // 53-bit precision, mapped into [0, 1)
     const denom: f64 = @as(f64, @floatFromInt(@as(u64, 1) << 53));
     const r = @as(f64, @floatFromInt(v >> 11)) / denom;
-    return .{ .float = lo + r * (hi - lo) };
+    return NativeResult.scalar(.{ .float = lo + r * (hi - lo) });
 }
 
-fn rzNextFloat(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rzNextFloat(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const eng_opt = engine(ctx);
     const v = if (eng_opt) |e| engineNextU64(ctx, e) else freshU64FromCrypto();
     const denom: f64 = @as(f64, @floatFromInt(@as(u64, 1) << 53));
-    return .{ .float = @as(f64, @floatFromInt(v >> 11)) / denom };
+    return NativeResult.scalar(.{ .float = @as(f64, @floatFromInt(v >> 11)) / denom });
 }
 
 fn rollN(ctx: *NativeContext, n: usize) usize {
@@ -398,8 +390,8 @@ fn rollN(ctx: *NativeContext, n: usize) usize {
     return @intCast(rangeU64(ctx, eng_opt, @as(u64, @intCast(n - 1))));
 }
 
-fn rzShuffleArray(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .array) return .{ .bool = false };
+fn rzShuffleArray(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const src = args[0].array;
     const dst = try ctx.allocator.create(PhpArray);
     dst.* = .{};
@@ -413,11 +405,11 @@ fn rzShuffleArray(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         dst.entries.items[i].value = dst.entries.items[j].value;
         dst.entries.items[j].value = tmp;
     }
-    return .{ .array = dst };
+    return NativeResult.borrowed(.{ .array = dst });
 }
 
-fn rzShuffleBytes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn rzShuffleBytes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const src = args[0].string.bytes();
     const buf = try ctx.allocator.dupe(u8, src);
     var i: usize = buf.len;
@@ -428,15 +420,14 @@ fn rzShuffleBytes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         buf[i] = buf[j];
         buf[j] = tmp;
     }
-    try ctx.vm.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn rzPickArrayKeys(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .array or args[1] != .int) return .{ .bool = false };
+fn rzPickArrayKeys(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .array or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const src = args[0].array;
     const want: usize = @intCast(args[1].int);
-    if (want > src.entries.items.len) return .{ .bool = false };
+    if (want > src.entries.items.len) return NativeResult.scalar(.{ .bool = false });
     const keys = try ctx.allocator.alloc(PhpArray.Key, src.entries.items.len);
     defer ctx.allocator.free(keys);
     for (src.entries.items, 0..) |e, idx| keys[idx] = e.key;
@@ -458,5 +449,5 @@ fn rzPickArrayKeys(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         };
         try out.append(ctx.allocator, v);
     }
-    return .{ .array = out };
+    return NativeResult.borrowed(.{ .array = out });
 }

--- a/src/stdlib/reflection.zig
+++ b/src/stdlib/reflection.zig
@@ -8,6 +8,7 @@ const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 const AttributeDef = vm_mod.AttributeDef;
 const ObjFunction = @import("../pipeline/bytecode.zig").ObjFunction;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
@@ -742,7 +743,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionFiber::getTrace", rfibGetTrace);
 }
 
-fn rextConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rextConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0 or args[0] != .string) return throwReflection(ctx, "ReflectionExtension::__construct() expects an extension name");
     const loaded = try ctx.vm.callByName("extension_loaded", args[0..1]);
     if (!loaded.isTruthy()) {
@@ -750,36 +751,36 @@ fn rextConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.strings.append(ctx.allocator, msg);
         return throwReflection(ctx, msg);
     }
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(try ctx.createString(args[0].string.bytes())) }) catch return error.OutOfMemory;
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rextGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn rextGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn rextGetVersion(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed("8.4.1") };
+fn rextGetVersion(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal("8.4.1");
 }
 
-fn reflectionEmptyArray(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .array = try ctx.createArray() };
+fn reflectionEmptyArray(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
-fn reflectionTrue(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn reflectionTrue(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn rextInfo(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rextInfo(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const name = this.get("name");
     if (name == .string) try ctx.vm.output.appendSlice(ctx.allocator, name.string.bytes());
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rextToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rextToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return rextGetName(ctx, &.{});
 }
 
@@ -1019,7 +1020,7 @@ fn hasInterfaceMethod(vm: *VM, iface_name: []const u8, method_name: []const u8) 
     return false;
 }
 
-fn rcConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rcConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1) return throwReflection(ctx, "ReflectionClass::__construct() expects a class name");
     const raw_class_name = if (args[0] == .string)
         args[0].string.bytes()
@@ -1030,7 +1031,7 @@ fn rcConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // PHP accepts leading-backslash on FQN class strings; normalize so the
     // class registry lookup succeeds either way
     const class_name = if (raw_class_name.len > 0 and raw_class_name[0] == '\\') raw_class_name[1..] else raw_class_name;
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     _ = resolveClassName(ctx.vm, class_name) catch {
         const msg = std.fmt.allocPrint(ctx.allocator, "Class \"{s}\" does not exist", .{class_name}) catch return throwReflection(ctx, "Class does not exist");
@@ -1047,56 +1048,56 @@ fn rcConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(stable_name) });
     try this.set(ctx.allocator, "_is_interface", .{ .bool = ctx.vm.interfaces.contains(class_name) });
     try this.set(ctx.allocator, "_is_trait", .{ .bool = ctx.vm.traits.contains(class_name) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rcGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn rcGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn rcGetConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
-    if (!ctx.vm.hasMethod(class_name, "__construct")) return .null;
+    if (!ctx.vm.hasMethod(class_name, "__construct")) return NativeResult.scalar(.null);
 
     const declaring = findDeclaringClass(ctx.vm, class_name, "__construct");
-    const cls = ctx.vm.classes.get(declaring) orelse return .null;
+    const cls = ctx.vm.classes.get(declaring) orelse return NativeResult.scalar(.null);
     const info = cls.methods.get("__construct") orelse ClassDef.MethodInfo{ .name = "__construct", .arity = 0 };
     const obj = try buildMethodObj(ctx, class_name, "__construct", info, declaring);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rcIsInstantiable(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rcIsInstantiable(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const is_iface = this.get("_is_interface");
-    if (is_iface == .bool and is_iface.bool) return .{ .bool = false };
+    if (is_iface == .bool and is_iface.bool) return NativeResult.scalar(.{ .bool = false });
     const is_trait = this.get("_is_trait");
-    if (is_trait == .bool and is_trait.bool) return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = true };
-    if (cls.is_abstract) return .{ .bool = false };
-    return .{ .bool = true };
+    if (is_trait == .bool and is_trait.bool) return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = true });
+    if (cls.is_abstract) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn rcGetParentClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
-    const parent_name = cls.parent orelse return .{ .bool = false };
+fn rcGetParentClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    const parent_name = cls.parent orelse return NativeResult.scalar(.{ .bool = false });
 
     const parent_obj = try ctx.createObject("ReflectionClass");
     try parent_obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(parent_name) });
     try parent_obj.set(ctx.allocator, "_is_interface", .{ .bool = ctx.vm.interfaces.contains(parent_name) });
-    return .{ .object = parent_obj };
+    return NativeResult.borrowed(.{ .object = parent_obj });
 }
 
-fn rcImplementsInterface(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn rcImplementsInterface(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const iface_name = args[0].string.bytes();
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
 
     var queue = std.ArrayListUnmanaged([]const u8){};
     defer queue.deinit(ctx.allocator);
@@ -1109,62 +1110,62 @@ fn rcImplementsInterface(ctx: *NativeContext, args: []const Value) RuntimeError!
     var i: usize = 0;
     while (i < queue.items.len) : (i += 1) {
         const iface = queue.items[i];
-        if (std.mem.eql(u8, iface, iface_name)) return .{ .bool = true };
+        if (std.mem.eql(u8, iface, iface_name)) return NativeResult.scalar(.{ .bool = true });
         if (ctx.vm.classes.get(iface)) |idef| {
             for (idef.interfaces.items) |sub| try queue.append(ctx.allocator, sub);
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcIsInstance(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+fn rcIsInstance(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
     const obj_class = args[0].object.class_name;
-    if (std.mem.eql(u8, obj_class, class_name)) return .{ .bool = true };
+    if (std.mem.eql(u8, obj_class, class_name)) return NativeResult.scalar(.{ .bool = true });
     if (ctx.vm.interfaces.contains(class_name)) {
         var current: ?[]const u8 = obj_class;
         while (current) |name| {
             const cls = ctx.vm.classes.get(name) orelse break;
             for (cls.interfaces.items) |iface| {
-                if (std.mem.eql(u8, iface, class_name)) return .{ .bool = true };
+                if (std.mem.eql(u8, iface, class_name)) return NativeResult.scalar(.{ .bool = true });
             }
             current = cls.parent;
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     var current: ?[]const u8 = obj_class;
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
         if (cls.parent) |p| {
-            if (std.mem.eql(u8, p, class_name)) return .{ .bool = true };
+            if (std.mem.eql(u8, p, class_name)) return NativeResult.scalar(.{ .bool = true });
             current = p;
         } else break;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcIsSubclassOf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn rcIsSubclassOf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const parent_name = args[0].string.bytes();
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
 
     var current: ?[]const u8 = class_name;
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
         current = cls.parent;
         if (current) |p| {
-            if (std.mem.eql(u8, p, parent_name)) return .{ .bool = true };
+            if (std.mem.eql(u8, p, parent_name)) return NativeResult.scalar(.{ .bool = true });
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcNewInstance(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcNewInstance(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     if (ctx.vm.interfaces.contains(class_name)) {
         const msg = try std.fmt.allocPrint(ctx.allocator, "Cannot instantiate interface {s}", .{class_name});
         try ctx.strings.append(ctx.allocator, msg);
@@ -1190,12 +1191,12 @@ fn rcNewInstance(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (ctx.vm.hasMethod(class_name, "__construct")) {
         _ = try ctx.callMethod(obj, "__construct", args);
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rcNewInstanceArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcNewInstanceArgs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     if (ctx.vm.classes.get(class_name)) |cd| {
         if (cd.is_abstract) {
             const msg = try std.fmt.allocPrint(ctx.allocator, "Cannot instantiate abstract class {s}", .{class_name});
@@ -1205,7 +1206,7 @@ fn rcNewInstanceArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         }
     }
 
-    const arr = if (args.len >= 1 and args[0] == .array) args[0].array else return .null;
+    const arr = if (args.len >= 1 and args[0] == .array) args[0].array else return NativeResult.scalar(.null);
 
     var ctor_args: [16]Value = undefined;
     const count = @min(arr.entries.items.len, 16);
@@ -1223,12 +1224,12 @@ fn rcNewInstanceArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     if (ctx.vm.hasMethod(class_name, "__construct")) {
         _ = try ctx.callMethod(obj, "__construct", ctor_args[0..count]);
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rcGetMethods(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetMethods(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const filter: ?i64 = if (args.len >= 1 and args[0] == .int) args[0].int else null;
 
@@ -1247,7 +1248,7 @@ fn rcGetMethods(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const obj = try buildMethodObj(ctx, class_name, method_name, info, class_name);
             try arr.append(ctx.allocator, .{ .object = obj });
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
     var current: ?[]const u8 = class_name;
@@ -1285,7 +1286,7 @@ fn rcGetMethods(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         current = cls.parent;
         depth += 1;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn methodMatchesFilter(info: ClassDef.MethodInfo, filter: i64) bool {
@@ -1305,11 +1306,11 @@ fn methodModifiers(info: ClassDef.MethodInfo) i64 {
     return bits;
 }
 
-fn rcGetMethod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rcGetMethod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1 or args[0] != .string) return throwReflection(ctx, "ReflectionClass::getMethod() expects a method name");
     const method_name = args[0].string.bytes();
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     if (!ctx.vm.hasMethod(class_name, method_name)) {
         const msg = std.fmt.allocPrint(ctx.allocator, "Method {s}::{s}() does not exist", .{ class_name, method_name }) catch return error.OutOfMemory;
@@ -1318,103 +1319,103 @@ fn rcGetMethod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     const declaring = findDeclaringClass(ctx.vm, class_name, method_name);
-    const cls = ctx.vm.classes.get(declaring) orelse return .null;
+    const cls = ctx.vm.classes.get(declaring) orelse return NativeResult.scalar(.null);
     const info = cls.methods.get(method_name) orelse ClassDef.MethodInfo{ .name = method_name, .arity = 0 };
     const obj = try buildMethodObj(ctx, class_name, method_name, info, declaring);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rcHasMethod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+fn rcHasMethod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
     // PHP method names are case-insensitive
-    if (ctx.vm.hasMethod(class_name, args[0].string.bytes())) return .{ .bool = true };
+    if (ctx.vm.hasMethod(class_name, args[0].string.bytes())) return NativeResult.scalar(.{ .bool = true });
     var current: ?[]const u8 = class_name;
     while (current) |cn| {
         if (ctx.vm.classes.get(cn)) |cls| {
             var it = cls.methods.iterator();
             while (it.next()) |entry| {
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, args[0].string.bytes())) return .{ .bool = true };
+                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, args[0].string.bytes())) return NativeResult.scalar(.{ .bool = true });
             }
             current = cls.parent;
         } else break;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rcIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const is_iface = this.get("_is_interface");
-    if (is_iface == .bool and is_iface.bool) return .{ .bool = true };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
-    return .{ .bool = cls.is_abstract };
+    if (is_iface == .bool and is_iface.bool) return NativeResult.scalar(.{ .bool = true });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = cls.is_abstract });
 }
 
-fn rcIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
-    if (cls.is_enum) return .{ .bool = true };
-    return .{ .bool = cls.is_final };
+fn rcIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    if (cls.is_enum) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = cls.is_final });
 }
 
-fn rcGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rcGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP class modifier bitmask: IS_EXPLICIT_ABSTRACT=32, IS_IMPLICIT_ABSTRACT=16,
     // IS_FINAL=4, IS_READONLY=65536. these are used by ReflectionClass::getModifiers
-    const this = getThis(ctx) orelse return .{ .int = 0 };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .int = 0 };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .int = 0 };
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .int = 0 });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .int = 0 });
     var mods: i64 = 0;
     if (cls.is_abstract) mods |= 32;
     if (cls.is_final) mods |= 4;
     if (cls.is_readonly) mods |= 65536;
-    return .{ .int = mods };
+    return NativeResult.scalar(.{ .int = mods });
 }
 
-fn rcIsReadOnly(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
-    return .{ .bool = cls.is_readonly };
+fn rcIsReadOnly(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = cls.is_readonly });
 }
 
-fn rcIsCloneable(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rcIsCloneable(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const is_iface = this.get("_is_interface");
-    if (is_iface == .bool and is_iface.bool) return .{ .bool = false };
+    if (is_iface == .bool and is_iface.bool) return NativeResult.scalar(.{ .bool = false });
     const is_trait = this.get("_is_trait");
-    if (is_trait == .bool and is_trait.bool) return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = true };
-    if (cls.is_abstract) return .{ .bool = false };
-    if (cls.is_enum) return .{ .bool = false };
+    if (is_trait == .bool and is_trait.bool) return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = true });
+    if (cls.is_abstract) return NativeResult.scalar(.{ .bool = false });
+    if (cls.is_enum) return NativeResult.scalar(.{ .bool = false });
     if (cls.methods.get("__clone")) |m| {
-        if (m.visibility != .public) return .{ .bool = false };
+        if (m.visibility != .public) return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn rcIsInterface(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rcIsInterface(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const is_iface = this.get("_is_interface");
-    return .{ .bool = is_iface == .bool and is_iface.bool };
+    return NativeResult.scalar(.{ .bool = is_iface == .bool and is_iface.bool });
 }
 
-fn rcIsAnonymous(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rcIsAnonymous(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name = this.get("name");
-    if (name != .string) return .{ .bool = false };
-    return .{ .bool = std.mem.startsWith(u8, name.string.bytes(), "class@anonymous") };
+    if (name != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = std.mem.startsWith(u8, name.string.bytes(), "class@anonymous") });
 }
 
 // getInterfaces returns an array keyed by interface name with ReflectionClass
 // instances as values. PHP behaviour: includes all interfaces from the class
 // hierarchy plus their parents
-fn rcGetInterfaces(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetInterfaces(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const arr = try ctx.createArray();
     var seen = std.StringHashMapUnmanaged(void){};
@@ -1442,14 +1443,14 @@ fn rcGetInterfaces(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             for (idef.interfaces.items) |sub| try queue.append(ctx.allocator, sub);
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // getTraits returns an array keyed by trait name with ReflectionClass instances
 // as values, covering traits used by the class and its parent chain
-fn rcGetTraits(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetTraits(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const arr = try ctx.createArray();
     var seen = std.StringHashMapUnmanaged(void){};
@@ -1467,12 +1468,12 @@ fn rcGetTraits(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         }
         current = cls.parent;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rcGetInterfaceNames(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetInterfaceNames(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const arr = try ctx.createArray();
     var seen = std.StringHashMapUnmanaged(void){};
@@ -1497,7 +1498,7 @@ fn rcGetInterfaceNames(ctx: *NativeContext, _: []const Value) RuntimeError!Value
         const cls = ctx.vm.classes.get(chain.items[ci]) orelse continue;
         for (cls.interfaces.items) |iface| try emitInterfaceDeep(ctx, arr, &seen, iface);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn emitInterfaceDeep(ctx: *NativeContext, arr: *PhpArray, seen: *std.StringHashMapUnmanaged(void), name: []const u8) RuntimeError!void {
@@ -1540,11 +1541,11 @@ fn buildReflectionAttribute(ctx: *NativeContext, attr: AttributeDef, target: i64
 // filter matches any attribute whose class extends/implements the given name.
 const REFLECTION_ATTRIBUTE_IS_INSTANCEOF: i64 = 2;
 
-fn buildAttributeArray(ctx: *NativeContext, attrs: []const AttributeDef, filter: ?[]const u8, target: i64) RuntimeError!Value {
+fn buildAttributeArray(ctx: *NativeContext, attrs: []const AttributeDef, filter: ?[]const u8, target: i64) RuntimeError!NativeResult {
     return buildAttributeArrayWithFlags(ctx, attrs, filter, target, 0);
 }
 
-fn buildAttributeArrayWithFlags(ctx: *NativeContext, attrs: []const AttributeDef, filter: ?[]const u8, target: i64, flags: i64) RuntimeError!Value {
+fn buildAttributeArrayWithFlags(ctx: *NativeContext, attrs: []const AttributeDef, filter: ?[]const u8, target: i64, flags: i64) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     for (attrs) |attr| {
         if (filter) |f| {
@@ -1569,49 +1570,49 @@ fn buildAttributeArrayWithFlags(ctx: *NativeContext, attrs: []const AttributeDef
         }
         try arr.append(ctx.allocator, try buildReflectionAttribute(ctx, attr, target, count > 1));
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rcGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(name) orelse return .{ .bool = false };
-    if (cls.doc_comment.len == 0) return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(cls.doc_comment) };
+fn rcGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(name) orelse return NativeResult.scalar(.{ .bool = false });
+    if (cls.doc_comment.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, cls.doc_comment);
 }
 
-fn rmGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const func = rmLookupFunc(ctx) orelse return .{ .bool = false };
-    if (func.doc_comment.len == 0) return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(func.doc_comment) };
+fn rmGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const func = rmLookupFunc(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.doc_comment.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, func.doc_comment);
 }
 
-fn rfGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rfGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = false };
-    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return .{ .bool = false };
-    if (func.doc_comment.len == 0) return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(func.doc_comment) };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.doc_comment.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, func.doc_comment);
 }
 
-fn reflectionGetDocCommentFalse(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn reflectionGetDocCommentFalse(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // zphp doesn't preserve doc comments through compilation (architectural)
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .array = try ctx.createArray() };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .array = try ctx.createArray() };
+fn rcGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const filter: ?[]const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else null;
     const flags: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else 0;
     return buildAttributeArrayWithFlags(ctx, cls.attributes.items, filter, 1, flags);
 }
 
-fn rcGetProperties(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetProperties(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     const filter: i64 = if (args.len >= 1 and args[0] == .int) args[0].int else 0;
 
     const arr = try ctx.createArray();
@@ -1658,7 +1659,7 @@ fn rcGetProperties(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         current = cls.parent;
         is_own = false;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn appendInterfaceProperties(ctx: *NativeContext, reflected: []const u8, name: []const u8, filter: i64, arr: *PhpArray, seen: *std.StringHashMapUnmanaged(void)) RuntimeError!void {
@@ -1696,38 +1697,38 @@ fn matchPropFilter(filter: i64, vis: ClassDef.Visibility, is_static: bool) bool 
     return true;
 }
 
-fn rcGetProperty(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rcGetProperty(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1 or args[0] != .string) return throwReflection(ctx, "ReflectionClass::getProperty() expects a property name");
     const prop_name = args[0].string.bytes();
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     if (findPropertyDef(ctx.vm, class_name, prop_name)) |result| {
         const obj = try buildPropertyObjStatic(ctx, class_name, result.prop, result.declaring_class, result.is_static);
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     const msg = std.fmt.allocPrint(ctx.allocator, "Property {s}::${s} does not exist", .{ class_name, prop_name }) catch return error.OutOfMemory;
     try ctx.strings.append(ctx.allocator, msg);
     return throwReflection(ctx, msg);
 }
 
-fn rcHasProperty(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    return .{ .bool = findPropertyDef(ctx.vm, class_name, args[0].string.bytes()) != null };
+fn rcHasProperty(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = findPropertyDef(ctx.vm, class_name, args[0].string.bytes()) != null });
 }
 
-fn rcNewLazyProxy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rcNewLazyProxy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const result = try rcNewLazyGhost(ctx, args);
-    if (result == .object) result.object.lazy.?.proxy = true;
+    if (result.value == .object) result.value.object.lazy.?.proxy = true;
     return result;
 }
 
-fn rcNewLazyGhost(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    if (args.len < 1) return .null;
+fn rcNewLazyGhost(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const obj = try ctx.vm.allocator.create(PhpObject);
     // the lazy object owns its initializer until it runs or is cleared
     VM.retainValue(args[0]);
@@ -1745,24 +1746,24 @@ fn rcNewLazyGhost(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         ctx.vm.releaseValue(state.initializer);
         state.initializer = .null;
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rcInitializeLazyObject(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .null;
+fn rcInitializeLazyObject(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
     const obj = args[0].object;
     try ctx.vm.triggerLazyInit(obj);
-    return .{ .object = obj.storage() };
+    return NativeResult.borrowed(.{ .object = obj.storage() });
 }
 
-fn rcIsUninitializedLazyObject(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    const state = args[0].object.lazy orelse return .{ .bool = false };
-    return .{ .bool = state.initializer != .null and !state.running };
+fn rcIsUninitializedLazyObject(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const state = args[0].object.lazy orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = state.initializer != .null and !state.running });
 }
 
-fn rcMarkLazyObjectAsInitialized(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .null;
+fn rcMarkLazyObjectAsInitialized(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
     if (args[0].object.lazy) |state| {
         if (!state.running) {
             const initializer = state.initializer;
@@ -1770,12 +1771,12 @@ fn rcMarkLazyObjectAsInitialized(ctx: *NativeContext, args: []const Value) Runti
             ctx.vm.releaseValue(initializer);
         }
     }
-    return .{ .object = args[0].object.storage() };
+    return NativeResult.borrowed(.{ .object = args[0].object.storage() });
 }
 
-fn rcNewInstanceWithoutConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcNewInstanceWithoutConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const obj = try ctx.vm.allocator.create(PhpObject);
     ctx.vm.next_object_id += 1;
@@ -1788,61 +1789,61 @@ fn rcNewInstanceWithoutConstructor(ctx: *NativeContext, _: []const Value) Runtim
     // and aren't left null). the previous hand-rolled loop skipped the slot layout
     // and stored the raw shared default, leaving non-scalar defaults wrong
     try ctx.vm.initObjectProperties(obj, class_name);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rcGetShortName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetShortName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     if (std.mem.lastIndexOfScalar(u8, name, '\\')) |pos| {
-        return .{ .string = Value.String.borrowed(name[pos + 1 ..]) };
+        return try NativeResult.copyString(ctx.allocator, name[pos + 1 ..]);
     }
-    return .{ .string = Value.String.borrowed(name) };
+    return NativeResult.shareString(this.get("name").string);
 }
 
-fn rcGetNamespaceName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .string = Value.String.borrowed("") };
+fn rcGetNamespaceName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.literal("");
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.literal("");
     if (std.mem.lastIndexOfScalar(u8, name, '\\')) |pos| {
-        return .{ .string = Value.String.borrowed(name[0..pos]) };
+        return try NativeResult.copyString(ctx.allocator, name[0..pos]);
     }
-    return .{ .string = Value.String.borrowed("") };
+    return NativeResult.literal("");
 }
 
-fn rcInNamespace(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    return .{ .bool = std.mem.indexOfScalar(u8, name, '\\') != null };
+fn rcInNamespace(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = std.mem.indexOfScalar(u8, name, '\\') != null });
 }
 
-fn rcIsTrait(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rcIsTrait(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const v = this.get("_is_trait");
-    return .{ .bool = v == .bool and v.bool };
+    return NativeResult.scalar(.{ .bool = v == .bool and v.bool });
 }
 
-fn rcGetTraitNames(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .array = try ctx.createArray() };
+fn rcGetTraitNames(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 
     const arr = try ctx.createArray();
     for (cls.used_traits.items) |name| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(name) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rcIsEnum(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(name) orelse return .{ .bool = false };
-    return .{ .bool = cls.is_enum };
+fn rcIsEnum(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = cls.is_enum });
 }
 
-fn rcGetConstants(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetConstants(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const arr = try ctx.createArray();
     var is_own = true;
@@ -1875,12 +1876,12 @@ fn rcGetConstants(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         current = cls.parent;
         is_own = false;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rcGetReflectionConstants(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetReflectionConstants(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const arr = try ctx.createArray();
     var current: ?[]const u8 = class_name;
@@ -1905,13 +1906,13 @@ fn rcGetReflectionConstants(ctx: *NativeContext, _: []const Value) RuntimeError!
         }
         current = cls.parent;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rcGetReflectionConstant(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn rcGetReflectionConstant(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const target = args[0].string.bytes();
 
     var current: ?[]const u8 = class_name;
@@ -1919,44 +1920,44 @@ fn rcGetReflectionConstant(ctx: *NativeContext, args: []const Value) RuntimeErro
         const cls = ctx.vm.classes.get(name) orelse break;
         if (cls.constant_names.contains(target)) {
             if (cls.static_props.get(target)) |val| {
-                return try buildReflectionClassConstant(ctx, name, target, val);
+                return NativeResult.borrowed(try buildReflectionClassConstant(ctx, name, target, val));
             }
         }
         current = cls.parent;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcHasConstant(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn rcHasConstant(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const target = args[0].string.bytes();
 
     var current: ?[]const u8 = class_name;
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
-        if (cls.constant_names.contains(target)) return .{ .bool = true };
+        if (cls.constant_names.contains(target)) return NativeResult.scalar(.{ .bool = true });
         current = cls.parent;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcGetConstant(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn rcGetConstant(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const target = args[0].string.bytes();
 
     var current: ?[]const u8 = class_name;
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
         if (cls.constant_names.contains(target)) {
-            if (cls.static_props.get(target)) |val| return retainReturned(val);
+            if (cls.static_props.get(target)) |val| return NativeResult.share(val);
         }
         current = cls.parent;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 fn buildReflectionClassConstant(ctx: *NativeContext, class_name: []const u8, const_name: []const u8, _: Value) RuntimeError!Value {
@@ -1969,19 +1970,19 @@ fn buildReflectionClassConstant(ctx: *NativeContext, class_name: []const u8, con
     return .{ .object = obj };
 }
 
-fn rccGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn rccGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn rccGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rccGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const class_name = this.get("class");
     const const_name = this.get("name");
-    if (class_name != .string or const_name != .string) return .{ .bool = false };
-    const doc = findConstantDoc(ctx, class_name.string.bytes(), const_name.string.bytes(), 0) orelse return .{ .bool = false };
-    if (doc.len == 0) return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(doc) };
+    if (class_name != .string or const_name != .string) return NativeResult.scalar(.{ .bool = false });
+    const doc = findConstantDoc(ctx, class_name.string.bytes(), const_name.string.bytes(), 0) orelse return NativeResult.scalar(.{ .bool = false });
+    if (doc.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, doc);
 }
 
 fn findConstantOwner(ctx: *NativeContext, class_name: []const u8, name: []const u8, depth: usize) ?[]const u8 {
@@ -2014,20 +2015,20 @@ fn findConstantDoc(ctx: *NativeContext, class_name: []const u8, name: []const u8
     return null;
 }
 
-fn rccGetValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .null;
-    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rccGetValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.null);
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     var current: ?[]const u8 = class_name;
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
-        if (cls.static_props.get(const_name)) |val| return retainReturned(val);
+        if (cls.static_props.get(const_name)) |val| return NativeResult.share(val);
         current = cls.parent;
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rccGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rccGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP returns a bitmask: ReflectionClassConstant::IS_PUBLIC=1,
     // IS_PROTECTED=2, IS_PRIVATE=4, plus IS_FINAL=32 when declared `final`
     var mods: i64 = 0;
@@ -2038,26 +2039,26 @@ fn rccGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             .private => 4,
         };
     } else mods |= 1;
-    const this = getThis(ctx) orelse return .{ .int = mods };
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .{ .int = mods };
-    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .int = mods };
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = mods });
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.{ .int = mods });
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .int = mods });
     if (ctx.vm.classes.get(class_name)) |cls| {
         if (cls.const_final.contains(const_name)) mods |= 32;
     }
-    return .{ .int = mods };
+    return NativeResult.scalar(.{ .int = mods });
 }
 
-fn rccGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .null;
+fn rccGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.null);
     const rc = try ctx.createObject("ReflectionClass");
     try rc.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(class_name) });
-    return .{ .object = rc };
+    return NativeResult.borrowed(.{ .object = rc });
 }
 
-fn rccConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rccConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2) return throwReflection(ctx, "ReflectionClassConstant::__construct expects class and constant name");
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const raw_class: []const u8 = switch (args[0]) {
         .string => args[0].string.bytes(),
         .object => args[0].object.class_name,
@@ -2070,21 +2071,21 @@ fn rccConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const owner = findConstantOwner(ctx, class_name, const_name, 0) orelse return throwReflection(ctx, "Constant not found");
     try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(const_name) });
     try this.set(ctx.allocator, "class", .{ .string = Value.String.borrowed(owner) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rccGetAttributes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .null;
-    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rccGetAttributes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.null);
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
     const cls = ctx.vm.classes.get(class_name) orelse {
-        return .{ .array = try ctx.createArray() };
+        return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     };
     if (cls.constant_attributes.get(const_name)) |attrs| {
         return try buildAttributeArray(ctx, attrs, null, 16);
     }
-    return .{ .array = try ctx.createArray() };
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
 fn rccVisibility(ctx: *NativeContext) ?@import("../runtime/vm.zig").ClassDef.Visibility {
@@ -2095,85 +2096,85 @@ fn rccVisibility(ctx: *NativeContext) ?@import("../runtime/vm.zig").ClassDef.Vis
     return cls.const_visibility.get(const_name);
 }
 
-fn rccIsPublic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const v = rccVisibility(ctx) orelse return .{ .bool = true };
-    return .{ .bool = v == .public };
+fn rccIsPublic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const v = rccVisibility(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = v == .public });
 }
 
-fn rccIsProtected(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const v = rccVisibility(ctx) orelse return .{ .bool = false };
-    return .{ .bool = v == .protected };
+fn rccIsProtected(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const v = rccVisibility(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = v == .protected });
 }
 
-fn rccIsPrivate(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const v = rccVisibility(ctx) orelse return .{ .bool = false };
-    return .{ .bool = v == .private };
+fn rccIsPrivate(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const v = rccVisibility(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = v == .private });
 }
 
-fn rccIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .{ .bool = false };
-    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
-    return .{ .bool = cls.const_final.contains(const_name) };
+fn rccIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = cls.const_final.contains(const_name) });
 }
 
-fn rccIsEnumCase(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .{ .bool = false };
-    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
-    if (!cls.is_enum) return .{ .bool = false };
+fn rccIsEnumCase(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    if (!cls.is_enum) return NativeResult.scalar(.{ .bool = false });
     for (cls.case_order.items) |case_name| {
-        if (std.mem.eql(u8, case_name, const_name)) return .{ .bool = true };
+        if (std.mem.eql(u8, case_name, const_name)) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rccGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .null;
-    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rccGetType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.null);
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     var current: ?[]const u8 = class_name;
     while (current) |cn| {
         if (ctx.vm.classes.get(cn)) |cls| {
             if (cls.static_prop_types.get(const_name)) |type_str| {
                 if (cls.constant_names.contains(const_name)) {
-                    return .{ .object = try createTypeObj(ctx, type_str, false, cn) };
+                    return NativeResult.borrowed(.{ .object = try createTypeObj(ctx, type_str, false, cn) });
                 }
             }
             current = cls.parent;
         } else break;
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rccHasType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .{ .bool = false };
-    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+fn rccHasType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
     var current: ?[]const u8 = class_name;
     while (current) |cn| {
         if (ctx.vm.classes.get(cn)) |cls| {
-            if (cls.static_prop_types.get(const_name) != null and cls.constant_names.contains(const_name)) return .{ .bool = true };
+            if (cls.static_prop_types.get(const_name) != null and cls.constant_names.contains(const_name)) return NativeResult.scalar(.{ .bool = true });
             current = cls.parent;
         } else break;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rcIsInternal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rcIsInternal(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = false };
-    return .{ .bool = isInternalClassName(name_v.string.bytes()) };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = isInternalClassName(name_v.string.bytes()) });
 }
 
-fn rcIsUserDefined(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = true };
+fn rcIsUserDefined(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = true };
-    return .{ .bool = !isInternalClassName(name_v.string.bytes()) };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = !isInternalClassName(name_v.string.bytes()) });
 }
 
 // hard-coded list of built-in PHP classes zphp ships natively. used by
@@ -2184,33 +2185,33 @@ fn isInternalClassName(name: []const u8) bool {
     return @import("builtin_classes.zig").contains(name);
 }
 
-fn rcGetFileName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(name) orelse return .{ .bool = false };
-    if (cls.file_path.len == 0) return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(cls.file_path) };
+fn rcGetFileName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(name) orelse return NativeResult.scalar(.{ .bool = false });
+    if (cls.file_path.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, cls.file_path);
 }
 
-fn rcGetStartLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(name) orelse return .{ .bool = false };
-    if (cls.start_line == 0) return .{ .bool = false };
-    return .{ .int = @intCast(cls.start_line) };
+fn rcGetStartLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(name) orelse return NativeResult.scalar(.{ .bool = false });
+    if (cls.start_line == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(cls.start_line) });
 }
 
-fn rcGetEndLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(name) orelse return .{ .bool = false };
-    if (cls.end_line == 0) return .{ .bool = false };
-    return .{ .int = @intCast(cls.end_line) };
+fn rcGetEndLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(name) orelse return NativeResult.scalar(.{ .bool = false });
+    if (cls.end_line == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(cls.end_line) });
 }
 
-fn rcGetDefaultProperties(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetDefaultProperties(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     const arr = try ctx.createArray();
     var seen = std.StringHashMapUnmanaged(void){};
     defer seen.deinit(ctx.allocator);
@@ -2227,12 +2228,12 @@ fn rcGetDefaultProperties(ctx: *NativeContext, _: []const Value) RuntimeError!Va
         current = cls.parent;
         is_own = false;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rcGetStaticProperties(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rcGetStaticProperties(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     const arr = try ctx.createArray();
     var current: ?[]const u8 = class_name;
     while (current) |name| {
@@ -2244,30 +2245,30 @@ fn rcGetStaticProperties(ctx: *NativeContext, _: []const Value) RuntimeError!Val
         }
         current = cls.parent;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rcGetStaticPropertyValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rcGetStaticPropertyValue(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1 or args[0] != .string) return throwReflection(ctx, "ReflectionClass::getStaticPropertyValue() expects a property name");
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     const prop_name = args[0].string.bytes();
     var current: ?[]const u8 = class_name;
     while (current) |name| {
         const cls = ctx.vm.classes.get(name) orelse break;
         if (!cls.constant_names.contains(prop_name)) {
-            if (cls.static_props.get(prop_name)) |v| return v;
+            if (cls.static_props.get(prop_name)) |v| return NativeResult.share(v);
         }
         current = cls.parent;
     }
-    if (args.len >= 2) return args[1];
+    if (args.len >= 2) return NativeResult.share(args[1]);
     return throwReflection(ctx, "Static property does not exist");
 }
 
-fn rcSetStaticPropertyValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rcSetStaticPropertyValue(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2 or args[0] != .string) return throwReflection(ctx, "ReflectionClass::setStaticPropertyValue() expects a property name and value");
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     const prop_name = args[0].string.bytes();
     var current: ?[]const u8 = class_name;
     while (current) |name| {
@@ -2275,7 +2276,7 @@ fn rcSetStaticPropertyValue(ctx: *NativeContext, args: []const Value) RuntimeErr
         if (!cls_ptr.constant_names.contains(prop_name)) {
             if (cls_ptr.static_props.contains(prop_name)) {
                 try cls_ptr.static_props.put(ctx.vm.allocator, prop_name, args[1]);
-                return .null;
+                return NativeResult.scalar(.null);
             }
         }
         current = cls_ptr.parent;
@@ -2283,9 +2284,9 @@ fn rcSetStaticPropertyValue(ctx: *NativeContext, args: []const Value) RuntimeErr
     return throwReflection(ctx, "Static property does not exist");
 }
 
-fn rmConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rmConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1) return throwReflection(ctx, "ReflectionMethod::__construct() expects parameters");
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     var class_name: []const u8 = undefined;
     var method_name: []const u8 = undefined;
@@ -2345,7 +2346,7 @@ fn rmConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try this.set(ctx.allocator, "_visibility", .{ .int = @intFromEnum(info.visibility) });
 
     var buf: [256]u8 = undefined;
-    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .null;
+    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return NativeResult.scalar(.null);
     if (ctx.vm.functions.get(key)) |func| {
         try this.set(ctx.allocator, "_arity", .{ .int = func.arity });
         try this.set(ctx.allocator, "_required_params", .{ .int = func.required_params });
@@ -2354,12 +2355,12 @@ fn rmConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try this.set(ctx.allocator, "_required_params", .{ .int = info.arity });
     }
 
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rmGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn rmGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
 fn rmLookupFunc(ctx: *NativeContext) ?@TypeOf(ctx.vm.functions.get("").?) {
@@ -2371,48 +2372,48 @@ fn rmLookupFunc(ctx: *NativeContext) ?@TypeOf(ctx.vm.functions.get("").?) {
     return ctx.vm.functions.get(key);
 }
 
-fn rmGetFileName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const func = rmLookupFunc(ctx) orelse return .{ .bool = false };
-    if (func.file_path.len == 0) return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(func.file_path) };
+fn rmGetFileName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const func = rmLookupFunc(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.file_path.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, func.file_path);
 }
 
-fn rmGetStartLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const func = rmLookupFunc(ctx) orelse return .{ .bool = false };
-    if (func.start_line == 0) return .{ .bool = false };
-    return .{ .int = @intCast(func.start_line) };
+fn rmGetStartLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const func = rmLookupFunc(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.start_line == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(func.start_line) });
 }
 
-fn rmGetEndLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const func = rmLookupFunc(ctx) orelse return .{ .bool = false };
-    if (func.end_line == 0) return .{ .bool = false };
-    return .{ .int = @intCast(func.end_line) };
+fn rmGetEndLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const func = rmLookupFunc(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.end_line == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(func.end_line) });
 }
 
-fn rmIsInternal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const dc = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = false };
-    return .{ .bool = isInternalClassName(dc) };
+fn rmIsInternal(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const dc = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = isInternalClassName(dc) });
 }
 
-fn rmIsUserDefined(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = true };
-    const dc = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = true };
-    return .{ .bool = !isInternalClassName(dc) };
+fn rmIsUserDefined(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    const dc = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = !isInternalClassName(dc) });
 }
 
-fn reflectionEmptyString(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed("") };
+fn reflectionEmptyString(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal("");
 }
 
-fn rmGetParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const method_name = methodLookupName(this) orelse return .null;
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
+fn rmGetParameters(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.null);
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.null);
 
     var buf: [256]u8 = undefined;
-    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .null;
-    const func = ctx.vm.functions.get(key) orelse return .{ .array = try ctx.createArray() };
+    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return NativeResult.scalar(.null);
+    const func = ctx.vm.functions.get(key) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 
     const result = try buildParamArray(ctx, func, key);
     if (this.get("_hook_method") == .string and result == .array) {
@@ -2420,110 +2421,110 @@ fn rmGetParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             if (entry.value == .object) try entry.value.object.set(ctx.allocator, "_hook_declaring_function", .{ .object = this });
         }
     }
-    return result;
+    return NativeResult.borrowed(result);
 }
 
-fn rmIsPublic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rmIsPublic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const vis = this.get("_visibility");
-    return .{ .bool = vis == .int and vis.int == 0 };
+    return NativeResult.scalar(.{ .bool = vis == .int and vis.int == 0 });
 }
 
-fn rmIsProtected(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rmIsProtected(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const vis = this.get("_visibility");
-    return .{ .bool = vis == .int and vis.int == 1 };
+    return NativeResult.scalar(.{ .bool = vis == .int and vis.int == 1 });
 }
 
-fn rmIsPrivate(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rmIsPrivate(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const vis = this.get("_visibility");
-    return .{ .bool = vis == .int and vis.int == 2 };
+    return NativeResult.scalar(.{ .bool = vis == .int and vis.int == 2 });
 }
 
-fn rmIsStatic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rmIsStatic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const is_static = this.get("_is_static");
-    return .{ .bool = is_static == .bool and is_static.bool };
+    return NativeResult.scalar(.{ .bool = is_static == .bool and is_static.bool });
 }
 
-fn rmGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
+fn rmGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.null);
 
     const obj = try ctx.createObject("ReflectionClass");
     try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(declaring) });
     try obj.set(ctx.allocator, "_is_interface", .{ .bool = ctx.vm.interfaces.contains(declaring) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rmGetReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rmGetReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const hook_type = this.get("_hook_return_type");
     if (hook_type == .string) {
-        if (hook_type.string.bytes().len == 0) return .null;
-        return .{ .object = try createTypeObj(ctx, hook_type.string.bytes(), false, this.get("_declaring_class").string.bytes()) };
+        if (hook_type.string.bytes().len == 0) return NativeResult.scalar(.null);
+        return NativeResult.borrowed(.{ .object = try createTypeObj(ctx, hook_type.string.bytes(), false, this.get("_declaring_class").string.bytes()) });
     }
-    const method_name = methodLookupName(this) orelse return .null;
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.null);
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.null);
 
     var buf: [256]u8 = undefined;
-    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .null;
-    const type_info = vm_mod.getTypeInfo(key) orelse return .null;
-    if (type_info.return_type.len == 0) return .null;
+    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return NativeResult.scalar(.null);
+    const type_info = vm_mod.getTypeInfo(key) orelse return NativeResult.scalar(.null);
+    if (type_info.return_type.len == 0) return NativeResult.scalar(.null);
 
     const obj = try createTypeObj(ctx, type_info.return_type, false, declaring);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rmHasReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rmHasReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const hook_type = this.get("_hook_return_type");
     if (hook_type == .string) {
-        return .{ .bool = hook_type.string.bytes().len > 0 };
+        return NativeResult.scalar(.{ .bool = hook_type.string.bytes().len > 0 });
     }
-    const method_name = methodLookupName(this) orelse return .{ .bool = false };
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = false };
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.{ .bool = false });
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
 
     var buf: [256]u8 = undefined;
-    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .{ .bool = false };
-    const type_info = vm_mod.getTypeInfo(key) orelse return .{ .bool = false };
-    return .{ .bool = type_info.return_type.len > 0 };
+    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return NativeResult.scalar(.{ .bool = false });
+    const type_info = vm_mod.getTypeInfo(key) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = type_info.return_type.len > 0 });
 }
 
-fn rmIsConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rmIsConstructor(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name = this.get("name");
-    return .{ .bool = name == .string and std.mem.eql(u8, name.string.bytes(), "__construct") };
+    return NativeResult.scalar(.{ .bool = name == .string and std.mem.eql(u8, name.string.bytes(), "__construct") });
 }
 
-fn rmIsDestructor(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rmIsDestructor(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name = this.get("name");
-    return .{ .bool = name == .string and std.mem.eql(u8, name.string.bytes(), "__destruct") };
+    return NativeResult.scalar(.{ .bool = name == .string and std.mem.eql(u8, name.string.bytes(), "__destruct") });
 }
 
-fn rmGetNumberOfParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
+fn rmGetNumberOfParameters(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const arity = this.get("_arity");
-    return if (arity == .int) arity else .{ .int = 0 };
+    return if (arity == .int) NativeResult.share(arity) else NativeResult.scalar(.{ .int = 0 });
 }
 
-fn rmGetNumberOfRequiredParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
+fn rmGetNumberOfRequiredParameters(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const req = this.get("_required_params");
-    return if (req == .int) req else .{ .int = 0 };
+    return if (req == .int) NativeResult.share(req) else NativeResult.scalar(.{ .int = 0 });
 }
 
-fn rpGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn rpGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn rpGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpGetType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const type_val = this.get("_type_name");
-    if (type_val != .string or type_val.string.bytes().len == 0) return .null;
+    if (type_val != .string or type_val.string.bytes().len == 0) return NativeResult.scalar(.null);
 
     const nullable = this.get("_nullable");
     var is_nullable = nullable == .bool and nullable.bool;
@@ -2536,60 +2537,60 @@ fn rpGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const declaring = this.get("_declaring_class");
     const self_class: ?[]const u8 = if (declaring == .string and declaring.string.bytes().len > 0) declaring.string.bytes() else null;
     const obj = try createTypeObj(ctx, type_val.string.bytes(), is_nullable, self_class);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rpIsDefaultValueAvailable(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpIsDefaultValueAvailable(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const has_default = this.get("_has_default");
-    return .{ .bool = has_default == .bool and has_default.bool };
+    return NativeResult.scalar(.{ .bool = has_default == .bool and has_default.bool });
 }
 
-fn rpGetDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpGetDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const has_default = this.get("_has_default");
     if (has_default != .bool or !has_default.bool) return throwReflection(ctx, "Internal error: no default value available");
-    return retainReturned(this.get("_default_value"));
+    return NativeResult.share(this.get("_default_value"));
 }
 
-fn rpIsOptional(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpIsOptional(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const has_default = this.get("_has_default");
-    if (has_default == .bool and has_default.bool) return .{ .bool = true };
+    if (has_default == .bool and has_default.bool) return NativeResult.scalar(.{ .bool = true });
     const is_var = this.get("_is_variadic");
-    return .{ .bool = is_var == .bool and is_var.bool };
+    return NativeResult.scalar(.{ .bool = is_var == .bool and is_var.bool });
 }
 
-fn rpGetPosition(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
-    return this.get("_position");
+fn rpGetPosition(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(this.get("_position"));
 }
 
-fn rpAllowsNull(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = true };
+fn rpAllowsNull(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
     const type_val = this.get("_type_name");
-    if (type_val != .string or type_val.string.bytes().len == 0) return .{ .bool = true };
-    if (std.mem.eql(u8, type_val.string.bytes(), "mixed") or std.mem.eql(u8, type_val.string.bytes(), "null")) return .{ .bool = true };
+    if (type_val != .string or type_val.string.bytes().len == 0) return NativeResult.scalar(.{ .bool = true });
+    if (std.mem.eql(u8, type_val.string.bytes(), "mixed") or std.mem.eql(u8, type_val.string.bytes(), "null")) return NativeResult.scalar(.{ .bool = true });
     const nullable = this.get("_nullable");
-    return .{ .bool = nullable == .bool and nullable.bool };
+    return NativeResult.scalar(.{ .bool = nullable == .bool and nullable.bool });
 }
 
-fn rpIsPassedByReference(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpIsPassedByReference(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const by_ref = this.get("_by_reference");
-    return .{ .bool = by_ref == .bool and by_ref.bool };
+    return NativeResult.scalar(.{ .bool = by_ref == .bool and by_ref.bool });
 }
 
-fn rpCanBePassedByValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = true };
+fn rpCanBePassedByValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
     const by_ref = this.get("_by_reference");
-    return .{ .bool = !(by_ref == .bool and by_ref.bool) };
+    return NativeResult.scalar(.{ .bool = !(by_ref == .bool and by_ref.bool) });
 }
 
-fn rpHasType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpHasType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const type_val = this.get("_type_name");
-    return .{ .bool = type_val == .string and type_val.string.bytes().len > 0 };
+    return NativeResult.scalar(.{ .bool = type_val == .string and type_val.string.bytes().len > 0 });
 }
 
 // constant default sentinel: "\x00CC\x00<class>\x00<const>" (class empty for global constants)
@@ -2608,116 +2609,115 @@ fn decodeConstSentinel(ctx: *NativeContext, v: Value) !?[]const u8 {
     return joined;
 }
 
-fn rpIsDefaultValueConstant(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpIsDefaultValueConstant(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const has_default = this.get("_has_default");
-    if (has_default != .bool or !has_default.bool) return .{ .bool = false };
+    if (has_default != .bool or !has_default.bool) return NativeResult.scalar(.{ .bool = false });
     const name = this.get("_default_const_name");
-    return .{ .bool = name == .string and name.string.bytes().len > 0 };
+    return NativeResult.scalar(.{ .bool = name == .string and name.string.bytes().len > 0 });
 }
 
-fn rpGetDefaultValueConstantName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpGetDefaultValueConstantName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const has_default = this.get("_has_default");
     if (has_default != .bool or !has_default.bool) return throwReflection(ctx, "Internal error: no default value available");
     const name = this.get("_default_const_name");
-    if (name == .string and name.string.bytes().len > 0) return name;
-    return .null;
+    if (name == .string and name.string.bytes().len > 0) return NativeResult.share(name);
+    return NativeResult.scalar(.null);
 }
 
-fn rpGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const param_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .array = try ctx.createArray() };
-    const class_name = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .array = try ctx.createArray() };
-    const method_name = if (this.get("_method_name") == .string) this.get("_method_name").string.bytes() else return .{ .array = try ctx.createArray() };
+fn rpGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const param_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const class_name = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const method_name = if (this.get("_method_name") == .string) this.get("_method_name").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .array = try ctx.createArray() };
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 
     var key_buf: [256]u8 = undefined;
-    const key = std.fmt.bufPrint(&key_buf, "{s}:{s}", .{ method_name, param_name }) catch return .{ .array = try ctx.createArray() };
-    const attrs = cls.param_attributes.get(key) orelse return .{ .array = try ctx.createArray() };
+    const key = std.fmt.bufPrint(&key_buf, "{s}:{s}", .{ method_name, param_name }) catch return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const attrs = cls.param_attributes.get(key) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 
     const filter: ?[]const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else null;
     const flags: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else 0;
     return buildAttributeArrayWithFlags(ctx, attrs, filter, 32, flags);
 }
 
-fn rpGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const declaring = this.get("_declaring_class");
-    if (declaring != .string or declaring.string.bytes().len == 0) return .null;
+    if (declaring != .string or declaring.string.bytes().len == 0) return NativeResult.scalar(.null);
 
     const obj = try ctx.createObject("ReflectionClass");
     try obj.set(ctx.allocator, "name", declaring);
     try obj.set(ctx.allocator, "_is_interface", .{ .bool = ctx.vm.interfaces.contains(declaring.string.bytes()) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rpIsVariadic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpIsVariadic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const v = this.get("_is_variadic");
-    return .{ .bool = v == .bool and v.bool };
+    return NativeResult.scalar(.{ .bool = v == .bool and v.bool });
 }
 
-fn rpGetDeclaringFunction(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpGetDeclaringFunction(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const hook = this.get("_hook_declaring_function");
-    if (hook == .object) return hook;
+    if (hook == .object) return NativeResult.share(hook);
     const func_name = if (this.get("_function") == .string) this.get("_function").string.bytes() else "";
     const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else "";
     if (declaring.len > 0) {
         const obj = try ctx.createObject("ReflectionMethod");
         try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(func_name) });
         try obj.set(ctx.allocator, "_declaring_class", .{ .string = Value.String.borrowed(declaring) });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     const obj = try ctx.createObject("ReflectionFunction");
     try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(func_name) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rntGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return this.get("type_name");
+fn rntGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("type_name"));
 }
 
-fn rntToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rntToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const name_v = this.get("type_name");
-    if (name_v != .string) return name_v;
+    if (name_v != .string) return NativeResult.share(name_v);
     const nullable_v = this.get("nullable");
     const is_nullable = nullable_v == .bool and nullable_v.bool;
-    if (!is_nullable or std.mem.eql(u8, name_v.string.bytes(), "mixed") or std.mem.eql(u8, name_v.string.bytes(), "null")) return name_v;
-    const result = std.fmt.allocPrint(ctx.allocator, "?{s}", .{name_v.string.bytes()}) catch return name_v;
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    if (!is_nullable or std.mem.eql(u8, name_v.string.bytes(), "mixed") or std.mem.eql(u8, name_v.string.bytes(), "null")) return NativeResult.share(name_v);
+    const result = std.fmt.allocPrint(ctx.allocator, "?{s}", .{name_v.string.bytes()}) catch return NativeResult.share(name_v);
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn rntIsBuiltin(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rntIsBuiltin(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name = this.get("type_name");
-    if (name != .string) return .{ .bool = false };
-    return .{ .bool = isBuiltinType(name.string.bytes()) };
+    if (name != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = isBuiltinType(name.string.bytes()) });
 }
 
-fn rntAllowsNull(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rntAllowsNull(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const nullable = this.get("nullable");
-    if (nullable == .bool and nullable.bool) return .{ .bool = true };
+    if (nullable == .bool and nullable.bool) return NativeResult.scalar(.{ .bool = true });
     // mixed and null types implicitly allow null
     const tn = this.get("type_name");
     if (tn == .string) {
         if (std.mem.eql(u8, tn.string.bytes(), "mixed") or std.mem.eql(u8, tn.string.bytes(), "null")) {
-            return .{ .bool = true };
+            return NativeResult.scalar(.{ .bool = true });
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rutGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
+fn rutGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const ts_v = this.get("type_str");
-    if (ts_v != .string) return .{ .array = try ctx.createArray() };
+    if (ts_v != .string) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const sc_v = this.get("_self_class");
     const self_class: ?[]const u8 = if (sc_v == .string and sc_v.string.bytes().len > 0) sc_v.string.bytes() else null;
     const arr = try ctx.createArray();
@@ -2732,25 +2732,25 @@ fn rutGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         }
         try arr.append(ctx.allocator, .{ .object = obj });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rutAllowsNull(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rutAllowsNull(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const nullable = this.get("nullable");
-    return .{ .bool = nullable == .bool and nullable.bool };
+    return NativeResult.scalar(.{ .bool = nullable == .bool and nullable.bool });
 }
 
-fn rutToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rutToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const ts_v = this.get("type_str");
-    return ts_v;
+    return NativeResult.share(ts_v);
 }
 
-fn ritGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
+fn ritGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const ts_v = this.get("type_str");
-    if (ts_v != .string) return .{ .array = try ctx.createArray() };
+    if (ts_v != .string) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const arr = try ctx.createArray();
     var it = std.mem.splitScalar(u8, ts_v.string.bytes(), '&');
     while (it.next()) |part| {
@@ -2758,22 +2758,22 @@ fn ritGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         const obj = try createNamedTypeObj(ctx, part, false);
         try arr.append(ctx.allocator, .{ .object = obj });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn ritAllowsNull(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = false };
+fn ritAllowsNull(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn ritToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn ritToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const ts_v = this.get("type_str");
-    return ts_v;
+    return NativeResult.share(ts_v);
 }
 
-fn rfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1) return throwReflection(ctx, "ReflectionFunction::__construct() expects a function name");
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     if (args[0] == .object and std.mem.eql(u8, args[0].object.class_name, "Closure")) {
         const callable = args[0].object.get("__callable");
@@ -2783,7 +2783,7 @@ fn rfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const target = callable.array.entries.items[0].value;
             const method = callable.array.entries.items[1].value.string.bytes();
             const class_name = if (target == .object) target.object.class_name else if (target == .string) target.string.bytes() else "";
-            const full = std.fmt.allocPrint(ctx.allocator, "{s}::{s}", .{ class_name, method }) catch return .null;
+            const full = std.fmt.allocPrint(ctx.allocator, "{s}::{s}", .{ class_name, method }) catch return NativeResult.scalar(.null);
             try ctx.strings.append(ctx.allocator, full);
             try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(full) });
             try this.set(ctx.allocator, "__is_method_ref", .{ .bool = true });
@@ -2810,7 +2810,7 @@ fn rfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const method = arr.entries.items[1].value.string.bytes();
             const target = arr.entries.items[0].value;
             const class_name = if (target == .object) target.object.class_name else if (target == .string) target.string.bytes() else "";
-            const full = std.fmt.allocPrint(ctx.allocator, "{s}::{s}", .{ class_name, method }) catch return .null;
+            const full = std.fmt.allocPrint(ctx.allocator, "{s}::{s}", .{ class_name, method }) catch return NativeResult.scalar(.null);
             try ctx.strings.append(ctx.allocator, full);
             try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(full) });
             try this.set(ctx.allocator, "__is_method_ref", .{ .bool = true });
@@ -2823,48 +2823,48 @@ fn rfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     } else {
         return throwReflection(ctx, "ReflectionFunction::__construct() expects a function name");
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rfInvoke(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const fn_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    return ctx.vm.callByName(fn_name, args);
+fn rfInvoke(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const fn_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callByName(fn_name, args));
 }
 
-fn rfInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const fn_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    if (args.len < 1 or args[0] != .array) return .null;
+fn rfInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const fn_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.null);
     const arr = args[0].array;
     var call_args: [16]Value = undefined;
     const count = @min(arr.entries.items.len, 16);
     for (0..count) |i| call_args[i] = arr.entries.items[i].value;
-    return ctx.vm.callByName(fn_name, call_args[0..count]);
+    return NativeResult.share(try ctx.vm.callByName(fn_name, call_args[0..count]));
 }
 
-fn rfGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn rfGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn rfGetParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rfGetParameters(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
-    const func = ctx.vm.functions.get(func_name) orelse return .{ .array = try ctx.createArray() };
-    return buildParamArray(ctx, func, func_name);
+    const func = ctx.vm.functions.get(func_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    return NativeResult.borrowed(try buildParamArray(ctx, func, func_name));
 }
 
-fn rfGetReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rfGetReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
 
-    const type_info = closureAwareTypeInfo(func_name) orelse return .null;
-    if (type_info.return_type.len == 0) return .null;
+    const type_info = closureAwareTypeInfo(func_name) orelse return NativeResult.scalar(.null);
+    if (type_info.return_type.len == 0) return NativeResult.scalar(.null);
 
     const obj = try createTypeObj(ctx, type_info.return_type, false, null);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 fn closureAwareTypeInfo(func_name: []const u8) ?@TypeOf(vm_mod.getTypeInfo("").?) {
@@ -2879,122 +2879,122 @@ fn closureAwareTypeInfo(func_name: []const u8) ?@TypeOf(vm_mod.getTypeInfo("").?
     return null;
 }
 
-fn rfHasReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+fn rfHasReturnType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
 
-    const type_info = closureAwareTypeInfo(func_name) orelse return .{ .bool = false };
-    return .{ .bool = type_info.return_type.len > 0 };
+    const type_info = closureAwareTypeInfo(func_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = type_info.return_type.len > 0 });
 }
 
-fn rfGetNumberOfParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .int = 0 };
-    const func = ctx.vm.functions.get(func_name) orelse return .{ .int = 0 };
-    return .{ .int = func.arity };
+fn rfGetNumberOfParameters(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .int = 0 });
+    const func = ctx.vm.functions.get(func_name) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = func.arity });
 }
 
-fn rfGetNumberOfRequiredParameters(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .int = 0 };
-    const func = ctx.vm.functions.get(func_name) orelse return .{ .int = 0 };
-    return .{ .int = func.required_params };
+fn rfGetNumberOfRequiredParameters(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .int = 0 });
+    const func = ctx.vm.functions.get(func_name) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = func.required_params });
 }
 
 // internal builtins (registered in vm.native_fns) have no file/line. user-
 // defined functions live in vm.functions and carry the source path on their
 // ObjFunction. start line comes from the first instruction's stored line
-fn rfGetFileName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rfGetFileName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = false };
-    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return .{ .bool = false };
-    if (func.file_path.len == 0) return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(func.file_path) };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.file_path.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, func.file_path);
 }
 
-fn rfGetStartLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rfGetStartLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = false };
-    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return .{ .bool = false };
-    if (func.start_line == 0) return .{ .bool = false };
-    return .{ .int = @intCast(func.start_line) };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.start_line == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(func.start_line) });
 }
 
-fn rfGetEndLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rfGetEndLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = false };
-    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return .{ .bool = false };
-    if (func.end_line == 0) return .{ .bool = false };
-    return .{ .int = @intCast(func.end_line) };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(name_v.string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
+    if (func.end_line == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(func.end_line) });
 }
 
-fn rfGetNamespaceName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
+fn rfGetNamespaceName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.literal("");
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .string = Value.String.borrowed("") };
+    if (name_v != .string) return NativeResult.literal("");
     const name = name_v.string.bytes();
-    const last_bs = std.mem.lastIndexOfScalar(u8, name, '\\') orelse return .{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(name[0..last_bs]) };
+    const last_bs = std.mem.lastIndexOfScalar(u8, name, '\\') orelse return NativeResult.literal("");
+    return try NativeResult.copyString(ctx.allocator, name[0..last_bs]);
 }
 
-fn rfGetShortName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
+fn rfGetShortName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.literal("");
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .string = Value.String.borrowed("") };
+    if (name_v != .string) return NativeResult.literal("");
     const name = name_v.string.bytes();
-    const last_bs = std.mem.lastIndexOfScalar(u8, name, '\\') orelse return .{ .string = Value.String.borrowed(name) };
-    return .{ .string = Value.String.borrowed(name[last_bs + 1 ..]) };
+    const last_bs = std.mem.lastIndexOfScalar(u8, name, '\\') orelse return NativeResult.shareString(name_v.string);
+    return try NativeResult.copyString(ctx.allocator, name[last_bs + 1 ..]);
 }
 
-fn rfInNamespace(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rfInNamespace(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = false };
-    return .{ .bool = std.mem.indexOfScalar(u8, name_v.string.bytes(), '\\') != null };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = std.mem.indexOfScalar(u8, name_v.string.bytes(), '\\') != null });
 }
 
-fn rfIsAnonymous(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    return .{ .bool = std.mem.startsWith(u8, name, "__closure_") };
+fn rfIsAnonymous(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = std.mem.startsWith(u8, name, "__closure_") });
 }
 
-fn rfIsInternal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rfIsInternal(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // built-in native functions register in vm.native_fns. user functions
     // land in vm.functions. closures sit under __closure_ keys which are
     // also user-defined
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    if (std.mem.startsWith(u8, name, "__closure_")) return .{ .bool = false };
-    if (ctx.vm.functions.contains(name)) return .{ .bool = false };
-    return .{ .bool = ctx.vm.native_fns.contains(name) };
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    if (std.mem.startsWith(u8, name, "__closure_")) return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.functions.contains(name)) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = ctx.vm.native_fns.contains(name) });
 }
 
-fn rfIsUserDefined(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const internal = try rfIsInternal(ctx, &.{});
-    return .{ .bool = !(internal == .bool and internal.bool) };
+fn rfIsUserDefined(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const internal = (try rfIsInternal(ctx, &.{})).value;
+    return NativeResult.scalar(.{ .bool = !(internal == .bool and internal.bool) });
 }
 
-fn rfIsGenerator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const func = ctx.vm.functions.get(func_name) orelse return .{ .bool = false };
-    return .{ .bool = func.is_generator };
+fn rfIsGenerator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(func_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = func.is_generator });
 }
 
-fn rfIsVariadic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const func = ctx.vm.functions.get(func_name) orelse return .{ .bool = false };
-    return .{ .bool = func.is_variadic };
+fn rfIsVariadic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(func_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = func.is_variadic });
 }
 
-fn rfGetClosureUsedVariables(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const fn_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .array = try ctx.createArray() };
+fn rfGetClosureUsedVariables(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const fn_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const result = try ctx.createArray();
     for (ctx.vm.captures.items) |cap| {
         if (std.mem.eql(u8, cap.closure_name, fn_name)) {
@@ -3004,59 +3004,59 @@ fn rfGetClosureUsedVariables(ctx: *NativeContext, _: []const Value) RuntimeError
             try result.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, val);
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn rfGetClosureCalledClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rfGetClosureCalledClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (this.get("__scope_class") == .string) {
         const scope_name = this.get("__scope_class").string.bytes();
         const obj = try ctx.createObject("ReflectionClass");
         try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(scope_name) });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rfGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .array = try ctx.createArray() };
+fn rfGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const compile_name = ctx.vm.getOrigClosureName(func_name);
-    const attrs = ctx.vm.function_attributes.get(compile_name) orelse return .{ .array = try ctx.createArray() };
+    const attrs = ctx.vm.function_attributes.get(compile_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const filter: ?[]const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else null;
     const flags: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else 0;
     return buildAttributeArrayWithFlags(ctx, attrs, filter, 2, flags);
 }
 
-fn rfGetClosureScopeClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rfGetClosureScopeClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     if (this.get("__scope_class") == .string) {
         const scope_name = this.get("__scope_class").string.bytes();
         const obj = try ctx.createObject("ReflectionClass");
         try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(scope_name) });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (ctx.vm.closureScopeByName(name)) |scope| {
         const obj = try ctx.createObject("ReflectionClass");
         try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(scope) });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rfGetClosureThis(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    return ctx.vm.closureThisByName(name);
+fn rfGetClosureThis(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    return NativeResult.share(ctx.vm.closureThisByName(name));
 }
 
-fn rfIsStatic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rfIsStatic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     _ = ctx;
     // a "static" closure is one declared with `static function` keyword.
     // zphp does not track this flag separately; reporting false matches PHP
     // for ordinary closures and is a known nuance for `static fn` declarations.
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 /// populate fields on a ReflectionParameter `this` object from a function +
@@ -3122,9 +3122,9 @@ fn populateRpFields(ctx: *NativeContext, obj: *PhpObject, func: *const ObjFuncti
     }
 }
 
-fn rpConstructParam(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rpConstructParam(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2) return throwReflection(ctx, "ReflectionParameter::__construct expects function and parameter");
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     // accept "func_name" | ["Class", "method"] | [$obj, "method"] | Closure-ish
     var key_buf: [256]u8 = undefined;
@@ -3169,7 +3169,7 @@ fn rpConstructParam(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     if (idx == null) return throwReflection(ctx, "ReflectionParameter could not find parameter");
 
     try populateRpFields(ctx, this, func, lookup_key, idx.?);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn buildParamArray(ctx: *NativeContext, func: *const ObjFunction, type_key: []const u8) RuntimeError!Value {
@@ -3247,13 +3247,13 @@ fn buildParamArray(ctx: *NativeContext, func: *const ObjFunction, type_key: []co
     return .{ .array = arr };
 }
 
-fn closureBind(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .null;
+fn closureBind(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
     const closure = args[0];
-    if (closure != .string or !std.mem.startsWith(u8, closure.string.bytes(), "__closure_")) return .null;
+    if (closure != .string or !std.mem.startsWith(u8, closure.string.bytes(), "__closure_")) return NativeResult.scalar(.null);
     const new_this = if (args.len >= 2) args[1] else Value.null;
     const scope = resolveScope(args);
-    return ctx.vm.cloneClosureWithThis(closure.string.bytes(), new_this, scope);
+    return NativeResult.transfer(try ctx.vm.cloneClosureWithThis(closure.string.bytes(), new_this, scope));
 }
 
 fn resolveScope(args: []const Value) VM.ClosureScope {
@@ -3270,18 +3270,18 @@ fn resolveScope(args: []const Value) VM.ClosureScope {
     return .preserve;
 }
 
-fn wrapCallableClosure(ctx: *NativeContext, callable: Value) RuntimeError!Value {
+fn wrapCallableClosure(ctx: *NativeContext, callable: Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("Closure");
     try obj.set(ctx.allocator, "__callable", callable);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn closureFromCallable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .null;
+fn closureFromCallable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
     const callable = args[0];
-    if (callable == .object and std.mem.eql(u8, callable.object.class_name, "Closure")) return callable;
+    if (callable == .object and std.mem.eql(u8, callable.object.class_name, "Closure")) return NativeResult.share(callable);
     // if already a closure, return as-is
-    if (callable == .string and std.mem.startsWith(u8, callable.string.bytes(), "__closure_")) return callable;
+    if (callable == .string and std.mem.startsWith(u8, callable.string.bytes(), "__closure_")) return NativeResult.share(callable);
     if (callable == .string) {
         const raw = callable.string.bytes();
         const name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
@@ -3309,7 +3309,7 @@ fn closureFromCallable(ctx: *NativeContext, args: []const Value) RuntimeError!Va
             const method = entries[1].value.string.bytes();
             if (entries[0].value == .string) {
                 if (ctx.vm.hasMethod(entries[0].value.string.bytes(), method)) {
-                    const full = std.fmt.allocPrint(ctx.allocator, "{s}::{s}", .{ entries[0].value.string.bytes(), method }) catch return .null;
+                    const full = std.fmt.allocPrint(ctx.allocator, "{s}::{s}", .{ entries[0].value.string.bytes(), method }) catch return NativeResult.scalar(.null);
                     try ctx.strings.append(ctx.allocator, full);
                     return wrapCallableClosure(ctx, .{ .string = Value.String.borrowed(full) });
                 }
@@ -3324,12 +3324,12 @@ fn closureFromCallable(ctx: *NativeContext, args: []const Value) RuntimeError!Va
     return error.RuntimeError;
 }
 
-fn reflectionNoop(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn reflectionNoop(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn reflectionFalse(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = false };
+fn reflectionFalse(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 fn methodLookupName(obj: *PhpObject) ?[]const u8 {
@@ -3385,39 +3385,39 @@ fn buildHookObj(ctx: *NativeContext, hook: ReflectedHook, kind: []const u8) !*Ph
     return obj;
 }
 
-fn rpropHasHooks(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = lookupPropertyHook(ctx, "get") != null or lookupPropertyHook(ctx, "set") != null };
+fn rpropHasHooks(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = lookupPropertyHook(ctx, "get") != null or lookupPropertyHook(ctx, "set") != null });
 }
 
-fn rpropHasHook(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = lookupPropertyHook(ctx, try hookKind(ctx, args)) != null };
+fn rpropHasHook(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = lookupPropertyHook(ctx, try hookKind(ctx, args)) != null });
 }
 
-fn rpropGetHook(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rpropGetHook(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const kind = try hookKind(ctx, args);
-    const hook = lookupPropertyHook(ctx, kind) orelse return .null;
-    return .{ .object = try buildHookObj(ctx, hook, kind) };
+    const hook = lookupPropertyHook(ctx, kind) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .object = try buildHookObj(ctx, hook, kind) });
 }
 
-fn rpropGetHooks(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rpropGetHooks(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     for ([_][]const u8{ "get", "set" }) |kind| {
         if (lookupPropertyHook(ctx, kind)) |hook| {
             try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(kind) }, .{ .object = try buildHookObj(ctx, hook, kind) });
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rrefFromArrayElement(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn rrefFromArrayElement(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn rrefGetId(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn rrefGetId(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn rpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2) {
         return throwReflection(
             ctx,
@@ -3425,7 +3425,7 @@ fn rpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         );
     }
 
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     const raw_class = if (args[0] == .string)
         args[0].string.bytes()
@@ -3522,57 +3522,57 @@ fn rpConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         return throwReflection(ctx, msg);
     }
 
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rpGetValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rpGetValue(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     if (args.len > 0 and args[0] == .object) {
         const dc = this.get("_declaring_class");
         if (dc == .string and !ctx.vm.isInstanceOf(args[0].object.class_name, dc.string.bytes()))
             return throwReflection(ctx, "Given object is not an instance of the class this property was declared in");
         try ctx.vm.triggerLazyProperty(args[0].object, prop_name, if (dc == .string) dc.string.bytes() else null);
-        return args[0].object.getForScope(prop_name, if (dc == .string) dc.string.bytes() else null);
+        return NativeResult.share(args[0].object.getForScope(prop_name, if (dc == .string) dc.string.bytes() else null));
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rpSetValue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rpSetValue(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return rpWrite(ctx, args, false);
 }
-fn rpSetWithoutLazy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rpSetWithoutLazy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return rpWrite(ctx, args, true);
 }
-fn rpSkipLazy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .null;
+fn rpSkipLazy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const name = this.get("name");
     const dc = this.get("_declaring_class");
-    if (name != .string) return .null;
+    if (name != .string) return NativeResult.scalar(.null);
     const obj = args[0].object;
     if (obj.lazy) |state| {
-        if (state.running or state.initializer == .null) return .null;
+        if (state.running or state.initializer == .null) return NativeResult.scalar(.null);
         if (obj.getSlotIndexForScope(name.string.bytes(), if (dc == .string) dc.string.bytes() else null)) |i| state.pending[i] = false;
         for (state.pending) |pending| {
-            if (pending) return .null;
+            if (pending) return NativeResult.scalar(.null);
         }
         const initializer = state.initializer;
         state.initializer = .null;
         ctx.vm.releaseValue(initializer);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
-fn rpIsLazy(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn rpIsLazy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const name = this.get("name");
     const dc = this.get("_declaring_class");
-    return .{ .bool = name == .string and args[0].object.isLazySlot(name.string.bytes(), if (dc == .string) dc.string.bytes() else null) };
+    return NativeResult.scalar(.{ .bool = name == .string and args[0].object.isLazySlot(name.string.bytes(), if (dc == .string) dc.string.bytes() else null) });
 }
-fn rpWrite(ctx: *NativeContext, args: []const Value, skip: bool) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
+fn rpWrite(ctx: *NativeContext, args: []const Value, skip: bool) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
     if (args.len >= 2 and args[0] == .object) {
         const target = args[0].object;
         const dc = this.get("_declaring_class");
@@ -3590,21 +3590,21 @@ fn rpWrite(ctx: *NativeContext, args: []const Value, skip: bool) RuntimeError!Va
         try target.setForScope(ctx.allocator, prop_name, value, scope);
         if (skip) _ = try rpSkipLazy(ctx, args);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rpropGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn rpropGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn rpropGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpropGetType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const dc_v = this.get("_declaring_class");
-    if (dc_v != .string) return .null;
+    if (dc_v != .string) return NativeResult.scalar(.null);
     const class_name = dc_v.string.bytes();
     const prop_name_v = this.get("name");
-    if (prop_name_v != .string) return .null;
+    if (prop_name_v != .string) return NativeResult.scalar(.null);
     const prop_name = prop_name_v.string.bytes();
 
     // walk the class chain looking for a declared property with a type. each
@@ -3617,19 +3617,19 @@ fn rpropGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
                 if (std.mem.eql(u8, p.name, prop_name)) {
                     if (p.type_str.len > 0) {
                         const obj = try createTypeObj(ctx, p.type_str, false, cn);
-                        return .{ .object = obj };
+                        return NativeResult.borrowed(.{ .object = obj });
                     }
-                    return .null;
+                    return NativeResult.scalar(.null);
                 }
             }
             if (cls.static_prop_types.get(prop_name)) |type_str| {
                 const obj = try createTypeObj(ctx, type_str, false, cn);
-                return .{ .object = obj };
+                return NativeResult.borrowed(.{ .object = obj });
             }
             current = cls.parent;
         } else break;
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn makeReflectionType(ctx: *NativeContext, type_str: []const u8) RuntimeError!Value {
@@ -3677,35 +3677,35 @@ fn isBuiltinTypeName(name: []const u8) bool {
     return false;
 }
 
-fn rpropIsPublic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = true };
+fn rpropIsPublic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
     const vis = this.get("_visibility");
-    return .{ .bool = vis == .int and vis.int == 0 };
+    return NativeResult.scalar(.{ .bool = vis == .int and vis.int == 0 });
 }
 
-fn rpropIsProtected(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropIsProtected(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const vis = this.get("_visibility");
-    return .{ .bool = vis == .int and vis.int == 1 };
+    return NativeResult.scalar(.{ .bool = vis == .int and vis.int == 1 });
 }
 
-fn rpropIsPrivate(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropIsPrivate(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const vis = this.get("_visibility");
-    return .{ .bool = vis == .int and vis.int == 2 };
+    return NativeResult.scalar(.{ .bool = vis == .int and vis.int == 2 });
 }
 
-fn rpropIsPrivateSet(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropIsPrivateSet(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const vis = this.get("_visibility");
     const set_vis = this.get("_set_visibility");
     const vis_val = if (vis == .int) vis.int else 0;
     const set_vis_val = if (set_vis == .int) set_vis.int else vis_val;
-    return .{ .bool = set_vis_val == 2 and vis_val != 2 };
+    return NativeResult.scalar(.{ .bool = set_vis_val == 2 and vis_val != 2 });
 }
 
-fn rpropIsProtectedSet(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropIsProtectedSet(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const vis = this.get("_visibility");
     const set_vis = this.get("_set_visibility");
     const has_set_vis = this.get("_has_set_visibility");
@@ -3715,17 +3715,17 @@ fn rpropIsProtectedSet(ctx: *NativeContext, _: []const Value) RuntimeError!Value
     const vis_val = if (vis == .int) vis.int else 0;
     const set_vis_val = if (set_vis == .int) set_vis.int else vis_val;
 
-    return .{
+    return NativeResult.scalar(.{
         .bool = (set_vis_val == 1 and vis_val == 0) or
             (is_ro and vis_val == 0 and !has_explicit_set),
-    };
+    });
 }
-fn rpropIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
 
     const final_v = this.get("_is_final");
     const is_explicit_final = final_v == .bool and final_v.bool;
-    if (is_explicit_final) return .{ .bool = true };
+    if (is_explicit_final) return NativeResult.scalar(.{ .bool = true });
 
     const vis = this.get("_visibility");
     const set_vis = this.get("_set_visibility");
@@ -3739,100 +3739,101 @@ fn rpropIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const implicit_private_set_final =
         has_explicit_set and set_vis_val == 2 and vis_val != 2;
 
-    return .{ .bool = implicit_private_set_final };
+    return NativeResult.scalar(.{ .bool = implicit_private_set_final });
 }
 
-fn rpropIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rpropIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     for ([_][]const u8{ "get", "set" }) |kind| {
         if (lookupPropertyHook(ctx, kind)) |hook| {
-            if (hook.info.is_abstract) return .{ .bool = true };
+            if (hook.info.is_abstract) return NativeResult.scalar(.{ .bool = true });
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rpropGetDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpropGetDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const has_default = this.get("_has_default");
     if (has_default != .bool or !has_default.bool) return throwReflection(ctx, "Property does not have a default value");
-    return retainReturned(this.get("_default_value"));
+    return NativeResult.share(this.get("_default_value"));
 }
 
-fn rpropHasDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropHasDefaultValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const has_default = this.get("_has_default");
-    return .{ .bool = has_default == .bool and has_default.bool };
+    return NativeResult.scalar(.{ .bool = has_default == .bool and has_default.bool });
 }
 
-fn rpropIsInitialized(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
+fn rpropIsInitialized(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
     if (args.len > 0 and args[0] == .object) {
         const dc = this.get("_declaring_class");
         const scope = if (dc == .string) dc.string.bytes() else args[0].object.class_name;
         try ctx.vm.triggerLazyProperty(args[0].object, prop_name, scope);
         const vr = ctx.vm.findPropertyVisibility(scope, prop_name);
-        return .{ .bool = !args[0].object.isUnset(prop_name) and (args[0].object.getForScope(prop_name, scope) != .null or vr.type_str.len == 0 or (findPropertyDef(ctx.vm, scope, prop_name) orelse return .{ .bool = false }).prop.has_default) };
+        return NativeResult.scalar(.{ .bool = !args[0].object.isUnset(prop_name) and (args[0].object.getForScope(prop_name, scope) != .null or vr.type_str.len == 0 or (findPropertyDef(ctx.vm, scope, prop_name) orelse return NativeResult.scalar(.{ .bool = false })).prop.has_default) });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn rpropGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
+fn rpropGetDeclaringClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.null);
 
     const obj = try ctx.createObject("ReflectionClass");
     try obj.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(declaring) });
     try obj.set(ctx.allocator, "_is_interface", .{ .bool = ctx.vm.interfaces.contains(declaring) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn rpropIsDefault(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn rpropIsDefault(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn rpropIsReadOnly(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropIsReadOnly(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const v = this.get("_is_readonly");
-    return .{ .bool = v == .bool and v.bool };
+    return NativeResult.scalar(.{ .bool = v == .bool and v.bool });
 }
 
-fn rpropIsStatic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropIsStatic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const v = this.get("_is_static");
-    return .{ .bool = v == .bool and v.bool };
+    return NativeResult.scalar(.{ .bool = v == .bool and v.bool });
 }
 
-fn rpropIsPromoted(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn rpropIsPromoted(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // a property is promoted iff it appears as a constructor parameter that
     // had a visibility modifier (zphp tracks promotion on the constructor's
     // params; detect it by matching the property name against the ctor's
     // param list)
-    const this = getThis(ctx) orelse return .{ .bool = false };
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const class_name = if (this.get("_declaring_class") == .string)
         this.get("_declaring_class").string.bytes()
     else if (this.get("class") == .string)
         this.get("class").string.bytes()
     else
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     const prop_name_v = this.get("name");
-    if (prop_name_v != .string) return .{ .bool = false };
+    if (prop_name_v != .string) return NativeResult.scalar(.{ .bool = false });
     const prop_name = prop_name_v.string.bytes();
 
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
     for (cls.properties.items) |prop| {
-        if (std.mem.eql(u8, prop.name, prop_name) and prop.is_promoted) return .{ .bool = true };
+        if (std.mem.eql(u8, prop.name, prop_name) and prop.is_promoted) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rpropHasType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const type_value = try rpropGetType(ctx, &.{});
-    return .{ .bool = type_value != .null };
+fn rpropHasType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const type_value = (try rpropGetType(ctx, &.{})).value;
+    if (type_value == .string) type_value.string.release();
+    return NativeResult.scalar(.{ .bool = type_value != .null });
 }
 
-fn rpropGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
+fn rpropGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const vis = this.get("_visibility");
     const vis_val = if (vis == .int) vis.int else 0;
 
@@ -3870,83 +3871,83 @@ fn rpropGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         (is_ro and vis_val == 0 and !has_explicit_set);
     if (is_asym_prot_set) mods |= 2048;
 
-    return .{ .int = mods };
+    return NativeResult.scalar(.{ .int = mods });
 }
 
-fn rpropGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .array = try ctx.createArray() };
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .array = try ctx.createArray() };
-    const cls = ctx.vm.classes.get(declaring) orelse return .{ .array = try ctx.createArray() };
-    const attrs = cls.property_attributes.get(prop_name) orelse return .{ .array = try ctx.createArray() };
+fn rpropGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const prop_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const cls = ctx.vm.classes.get(declaring) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const attrs = cls.property_attributes.get(prop_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const filter: ?[]const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else null;
     const flags: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else 0;
     return buildAttributeArrayWithFlags(ctx, attrs, filter, 8, flags);
 }
 
-fn rpropGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpropGetDocComment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const dc_v = this.get("_declaring_class");
-    if (dc_v != .string) return .{ .bool = false };
+    if (dc_v != .string) return NativeResult.scalar(.{ .bool = false });
     const prop_name_v = this.get("name");
-    if (prop_name_v != .string) return .{ .bool = false };
+    if (prop_name_v != .string) return NativeResult.scalar(.{ .bool = false });
     var current: ?[]const u8 = dc_v.string.bytes();
     while (current) |cn| {
         if (ctx.vm.classes.get(cn)) |cls| {
             for (cls.properties.items) |p| {
                 if (std.mem.eql(u8, p.name, prop_name_v.string.bytes())) {
-                    if (p.doc_comment.len == 0) return .{ .bool = false };
-                    return .{ .string = Value.String.borrowed(p.doc_comment) };
+                    if (p.doc_comment.len == 0) return NativeResult.scalar(.{ .bool = false });
+                    return try NativeResult.copyString(ctx.allocator, p.doc_comment);
                 }
             }
             current = cls.parent;
         } else break;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rpropIsVirtual(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpropIsVirtual(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const dc = this.get("_declaring_class");
     const name = this.get("name");
     if (dc == .string and name == .string) {
         if (ctx.vm.classes.get(dc.string.bytes())) |cls| {
             for (cls.properties.items) |p| {
-                if (std.mem.eql(u8, p.name, name.string.bytes())) return .{ .bool = p.is_virtual };
+                if (std.mem.eql(u8, p.name, name.string.bytes())) return NativeResult.scalar(.{ .bool = p.is_virtual });
             }
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rmInvoke(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rmInvoke(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const guard_count = ctx.vm.prop_hook_guard.items.len;
     defer ctx.vm.prop_hook_guard.shrinkRetainingCapacity(guard_count);
     if (this.get("_hook_property") == .string and args.len > 0 and args[0] == .object) {
         try ctx.vm.prop_hook_guard.append(ctx.allocator, .{ .obj_ptr = @intFromPtr(args[0].object), .prop_name = this.get("_hook_property").string.bytes() });
     }
-    const method_name = methodLookupName(this) orelse return .null;
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.null);
     if (args.len > 0 and args[0] == .object) {
-        return ctx.callMethod(args[0].object, method_name, args[1..]) catch .null;
+        return NativeResult.share(ctx.callMethod(args[0].object, method_name, args[1..]) catch .null);
     }
     // static call: target is null/missing, dispatch by ClassName::methodName
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.null);
     var buf: [256]u8 = undefined;
-    const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .null;
+    const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return NativeResult.scalar(.null);
     const rest = if (args.len >= 1) args[1..] else args[0..];
-    return ctx.vm.callByName(full, rest) catch .null;
+    return NativeResult.share(ctx.vm.callByName(full, rest) catch .null);
 }
 
-fn rmInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rmInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const guard_count = ctx.vm.prop_hook_guard.items.len;
     defer ctx.vm.prop_hook_guard.shrinkRetainingCapacity(guard_count);
     if (this.get("_hook_property") == .string and args.len > 0 and args[0] == .object) {
         try ctx.vm.prop_hook_guard.append(ctx.allocator, .{ .obj_ptr = @intFromPtr(args[0].object), .prop_name = this.get("_hook_property").string.bytes() });
     }
-    const method_name = methodLookupName(this) orelse return .null;
-    if (args.len < 1) return .null;
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const target = args[0];
 
     var call_args: [16]Value = undefined;
@@ -3958,51 +3959,51 @@ fn rmInvokeArgs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
 
     if (target == .object) {
-        return ctx.callMethod(target.object, method_name, call_args[0..count]) catch .null;
+        return NativeResult.share(ctx.callMethod(target.object, method_name, call_args[0..count]) catch .null);
     }
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .null;
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.null);
     var buf: [256]u8 = undefined;
-    const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .null;
-    return ctx.vm.callByName(full, call_args[0..count]) catch .null;
+    const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return NativeResult.scalar(.null);
+    return NativeResult.share(ctx.vm.callByName(full, call_args[0..count]) catch .null);
 }
 
-fn rmGetClosure(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const method_name = methodLookupName(this) orelse return .null;
-    if (args.len < 1 or args[0] != .object) return .null;
+fn rmGetClosure(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
 
     const arr = try ctx.createArray();
     try arr.append(ctx.allocator, args[0]);
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(method_name) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rmIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const method_name = methodLookupName(this) orelse return .{ .bool = false };
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = false };
+fn rmIsAbstract(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.{ .bool = false });
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
 
-    if (ctx.vm.interfaces.contains(declaring)) return .{ .bool = true };
+    if (ctx.vm.interfaces.contains(declaring)) return NativeResult.scalar(.{ .bool = true });
 
     if (ctx.vm.classes.get(declaring)) |cls| {
         if (cls.methods.get(method_name)) |m| {
-            if (m.is_abstract) return .{ .bool = true };
+            if (m.is_abstract) return NativeResult.scalar(.{ .bool = true });
         }
     }
 
     var buf: [256]u8 = undefined;
-    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return .{ .bool = false };
-    if (ctx.vm.functions.get(key) == null and ctx.vm.native_fns.get(key) == null) return .{ .bool = true };
-    return .{ .bool = false };
+    const key = std.fmt.bufPrint(&buf, "{s}::{s}", .{ declaring, method_name }) catch return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.functions.get(key) == null and ctx.vm.native_fns.get(key) == null) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rmIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const method_name = methodLookupName(this) orelse return .{ .bool = false };
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(declaring) orelse return .{ .bool = false };
-    const m = cls.methods.get(method_name) orelse return .{ .bool = false };
-    return .{ .bool = m.is_final };
+fn rmIsFinal(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.{ .bool = false });
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(declaring) orelse return NativeResult.scalar(.{ .bool = false });
+    const m = cls.methods.get(method_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = m.is_final });
 }
 
 fn rmFullName(ctx: *NativeContext) ?[]const u8 {
@@ -4016,29 +4017,29 @@ fn rmFullName(ctx: *NativeContext) ?[]const u8 {
     return owned;
 }
 
-fn rmIsVariadic(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const key = rmFullName(ctx) orelse return .{ .bool = false };
-    const func = ctx.vm.functions.get(key) orelse return .{ .bool = false };
-    return .{ .bool = func.is_variadic };
+fn rmIsVariadic(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const key = rmFullName(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(key) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = func.is_variadic });
 }
 
-fn rmIsGenerator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const key = rmFullName(ctx) orelse return .{ .bool = false };
-    const func = ctx.vm.functions.get(key) orelse return .{ .bool = false };
-    return .{ .bool = func.is_generator };
+fn rmIsGenerator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const key = rmFullName(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const func = ctx.vm.functions.get(key) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = func.is_generator });
 }
 
-fn rmGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
-    const method_name = methodLookupName(this) orelse return .{ .int = 0 };
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .int = 0 };
-    const cls = ctx.vm.classes.get(declaring) orelse return .{ .int = 0 };
-    const info = cls.methods.get(method_name) orelse return .{ .int = 0 };
-    return .{ .int = if (this.get("_hook_method") == .string) (methodModifiers(info) & ~@as(i64, 7)) | 1 else methodModifiers(info) };
+fn rmGetModifiers(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.{ .int = 0 });
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.{ .int = 0 });
+    const cls = ctx.vm.classes.get(declaring) orelse return NativeResult.scalar(.{ .int = 0 });
+    const info = cls.methods.get(method_name) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = if (this.get("_hook_method") == .string) (methodModifiers(info) & ~@as(i64, 7)) | 1 else methodModifiers(info) });
 }
 
-fn reflectionGetModifierNames(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .array = try ctx.createArray() };
+fn reflectionGetModifierNames(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const m = args[0].int;
     const arr = try ctx.createArray();
     if ((m & 16) != 0) try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("static") });
@@ -4047,72 +4048,72 @@ fn reflectionGetModifierNames(ctx: *NativeContext, args: []const Value) RuntimeE
     if ((m & 4) != 0) try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("private") });
     if ((m & 2) != 0) try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("protected") });
     if ((m & 1) != 0) try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("public") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rmGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const method_name = methodLookupName(this) orelse return .{ .array = try ctx.createArray() };
-    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return .{ .array = try ctx.createArray() };
-    const cls = ctx.vm.classes.get(declaring) orelse return .{ .array = try ctx.createArray() };
-    const attrs = cls.method_attributes.get(method_name) orelse return .{ .array = try ctx.createArray() };
+fn rmGetAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const method_name = methodLookupName(this) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const cls = ctx.vm.classes.get(declaring) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const attrs = cls.method_attributes.get(method_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const filter: ?[]const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else null;
     const flags: i64 = if (args.len >= 2 and args[1] == .int) args[1].int else 0;
     return buildAttributeArrayWithFlags(ctx, attrs, filter, 4, flags);
 }
 
-fn rpIsPromoted(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn rpIsPromoted(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     // promoted iff declaring method is __construct AND the class has a
     // matching property that is itself flagged as promoted. previously we
     // returned true whenever any same-named property existed, which mis-
     // classified plain '?string $name = null' params as promoted whenever
     // the class happened to declare a separate '$name' property
     const method_v = this.get("_method_name");
-    if (method_v != .string or !std.mem.eql(u8, method_v.string.bytes(), "__construct")) return .{ .bool = false };
+    if (method_v != .string or !std.mem.eql(u8, method_v.string.bytes(), "__construct")) return NativeResult.scalar(.{ .bool = false });
     const class_v = this.get("_declaring_class");
-    if (class_v != .string) return .{ .bool = false };
+    if (class_v != .string) return NativeResult.scalar(.{ .bool = false });
     const name_v = this.get("name");
-    if (name_v != .string) return .{ .bool = false };
-    const cls = ctx.vm.classes.getPtr(class_v.string.bytes()) orelse return .{ .bool = false };
+    if (name_v != .string) return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.getPtr(class_v.string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
     for (cls.properties.items) |prop| {
-        if (std.mem.eql(u8, prop.name, name_v.string.bytes())) return .{ .bool = prop.is_promoted };
+        if (std.mem.eql(u8, prop.name, name_v.string.bytes())) return NativeResult.scalar(.{ .bool = prop.is_promoted });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn rpGetClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn rpGetClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const type_val = this.get("_type_name");
-    if (type_val != .string or type_val.string.bytes().len == 0) return .null;
-    if (isBuiltinType(type_val.string.bytes())) return .null;
+    if (type_val != .string or type_val.string.bytes().len == 0) return NativeResult.scalar(.null);
+    if (isBuiltinType(type_val.string.bytes())) return NativeResult.scalar(.null);
 
     if (ctx.vm.classes.contains(type_val.string.bytes()) or ctx.vm.interfaces.contains(type_val.string.bytes())) {
         const obj = try ctx.createObject("ReflectionClass");
         try obj.set(ctx.allocator, "name", type_val);
         try obj.set(ctx.allocator, "_is_interface", .{ .bool = ctx.vm.interfaces.contains(type_val.string.bytes()) });
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn attributeConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn attributeConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const flags = if (args.len > 0 and args[0] == .int) args[0] else Value{ .int = 127 };
     try this.set(ctx.allocator, "flags", flags);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn raGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn raGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn raGetArguments(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
+fn raGetArguments(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const args = this.get("_arguments");
-    if (args == .array) return args;
-    return .{ .array = try ctx.createArray() };
+    if (args == .array) return NativeResult.share(args);
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
 fn targetName(t: i64) []const u8 {
@@ -4147,10 +4148,10 @@ fn getAttributeFlags(vm: *VM, class_name: []const u8) i64 {
     return 127;
 }
 
-fn raNewInstance(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn raNewInstance(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const name_val = this.get("name");
-    if (name_val != .string) return .null;
+    if (name_val != .string) return NativeResult.scalar(.null);
     const attr_name = name_val.string.bytes();
 
     if (!ctx.vm.classes.contains(attr_name)) {
@@ -4212,7 +4213,7 @@ fn raNewInstance(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     // to set up lazy default-group handling)
     if (args_val != .array or args_val.array.entries.items.len == 0) {
         _ = ctx.callMethod(obj, "__construct", &.{}) catch {};
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     if (args_val == .array) {
         const arr = args_val.array;
@@ -4265,22 +4266,22 @@ fn raNewInstance(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             if (count > 0) _ = try ctx.callMethod(obj, "__construct", call_args[0..count]);
         }
     }
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn raGetTarget(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .int = 0 };
+fn raGetTarget(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const target = this.get("_target");
-    return if (target == .int) target else .{ .int = 0 };
+    return if (target == .int) NativeResult.share(target) else NativeResult.scalar(.{ .int = 0 });
 }
 
-fn raIsRepeated(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn raIsRepeated(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const repeated = this.get("_is_repeated");
-    return if (repeated == .bool) repeated else .{ .bool = false };
+    return if (repeated == .bool) NativeResult.share(repeated) else NativeResult.scalar(.{ .bool = false });
 }
 
-fn reConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn reConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1) return throwReflection(ctx, "ReflectionEnum::__construct() expects an enum name");
     const raw = if (args[0] == .string)
         args[0].string.bytes()
@@ -4289,7 +4290,7 @@ fn reConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     else
         return throwReflection(ctx, "ReflectionEnum::__construct() expects an enum name or object");
     const class_name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
-    const this = getThis(ctx) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     const cls = ctx.vm.classes.get(class_name) orelse {
         const msg = std.fmt.allocPrint(ctx.allocator, "Class \"{s}\" does not exist", .{class_name}) catch return throwReflection(ctx, "Class does not exist");
@@ -4306,64 +4307,64 @@ fn reConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try this.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(stable_name) });
     try this.set(ctx.allocator, "_is_interface", .{ .bool = false });
     try this.set(ctx.allocator, "_is_trait", .{ .bool = false });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn reIsBacked(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
-    return .{ .bool = cls.backed_type != .none };
+fn reIsBacked(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = cls.backed_type != .none });
 }
 
-fn reGetBackingType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    const cls = ctx.vm.classes.get(class_name) orelse return .null;
+fn reGetBackingType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.null);
     const type_name: []const u8 = switch (cls.backed_type) {
-        .none => return .null,
+        .none => return NativeResult.scalar(.null),
         .int_type => "int",
         .string_type => "string",
     };
     const obj = try createNamedTypeObj(ctx, type_name, false);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn reGetCases(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .array = try ctx.createArray() };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .array = try ctx.createArray() };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .array = try ctx.createArray() };
+fn reGetCases(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const arr = try ctx.createArray();
     for (cls.case_order.items) |case_name| {
         const case_obj = try buildEnumCase(ctx, class_name, case_name, cls.backed_type != .none);
         try arr.append(ctx.allocator, .{ .object = case_obj });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn reGetCase(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn reGetCase(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1 or args[0] != .string) return throwReflection(ctx, "ReflectionEnum::getCase() expects a name");
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    const cls = ctx.vm.classes.get(class_name) orelse return .null;
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.null);
     if (!cls.constant_names.contains(args[0].string.bytes())) {
         const msg = std.fmt.allocPrint(ctx.allocator, "Case {s}::{s} does not exist", .{ class_name, args[0].string.bytes() }) catch return throwReflection(ctx, "Case not found");
         try ctx.strings.append(ctx.allocator, msg);
         return throwReflection(ctx, msg);
     }
     const obj = try buildEnumCase(ctx, class_name, args[0].string.bytes(), cls.backed_type != .none);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn reHasCase(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .{ .bool = false };
-    const cls = ctx.vm.classes.get(class_name) orelse return .{ .bool = false };
+fn reHasCase(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
     for (cls.case_order.items) |case_name| {
-        if (std.mem.eql(u8, case_name, args[0].string.bytes())) return .{ .bool = true };
+        if (std.mem.eql(u8, case_name, args[0].string.bytes())) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 fn buildEnumCase(ctx: *NativeContext, class_name: []const u8, case_name: []const u8, is_backed: bool) !*PhpObject {
@@ -4374,48 +4375,48 @@ fn buildEnumCase(ctx: *NativeContext, class_name: []const u8, case_name: []const
     return obj;
 }
 
-fn reucConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    if (args.len < 2) return .null;
+fn reucConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.scalar(.null);
     const class_name: []const u8 = switch (args[0]) {
         .string => |s| s.bytes(),
         .object => |o| o.class_name,
-        else => return .null,
+        else => return NativeResult.scalar(.null),
     };
-    if (args[1] != .string) return .null;
+    if (args[1] != .string) return NativeResult.scalar(.null);
     try this.set(ctx.allocator, "class", .{ .string = Value.String.borrowed(class_name) });
     try this.set(ctx.allocator, "name", .{ .string = args[1].string });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn reucGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("name"));
+fn reucGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
 }
 
-fn reucGetValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .null;
-    const case_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    const cls = ctx.vm.classes.get(class_name) orelse return .null;
-    return cls.static_props.get(case_name) orelse .null;
+fn reucGetValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.null);
+    const case_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(cls.static_props.get(case_name) orelse .null);
 }
 
-fn rebcGetBackingValue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return .null;
-    const case_name = if (this.get("name") == .string) this.get("name").string.bytes() else return .null;
-    const cls = ctx.vm.classes.get(class_name) orelse return .null;
-    const case_obj_v = cls.static_props.get(case_name) orelse return .null;
-    if (case_obj_v != .object) return .null;
-    return case_obj_v.object.get("value");
+fn rebcGetBackingValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.null);
+    const case_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.null);
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.null);
+    const case_obj_v = cls.static_props.get(case_name) orelse return NativeResult.scalar(.null);
+    if (case_obj_v != .object) return NativeResult.scalar(.null);
+    return NativeResult.share(case_obj_v.object.get("value"));
 }
 
-fn rgConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rgConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1 or args[0] != .generator) return throwReflection(ctx, "ReflectionGenerator::__construct expects a Generator");
-    const obj = getThis(ctx) orelse return .null;
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__gen", .{ .int = @intCast(@intFromPtr(args[0].generator)) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn getGenPtr(obj: *PhpObject) ?*@import("../runtime/value.zig").Generator {
@@ -4424,54 +4425,54 @@ fn getGenPtr(obj: *PhpObject) ?*@import("../runtime/value.zig").Generator {
     return @ptrFromInt(@as(usize, @intCast(v.int)));
 }
 
-fn rgGetExecutingLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const gen = getGenPtr(obj) orelse return .null;
+fn rgGetExecutingLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = getGenPtr(obj) orelse return NativeResult.scalar(.null);
     const chunk = &gen.func.chunk;
     const ip = if (gen.ip > 0) gen.ip - 1 else 0;
     if (chunk.getSourceLocation(ip, ctx.vm.source)) |loc| {
-        return .{ .int = @intCast(loc.line) };
+        return NativeResult.scalar(.{ .int = @intCast(loc.line) });
     }
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn rgGetExecutingFile(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const gen = getGenPtr(obj) orelse return .null;
+fn rgGetExecutingFile(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = getGenPtr(obj) orelse return NativeResult.scalar(.null);
     _ = gen;
     // zphp stores a single source per VM; surface that as the executing file
-    return .{ .string = Value.String.borrowed(try ctx.createString(ctx.vm.file_path)) };
+    return try NativeResult.copyString(ctx.allocator, ctx.vm.file_path);
 }
 
-fn rgGetFunction(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const gen = getGenPtr(obj) orelse return .null;
+fn rgGetFunction(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = getGenPtr(obj) orelse return NativeResult.scalar(.null);
     const rf = try ctx.createObject("ReflectionFunction");
     try rf.set(ctx.allocator, "name", .{ .string = Value.String.borrowed(try ctx.createString(gen.func.name)) });
-    return .{ .object = rf };
+    return NativeResult.borrowed(.{ .object = rf });
 }
 
-fn rgGetThis(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const gen = getGenPtr(obj) orelse return .null;
-    if (gen.vars.get("$this")) |this_v| return this_v;
-    return .null;
+fn rgGetThis(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = getGenPtr(obj) orelse return NativeResult.scalar(.null);
+    if (gen.vars.get("$this")) |this_v| return NativeResult.share(this_v);
+    return NativeResult.scalar(.null);
 }
 
-fn rgGetExecutingGenerator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    var gen = getGenPtr(obj) orelse return .null;
+fn rgGetExecutingGenerator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    var gen = getGenPtr(obj) orelse return NativeResult.scalar(.null);
     // walk yield-from delegates to the innermost actually-executing generator
     while (gen.delegate) |del| switch (del) {
         .gen => |inner| gen = inner,
         else => break,
     };
-    return .{ .generator = gen };
+    return NativeResult.borrowed(.{ .generator = gen });
 }
 
-fn rgGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const gen = getGenPtr(obj) orelse return .null;
+fn rgGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = getGenPtr(obj) orelse return NativeResult.scalar(.null);
     const arr = try ctx.createArray();
     const frame = try ctx.createArray();
     if (gen.func.chunk.getSourceLocation(if (gen.ip > 0) gen.ip - 1 else 0, ctx.vm.source)) |loc| {
@@ -4480,14 +4481,14 @@ fn rgGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try frame.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString("file")) }, .{ .string = Value.String.borrowed(try ctx.createString(ctx.vm.file_path)) });
     try frame.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString("function")) }, .{ .string = Value.String.borrowed(try ctx.createString(gen.func.name)) });
     try arr.append(ctx.allocator, .{ .array = frame });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn rfibConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rfibConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1 or args[0] != .fiber) return throwReflection(ctx, "ReflectionFiber::__construct expects a Fiber");
-    const obj = getThis(ctx) orelse return .null;
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__fib", .{ .int = @intCast(@intFromPtr(args[0].fiber)) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn getFibPtr(obj: *PhpObject) ?*@import("../runtime/value.zig").Fiber {
@@ -4496,40 +4497,39 @@ fn getFibPtr(obj: *PhpObject) ?*@import("../runtime/value.zig").Fiber {
     return @ptrFromInt(@as(usize, @intCast(v.int)));
 }
 
-fn rfibGetExecutingLine(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const fib = getFibPtr(obj) orelse return .null;
-    if (fib.saved_frames.items.len == 0) return .{ .int = 0 };
+fn rfibGetExecutingLine(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const fib = getFibPtr(obj) orelse return NativeResult.scalar(.null);
+    if (fib.saved_frames.items.len == 0) return NativeResult.scalar(.{ .int = 0 });
     const top = &fib.saved_frames.items[fib.saved_frames.items.len - 1];
     const ip = if (top.ip > 0) top.ip - 1 else 0;
     if (top.chunk.getSourceLocation(ip, ctx.vm.source)) |loc| {
-        return .{ .int = @intCast(loc.line) };
+        return NativeResult.scalar(.{ .int = @intCast(loc.line) });
     }
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn rfibGetExecutingFile(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    _ = getFibPtr(obj) orelse return .null;
-    return .{ .string = Value.String.borrowed(try ctx.createString(ctx.vm.file_path)) };
+fn rfibGetExecutingFile(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    _ = getFibPtr(obj) orelse return NativeResult.scalar(.null);
+    return try NativeResult.copyString(ctx.allocator, ctx.vm.file_path);
 }
 
-fn rfibGetCallable(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const fib = getFibPtr(obj) orelse return .null;
-    ctx.returnShared(fib.callable);
-    return fib.callable;
+fn rfibGetCallable(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const fib = getFibPtr(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(fib.callable);
 }
 
-fn rfibGetFiber(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const fib = getFibPtr(obj) orelse return .null;
-    return .{ .fiber = fib };
+fn rfibGetFiber(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const fib = getFibPtr(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .fiber = fib });
 }
 
-fn rfibGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const fib = getFibPtr(obj) orelse return .null;
+fn rfibGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const fib = getFibPtr(obj) orelse return NativeResult.scalar(.null);
     const arr = try ctx.createArray();
     var i: usize = fib.saved_frames.items.len;
     while (i > 0) {
@@ -4543,5 +4543,5 @@ fn rfibGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try frame.set(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString("file")) }, .{ .string = Value.String.borrowed(try ctx.createString(ctx.vm.file_path)) });
         try arr.append(ctx.allocator, .{ .array = frame });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }

--- a/src/stdlib/registry.zig
+++ b/src/stdlib/registry.zig
@@ -3,7 +3,8 @@ const Value = @import("../runtime/value.zig").Value;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
-const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!Value;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
+const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!NativeResult;
 
 pub fn register(map: *std.StringHashMapUnmanaged(NativeFn), allocator: std.mem.Allocator) !void {
     const modules = .{
@@ -41,7 +42,14 @@ pub fn register(map: *std.StringHashMapUnmanaged(NativeFn), allocator: std.mem.A
     };
     @setEvalBranchQuota(10000);
     inline for (modules) |entries| {
-        inline for (entries) |f| try map.put(allocator, f[0], f[1]);
+        inline for (entries) |f| {
+            const info = @typeInfo(@TypeOf(f[1]));
+            const fn_info = if (info == .pointer) @typeInfo(info.pointer.child).@"fn" else info.@"fn";
+            if (fn_info.return_type.? != RuntimeError!NativeResult) {
+                @compileError("native function must return RuntimeError!NativeResult: " ++ f[0]);
+            }
+            try map.put(allocator, f[0], f[1]);
+        }
     }
 }
 

--- a/src/stdlib/serialize.zig
+++ b/src/stdlib/serialize.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -145,8 +146,8 @@ fn formatPhpFloat(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, f: f64
     }
 }
 
-fn native_serialize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_serialize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) {
         try ctx.vm.setPendingException("Exception", "Serialization of 'Closure' is not allowed");
         return error.RuntimeError;
@@ -168,17 +169,14 @@ fn native_serialize(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     return try serializeToString(ctx, args[0]);
 }
 
-// Public entrypoint for other stdlib modules that need to serialize PHP values
-// (e.g. session storage). Owns allocation via ctx.strings.
-pub fn serializeToString(ctx: *NativeContext, val: Value) RuntimeError!Value {
+pub fn serializeToString(ctx: *NativeContext, val: Value) RuntimeError!NativeResult {
     var buf = std.ArrayListUnmanaged(u8){};
     errdefer buf.deinit(ctx.allocator);
     var sctx = SerCtx{};
     defer sctx.deinit(ctx.allocator);
     try serializeValue(ctx, &buf, &sctx, val);
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 pub fn unserializeFromString(ctx: *NativeContext, s: []const u8) ?Value {
@@ -515,11 +513,11 @@ fn serializeValue(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), sctx: *
     }
 }
 
-fn native_unserialize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return Value{ .bool = false };
+fn native_unserialize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     // PHP returns false silently for empty input - no warning
-    if (s.len == 0) return Value{ .bool = false };
+    if (s.len == 0) return NativeResult.scalar(.{ .bool = false });
     var uctx = UnserCtx{};
     defer uctx.deinit(ctx.allocator);
     var name_storage: std.ArrayListUnmanaged([]const u8) = .{};
@@ -546,16 +544,16 @@ fn native_unserialize(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         // message that names the option + ini setting; generic parse errors
         // get 'Error at offset N of M bytes'
         if (uctx.depth_exceeded) {
-            const msg = std.fmt.allocPrint(ctx.allocator, "unserialize(): Maximum depth of {d} exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting", .{uctx.max_depth}) catch return Value{ .bool = false };
+            const msg = std.fmt.allocPrint(ctx.allocator, "unserialize(): Maximum depth of {d} exceeded. The depth limit can be changed using the max_depth unserialize() option or the unserialize_max_depth ini setting", .{uctx.max_depth}) catch return NativeResult.scalar(.{ .bool = false });
             ctx.vm.strings.append(ctx.allocator, msg) catch {};
             ctx.vm.emitWarning(msg);
         }
-        const msg2 = std.fmt.allocPrint(ctx.allocator, "unserialize(): Error at offset {d} of {d} bytes", .{ uctx.err_pos, s.len }) catch return Value{ .bool = false };
+        const msg2 = std.fmt.allocPrint(ctx.allocator, "unserialize(): Error at offset {d} of {d} bytes", .{ uctx.err_pos, s.len }) catch return NativeResult.scalar(.{ .bool = false });
         ctx.vm.strings.append(ctx.allocator, msg2) catch {};
         ctx.vm.emitWarning(msg2);
-        return Value{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
-    return result.value;
+    return NativeResult.share(result.value);
 }
 
 const ParseResult = struct {
@@ -879,7 +877,7 @@ fn parseString(s: []const u8, pos: usize) !StringResult {
 
 // SPL's legacy Serializable stream has one reference table spanning flags,
 // storage, and members (the separators themselves consume no reference IDs).
-pub fn serializeSplArray(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
+pub fn serializeSplArray(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
     var buf: std.ArrayListUnmanaged(u8) = .{};
     errdefer buf.deinit(ctx.allocator);
     var refs: SerCtx = .{};
@@ -895,8 +893,7 @@ pub fn serializeSplArray(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Valu
     const members = try splMembers(ctx, obj);
     try serializeValue(ctx, &buf, &refs, .{ .array = members });
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 fn splInternal(name: []const u8) bool {
@@ -929,8 +926,8 @@ fn splMembers(ctx: *NativeContext, obj: *PhpObject) !*PhpArray {
     return members;
 }
 
-pub fn unserializeSplArray(ctx: *NativeContext, obj: *PhpObject, s: []const u8) RuntimeError!Value {
-    if (s.len == 0) return .null; // PHP treats an empty payload as a no-op.
+pub fn unserializeSplArray(ctx: *NativeContext, obj: *PhpObject, s: []const u8) RuntimeError!NativeResult {
+    if (s.len == 0) return NativeResult.scalar(.null); // PHP treats an empty payload as a no-op.
     var refs: UnserCtx = .{};
     defer refs.deinit(ctx.allocator);
     var pos: usize = 0;
@@ -942,7 +939,7 @@ pub fn unserializeSplArray(ctx: *NativeContext, obj: *PhpObject, s: []const u8) 
         try ctx.vm.setPendingException("UnexpectedValueException", msg);
         return error.RuntimeError;
     };
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn parseSplArray(ctx: *NativeContext, obj: *PhpObject, refs: *UnserCtx, s: []const u8, pos: *usize) !void {
@@ -978,7 +975,7 @@ fn parseSplArray(ctx: *NativeContext, obj: *PhpObject, refs: *UnserCtx, s: []con
     // Trailing bytes are intentionally ignored, as in PHP 8.5.
 }
 
-pub fn splArrayState(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
+pub fn splArrayState(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
     const state = try ctx.createArray();
     try state.append(ctx.allocator, obj.get("__flags"));
     const data = obj.get("__data");
@@ -986,10 +983,10 @@ pub fn splArrayState(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
     try state.append(ctx.allocator, if (data == .array) .{ .array = try splStorageSnapshot(ctx, data.array) } else data);
     try state.append(ctx.allocator, .{ .array = try splMembers(ctx, obj) });
     try state.append(ctx.allocator, obj.get("__iter_class"));
-    return .{ .array = state };
+    return NativeResult.borrowed(.{ .array = state });
 }
 
-pub fn restoreSplArrayState(ctx: *NativeContext, obj: *PhpObject, state: Value) RuntimeError!Value {
+pub fn restoreSplArrayState(ctx: *NativeContext, obj: *PhpObject, state: Value) RuntimeError!NativeResult {
     if (state != .array) return error.RuntimeError;
     const flags = state.array.get(.{ .int = 0 });
     const storage = state.array.get(.{ .int = 1 });
@@ -1019,7 +1016,7 @@ pub fn restoreSplArrayState(ctx: *NativeContext, obj: *PhpObject, state: Value) 
             if (!splInternal(name)) try obj.set(ctx.allocator, name, entry.value);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // Decode R: aliases into the same owning cells/registry used by VM array

--- a/src/stdlib/session.zig
+++ b/src/stdlib/session.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -35,15 +36,15 @@ pub const entries = .{
 // backend continues to serve $_SESSION). this lets apps that follow the
 // "register a custom handler before starting" pattern run end-to-end without
 // hitting an undefined-function fatal
-fn native_session_set_save_handler(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_session_set_save_handler(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // legacy 6-callable form: session_set_save_handler(open, close, read, write, destroy, gc, ...)
-    if (args.len >= 6 and args[0] != .object) return .{ .bool = true };
+    if (args.len >= 6 and args[0] != .object) return NativeResult.scalar(.{ .bool = true });
     // OO form: session_set_save_handler($handler [, $register_shutdown = true])
     if (args.len >= 1 and args[0] == .object) {
         try setSessionVar(ctx, "__session_handler", args[0]);
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 const default_session_dir = "/tmp";
@@ -67,12 +68,12 @@ fn setSessionVar(ctx: *NativeContext, key: []const u8, val: Value) !void {
 const session_id_alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
 const session_id_len = 26;
 
-fn generateId(ctx: *NativeContext) ![]const u8 {
+fn generateId(ctx: *NativeContext) !Value.String {
     var raw: [session_id_len]u8 = undefined;
     std.crypto.random.bytes(&raw);
     // map each byte into the alphabet; modulo bias is negligible for this use
     for (&raw) |*b| b.* = session_id_alphabet[b.* % session_id_alphabet.len];
-    return ctx.createString(&raw);
+    return Value.String.create(ctx.allocator, &raw);
 }
 
 // PHP restricts session IDs to [a-zA-Z0-9,-] by default. We reject anything else
@@ -116,7 +117,8 @@ fn saveSessionData(ctx: *NativeContext, sid: []const u8) !void {
     const session_val = ctx.vm.request_vars.get("$_SESSION") orelse return;
     if (session_val != .array) return;
 
-    const serialized = try serialize_mod.serializeToString(ctx, session_val);
+    const serialized = (try serialize_mod.serializeToString(ctx, session_val)).value;
+    defer if (serialized == .string) serialized.string.release();
     if (serialized != .string) return;
 
     const path = try sessionPath(ctx, sid);
@@ -135,18 +137,18 @@ fn getCookieSessionId(ctx: *NativeContext) ?[]const u8 {
 fn setSessionCookie(ctx: *NativeContext, sid: []const u8) !void {
     var buf: [256]u8 = undefined;
     const cookie = std.fmt.bufPrint(&buf, "Set-Cookie: {s}={s}; Path=/; HttpOnly; SameSite=Lax", .{ default_name, sid }) catch return;
-    const hdr = try ctx.createString(cookie);
-
-    try @import("http.zig").appendResponseHeader(ctx, hdr);
+    try @import("http.zig").appendResponseHeader(ctx, cookie);
 }
 
-fn native_session_start(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_session_start(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // already active? (do not short-circuit on __session_id alone so that
     // a session reopened after session_write_close correctly re-loads data)
     const active = getSessionVar(ctx, "__session_active");
-    if (active != null and active.? == .bool and active.?.bool) return .{ .bool = true };
+    if (active != null and active.? == .bool and active.?.bool) return NativeResult.scalar(.{ .bool = true });
 
     var sid: []const u8 = undefined;
+    var generated: ?Value.String = null;
+    defer if (generated) |value| value.release();
     var is_new = false;
 
     // prefer an existing id cached on this request (e.g. from a prior
@@ -158,26 +160,33 @@ fn native_session_start(ctx: *NativeContext, _: []const Value) RuntimeError!Valu
             if (isValidSessionId(cookie_sid)) {
                 sid = cookie_sid;
             } else {
-                sid = try generateId(ctx);
+                generated = try generateId(ctx);
+                sid = generated.?.bytes();
                 is_new = true;
             }
         } else {
-            sid = try generateId(ctx);
+            generated = try generateId(ctx);
+            sid = generated.?.bytes();
             is_new = true;
         }
     } else if (getCookieSessionId(ctx)) |cookie_sid| {
         if (isValidSessionId(cookie_sid)) {
             sid = cookie_sid;
         } else {
-            sid = try generateId(ctx);
+            generated = try generateId(ctx);
+            sid = generated.?.bytes();
             is_new = true;
         }
     } else {
-        sid = try generateId(ctx);
+        generated = try generateId(ctx);
+        sid = generated.?.bytes();
         is_new = true;
     }
 
-    try setSessionVar(ctx, "__session_id", .{ .string = Value.String.borrowed(sid) });
+    const stored_sid = try Value.String.create(ctx.allocator, sid);
+    defer stored_sid.release();
+    sid = stored_sid.bytes();
+    try setSessionVar(ctx, "__session_id", .{ .string = stored_sid });
     try setSessionVar(ctx, "__session_active", .{ .bool = true });
 
     const arr = try loadSessionData(ctx, sid);
@@ -185,41 +194,44 @@ fn native_session_start(ctx: *NativeContext, _: []const Value) RuntimeError!Valu
 
     if (is_new) try setSessionCookie(ctx, sid);
 
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_session_id(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_session_id(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len >= 1 and args[0] == .string) {
         try setSessionVar(ctx, "__session_id", args[0]);
-        return .{ .string = Value.String.borrowed(args[0].string.bytes()) };
+        return NativeResult.share(args[0]);
     }
-    const v = getSessionVar(ctx, "__session_id") orelse return .{ .string = Value.String.borrowed("") };
-    if (v == .string) return v;
-    return .{ .string = Value.String.borrowed("") };
+    const v = getSessionVar(ctx, "__session_id") orelse return NativeResult.literal("");
+    if (v == .string) return NativeResult.share(v);
+    return NativeResult.literal("");
 }
 
-fn native_session_destroy(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const sid_val = getSessionVar(ctx, "__session_id") orelse return .{ .bool = false };
-    if (sid_val != .string) return .{ .bool = false };
+fn native_session_destroy(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const sid_val = getSessionVar(ctx, "__session_id") orelse return NativeResult.scalar(.{ .bool = false });
+    if (sid_val != .string) return NativeResult.scalar(.{ .bool = false });
 
     const path = try sessionPath(ctx, sid_val.string.bytes());
     defer ctx.allocator.free(path);
     std.fs.cwd().deleteFile(path) catch {};
 
     try setSessionVar(ctx, "__session_active", .{ .bool = false });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_session_regenerate_id(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const old_sid_val = getSessionVar(ctx, "__session_id") orelse return .{ .bool = false };
-    if (old_sid_val != .string) return .{ .bool = false };
+fn native_session_regenerate_id(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const old_sid_val = getSessionVar(ctx, "__session_id") orelse return NativeResult.scalar(.{ .bool = false });
+    if (old_sid_val != .string) return NativeResult.scalar(.{ .bool = false });
 
+    old_sid_val.string.retain();
+    defer old_sid_val.string.release();
     const new_sid = try generateId(ctx);
+    defer new_sid.release();
 
     // migrate current $_SESSION contents to the new ID so session data survives
     // regeneration (this is how every PHP framework uses it post-login).
-    try setSessionVar(ctx, "__session_id", .{ .string = Value.String.borrowed(new_sid) });
-    saveSessionData(ctx, new_sid) catch {};
+    try setSessionVar(ctx, "__session_id", .{ .string = new_sid });
+    saveSessionData(ctx, new_sid.bytes()) catch {};
 
     const delete_old = args.len >= 1 and args[0].isTruthy();
     if (delete_old) {
@@ -228,98 +240,97 @@ fn native_session_regenerate_id(ctx: *NativeContext, args: []const Value) Runtim
         std.fs.cwd().deleteFile(path) catch {};
     }
 
-    try setSessionCookie(ctx, new_sid);
-    return .{ .bool = true };
+    try setSessionCookie(ctx, new_sid.bytes());
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_session_name(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed(default_name) };
+fn native_session_name(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal(default_name);
 }
 
-fn native_session_status(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_session_status(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const active = getSessionVar(ctx, "__session_active");
-    if (active != null and active.? == .bool and active.?.bool) return .{ .int = 2 }; // PHP_SESSION_ACTIVE
-    return .{ .int = 1 }; // PHP_SESSION_NONE
+    if (active != null and active.? == .bool and active.?.bool) return NativeResult.scalar(.{ .int = 2 }); // PHP_SESSION_ACTIVE
+    return NativeResult.scalar(.{ .int = 1 }); // PHP_SESSION_NONE
 }
 
-fn native_session_write_close(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const sid_val = getSessionVar(ctx, "__session_id") orelse return .null;
-    if (sid_val != .string) return .null;
+fn native_session_write_close(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const sid_val = getSessionVar(ctx, "__session_id") orelse return NativeResult.scalar(.null);
+    if (sid_val != .string) return NativeResult.scalar(.null);
     const active = getSessionVar(ctx, "__session_active");
-    if (active == null or active.? != .bool or !active.?.bool) return .null;
+    if (active == null or active.? != .bool or !active.?.bool) return NativeResult.scalar(.null);
     try saveSessionData(ctx, sid_val.string.bytes());
     try setSessionVar(ctx, "__session_active", .{ .bool = false });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_session_unset(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_session_unset(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     try ctx.vm.putRequestVar("$_SESSION", .{ .array = arr });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_session_save_path(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const current = currentSessionDir(ctx);
+fn native_session_save_path(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const current = try Value.String.create(ctx.allocator, currentSessionDir(ctx));
+    errdefer current.release();
     if (args.len >= 1 and args[0] == .string and args[0].string.bytes().len > 0) {
         try setSessionVar(ctx, "__session_save_path", args[0]);
     }
-    const dup = try ctx.allocator.dupe(u8, current);
-    try ctx.vm.strings.append(ctx.allocator, dup);
-    return .{ .string = Value.String.borrowed(dup) };
+    return NativeResult.takeString(current);
 }
 
-fn native_session_module_name(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_session_module_name(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     _ = ctx;
     if (args.len >= 1) {
         // accept and ignore - we only implement the 'files' handler
     }
-    return .{ .string = Value.String.borrowed("files") };
+    return NativeResult.literal("files");
 }
 
-fn native_session_cache_limiter(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len >= 1 and args[0] == .string) return args[0];
-    return .{ .string = Value.String.borrowed("nocache") };
+fn native_session_cache_limiter(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len >= 1 and args[0] == .string) return NativeResult.share(args[0]);
+    return NativeResult.literal("nocache");
 }
 
-fn native_session_cache_expire(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len >= 1 and args[0] == .int) return args[0];
-    return .{ .int = 180 };
+fn native_session_cache_expire(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len >= 1 and args[0] == .int) return NativeResult.share(args[0]);
+    return NativeResult.scalar(.{ .int = 180 });
 }
 
-fn native_session_create_id(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_session_create_id(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const sid = try generateId(ctx);
+    defer sid.release();
     if (args.len >= 1 and args[0] == .string and args[0].string.bytes().len > 0) {
-        const combined = try std.mem.concat(ctx.allocator, u8, &.{ args[0].string.bytes(), sid });
-        try ctx.vm.strings.append(ctx.allocator, combined);
-        return .{ .string = Value.String.borrowed(combined) };
+        const combined = try std.mem.concat(ctx.allocator, u8, &.{ args[0].string.bytes(), sid.bytes() });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, combined));
     }
-    return .{ .string = Value.String.borrowed(sid) };
+    return NativeResult.shareString(sid);
 }
 
-fn native_session_gc(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_session_gc(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP returns the number of deleted sessions; without configurable GC, return 0
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_session_abort(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_session_abort(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // discard pending changes by clearing active state without saving
     try setSessionVar(ctx, "__session_active", .{ .bool = false });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_session_reset(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const sid_val = getSessionVar(ctx, "__session_id") orelse return .{ .bool = false };
-    if (sid_val != .string) return .{ .bool = false };
+fn native_session_reset(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const sid_val = getSessionVar(ctx, "__session_id") orelse return NativeResult.scalar(.{ .bool = false });
+    if (sid_val != .string) return NativeResult.scalar(.{ .bool = false });
     const arr = try loadSessionData(ctx, sid_val.string.bytes());
     try ctx.vm.putRequestVar("$_SESSION", .{ .array = arr });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_session_set_cookie_params(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_session_set_cookie_params(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_session_get_cookie_params(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_session_get_cookie_params(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("lifetime") }, .{ .int = 0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("path") }, .{ .string = Value.String.borrowed("/") });
@@ -327,21 +338,21 @@ fn native_session_get_cookie_params(ctx: *NativeContext, _: []const Value) Runti
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("secure") }, .{ .bool = false });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("httponly") }, .{ .bool = true });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("samesite") }, .{ .string = Value.String.borrowed("Lax") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_session_encode(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const session_val = ctx.vm.request_vars.get("$_SESSION") orelse return .{ .string = Value.String.borrowed("") };
-    if (session_val != .array) return .{ .string = Value.String.borrowed("") };
+fn native_session_encode(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const session_val = ctx.vm.request_vars.get("$_SESSION") orelse return NativeResult.literal("");
+    if (session_val != .array) return NativeResult.literal("");
     return try serialize_mod.serializeToString(ctx, session_val);
 }
 
-fn native_session_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const parsed = serialize_mod.unserializeFromString(ctx, args[0].string.bytes()) orelse return .{ .bool = false };
-    if (parsed != .array) return .{ .bool = false };
+fn native_session_decode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const parsed = serialize_mod.unserializeFromString(ctx, args[0].string.bytes()) orelse return NativeResult.scalar(.{ .bool = false });
+    if (parsed != .array) return NativeResult.scalar(.{ .bool = false });
     try ctx.vm.putRequestVar("$_SESSION", parsed);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 // called from serve after PHP execution to persist session

--- a/src/stdlib/simplexml.zig
+++ b/src/stdlib/simplexml.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -263,58 +264,58 @@ fn isSequentialList(arr: *const PhpArray) bool {
 
 // ---------------- top-level functions ----------------
 
-fn sxmlLoadString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn sxmlLoadString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const src = args[0].string.bytes();
     var opts: c_int = 0;
     if (args.len > 2 and args[2] == .int) opts = @intCast(args[2].int);
-    const doc = c.xmlReadMemory(src.ptr, @intCast(src.len), null, null, opts) orelse return .{ .bool = false };
+    const doc = c.xmlReadMemory(src.ptr, @intCast(src.len), null, null, opts) orelse return NativeResult.scalar(.{ .bool = false });
     const root = c.xmlDocGetRootElement(doc) orelse {
         c.xmlFreeDoc(doc);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     const wrapper = try buildRootWrapper(ctx, doc, root);
     try wrapper.set(ctx.allocator, "__owns_doc", .{ .bool = true });
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
-fn sxmlLoadFile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn sxmlLoadFile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const path_z = try dupZ(ctx, args[0].string.bytes());
     var opts: c_int = 0;
     if (args.len > 2 and args[2] == .int) opts = @intCast(args[2].int);
-    const doc = c.xmlReadFile(path_z.ptr, null, opts) orelse return .{ .bool = false };
+    const doc = c.xmlReadFile(path_z.ptr, null, opts) orelse return NativeResult.scalar(.{ .bool = false });
     const root = c.xmlDocGetRootElement(doc) orelse {
         c.xmlFreeDoc(doc);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     const wrapper = try buildRootWrapper(ctx, doc, root);
     try wrapper.set(ctx.allocator, "__owns_doc", .{ .bool = true });
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
-fn sxmlImportDom(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .null;
+fn sxmlImportDom(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
     const dom_obj = args[0].object;
     // DOM objects store xmlNodePtr in "__node" via dom.zig - reuse that
     const node_v = dom_obj.get("__node");
-    if (node_v != .int or node_v.int == 0) return .null;
+    if (node_v != .int or node_v.int == 0) return NativeResult.scalar(.null);
     const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(node_v.int)));
     // for a DOMDocument, descend to root; for any node, use it
     const target: *c.xmlNode = if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE)
-        c.xmlDocGetRootElement(@ptrCast(node)) orelse return .null
+        c.xmlDocGetRootElement(@ptrCast(node)) orelse return NativeResult.scalar(.null)
     else
         node;
-    const doc = target.doc orelse return .null;
+    const doc = target.doc orelse return NativeResult.scalar(.null);
     const wrapper = try buildWrapper(ctx, doc, target);
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
 // ---------------- SimpleXMLElement::__construct ----------------
 
-fn sxmlConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn sxmlConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const src = args[0].string.bytes();
     var opts: c_int = 0;
     if (args.len > 1 and args[1] == .int) opts = @intCast(args[1].int);
@@ -325,42 +326,42 @@ fn sxmlConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const path_z = try dupZ(ctx, src);
         break :blk c.xmlReadFile(path_z.ptr, null, opts);
     } else c.xmlReadMemory(src.ptr, @intCast(src.len), null, null, opts);
-    if (doc == null) return .null;
+    if (doc == null) return NativeResult.scalar(.null);
 
     const root = c.xmlDocGetRootElement(doc) orelse {
         c.xmlFreeDoc(doc);
-        return .null;
+        return NativeResult.scalar(.null);
     };
     try obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(root)) });
     try obj.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
     try obj.set(ctx.allocator, "__owns_doc", .{ .bool = true });
     try obj.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try obj.set(ctx.allocator, "__iter_children", .{ .bool = true });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ---------------- methods ----------------
 
-fn sxmlGetName(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sxmlGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (obj.get("__is_attr") == .bool and obj.get("__is_attr").bool) {
         const an = obj.get("__attr_name");
-        if (an == .string) return an;
+        if (an == .string) return NativeResult.share(an);
     }
-    const node = getNodePtr(obj) orelse return .null;
-    if (node.name == null) return .null;
-    return .{ .string = Value.String.borrowed(try dupString(ctx, node.name[0..cstrLen(node.name)])) };
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
+    if (node.name == null) return NativeResult.scalar(.null);
+    return try NativeResult.copyString(ctx.allocator, node.name[0..cstrLen(node.name)]);
 }
 
-fn sxmlAsXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn sxmlAsXML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
     if (args.len > 0 and args[0] == .string) {
         const path_z = try dupZ(ctx, args[0].string.bytes());
         const written = c.xmlSaveFormatFile(path_z.ptr, doc, 0);
-        return .{ .bool = written >= 0 };
+        return NativeResult.scalar(.{ .bool = written >= 0 });
     }
 
     // is this the root element? PHP returns full doc XML; otherwise just node fragment
@@ -369,33 +370,33 @@ fn sxmlAsXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         var out: [*c]u8 = null;
         var size: c_int = 0;
         c.xmlDocDumpFormatMemoryEnc(doc, &out, &size, doc.*.encoding, 0);
-        if (out == null) return .{ .bool = false };
+        if (out == null) return NativeResult.scalar(.{ .bool = false });
         defer c.xmlFree.?(out);
-        return .{ .string = Value.String.borrowed(try dupString(ctx, out[0..@intCast(size)])) };
+        return try NativeResult.copyString(ctx.allocator, out[0..@intCast(size)]);
     }
 
     const buf = c.xmlBufferCreate();
     defer c.xmlBufferFree(buf);
     _ = c.xmlNodeDump(buf, doc, node, 0, 0);
     const content = c.xmlBufferContent(buf);
-    if (content == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-    return .{ .string = Value.String.borrowed(try dupString(ctx, content[0..cstrLen(content)])) };
+    if (content == null) return try NativeResult.copyString(ctx.allocator, "");
+    return try NativeResult.copyString(ctx.allocator, content[0..cstrLen(content)]);
 }
 
-fn sxmlSaveXML(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn sxmlSaveXML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return sxmlAsXML(ctx, args);
 }
 
-fn sxmlCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const node = getNodePtr(obj) orelse return .{ .int = 0 };
+fn sxmlCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .int = 0 });
     // count matches iteration: children-mode counts child elements; sibling-mode
     // counts same-named siblings of $this; attr-view counts attributes
     if (obj.get("__attr_view") == .bool and obj.get("__attr_view").bool) {
         var count: i64 = 0;
         var attr = node.properties;
         while (attr != null) : (attr = attr.*.next) count += 1;
-        return .{ .int = count };
+        return NativeResult.scalar(.{ .int = count });
     }
     if (obj.get("__iter_children") == .bool and obj.get("__iter_children").bool) {
         const ns_v = obj.get("__ns");
@@ -407,9 +408,9 @@ fn sxmlCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             if (ns_filter) |ns| if (!nodeInNs(child, ns)) continue;
             count += 1;
         }
-        return .{ .int = count };
+        return NativeResult.scalar(.{ .int = count });
     }
-    if (node.name == null) return .{ .int = 0 };
+    if (node.name == null) return NativeResult.scalar(.{ .int = 0 });
     const self_name = node.name[0..cstrLen(node.name)];
     var count: i64 = 0;
     var ch: ?*c.xmlNode = node;
@@ -419,13 +420,13 @@ fn sxmlCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         if (cn.name == null) continue;
         if (std.mem.eql(u8, cn.name[0..cstrLen(cn.name)], self_name)) count += 1;
     }
-    return .{ .int = count };
+    return NativeResult.scalar(.{ .int = count });
 }
 
-fn sxmlChildren(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
-    const doc = getDocPtr(obj) orelse return .null;
+fn sxmlChildren(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     // ->children() must yield the node's CHILDREN, not iterate same-named
     // siblings of the node itself - that's the default sibling-mode wrapper
     const wrapper = try buildWrapperMode(ctx, doc, node, .children);
@@ -450,13 +451,13 @@ fn sxmlChildren(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const owned = try ctx.allocator.dupe(u8, resolved_ns);
     try ctx.strings.append(ctx.allocator, owned);
     try wrapper.set(ctx.allocator, "__ns", .{ .string = Value.String.borrowed(owned) });
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
-fn sxmlAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
-    const doc = getDocPtr(obj) orelse return .null;
+fn sxmlAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const wrapper = try ctx.createObject("SimpleXMLElement");
     try wrapper.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
     try wrapper.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
@@ -481,7 +482,7 @@ fn sxmlAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const owned = try ctx.allocator.dupe(u8, resolved_ns);
     try ctx.strings.append(ctx.allocator, owned);
     try wrapper.set(ctx.allocator, "__ns", .{ .string = Value.String.borrowed(owned) });
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
 // walks all element nodes from the given root, registering each declared
@@ -502,13 +503,13 @@ fn autoRegisterNamespaces(ctx: *NativeContext, xctx: *c.xmlXPathContext, node: *
     }
 }
 
-fn sxmlXpath(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
-    const doc = getDocPtr(obj) orelse return .{ .bool = false };
+fn sxmlXpath(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
 
-    const xctx = c.xmlXPathNewContext(doc) orelse return .{ .bool = false };
+    const xctx = c.xmlXPathNewContext(doc) orelse return NativeResult.scalar(.{ .bool = false });
     defer c.xmlXPathFreeContext(xctx);
     xctx.*.node = node;
 
@@ -531,7 +532,7 @@ fn sxmlXpath(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     const expr_z = try dupZ(ctx, args[0].string.bytes());
     const result = c.xmlXPathEvalExpression(@ptrCast(expr_z.ptr), xctx);
-    if (result == null) return .{ .bool = false };
+    if (result == null) return NativeResult.scalar(.{ .bool = false });
     defer c.xmlXPathFreeObject(result);
 
     const arr = try ctx.createArray();
@@ -545,12 +546,12 @@ fn sxmlXpath(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .object = wrapper });
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn sxmlRegisterXPathNamespace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn sxmlRegisterXPathNamespace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     var ns_map = obj.get("__namespaces");
     if (ns_map != .array) {
         const arr = try ctx.createArray();
@@ -560,14 +561,14 @@ fn sxmlRegisterXPathNamespace(ctx: *NativeContext, args: []const Value) RuntimeE
     const key = try dupString(ctx, args[0].string.bytes());
     const val = try dupString(ctx, args[1].string.bytes());
     try ns_map.array.set(ctx.allocator, .{ .string = Value.String.borrowed(key) }, .{ .string = Value.String.borrowed(val) });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn sxmlAddChild(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
-    const doc = getDocPtr(obj) orelse return .null;
+fn sxmlAddChild(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const content_z: ?[:0]u8 = if (args.len > 1 and args[1] == .string) try dupZ(ctx, args[1].string.bytes()) else null;
     const ns_str: ?[]const u8 = if (args.len > 2 and args[2] == .string and args[2].string.bytes().len > 0) args[2].string.bytes() else null;
 
@@ -597,7 +598,7 @@ fn sxmlAddChild(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     const content_ptr: [*c]const u8 = if (content_z) |cz| @ptrCast(cz.ptr) else null;
     const child_raw = c.xmlNewTextChild(node, ns_ptr, @ptrCast(local_z.ptr), content_ptr);
-    if (child_raw == null) return .null;
+    if (child_raw == null) return NativeResult.scalar(.null);
     const child: *c.xmlNode = @ptrCast(child_raw);
     // attach the namespace to the child itself so it serializes as
     // <prefix:local xmlns:prefix="..."> when the prefix wasn't already in scope
@@ -606,27 +607,27 @@ fn sxmlAddChild(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         child.nsDef = np;
     };
     const wrapper = try buildWrapper(ctx, doc, child);
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
-fn sxmlAddAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn sxmlAddAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const val_z = try dupZ(ctx, args[1].string.bytes());
     _ = c.xmlNewProp(node, @ptrCast(name_z.ptr), @ptrCast(val_z.ptr));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sxmlGetNamespaces(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn sxmlGetNamespaces(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     var recursive: bool = false;
     if (args.len > 0 and args[0] == .bool) recursive = args[0].bool;
     const arr = try ctx.createArray();
     try collectNamespaces(ctx, node, arr, recursive);
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn collectNamespaces(ctx: *NativeContext, node: *c.xmlNode, arr: *PhpArray, recursive: bool) !void {
@@ -647,28 +648,28 @@ fn collectNamespaces(ctx: *NativeContext, node: *c.xmlNode, arr: *PhpArray, recu
     }
 }
 
-fn sxmlGetDocNamespaces(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn sxmlGetDocNamespaces(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return sxmlGetNamespaces(ctx, args);
 }
 
-fn sxmlToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+fn sxmlToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
     // attribute pseudo-element: return the attribute's value
     if (obj.get("__is_attr") == .bool and obj.get("__is_attr").bool) {
-        const owner = getNodePtr(obj) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        const owner = getNodePtr(obj) orelse return try NativeResult.copyString(ctx.allocator, "");
         const an = obj.get("__attr_name");
-        if (an != .string) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        if (an != .string) return try NativeResult.copyString(ctx.allocator, "");
         const an_z = try dupZ(ctx, an.string.bytes());
         const ns_v = obj.get("__attr_ns");
         const v: [*c]u8 = if (ns_v == .string and ns_v.string.bytes().len > 0) blk: {
             const ns_z = try dupZ(ctx, ns_v.string.bytes());
             break :blk c.xmlGetNsProp(owner, @ptrCast(an_z.ptr), @ptrCast(ns_z.ptr));
         } else c.xmlGetProp(owner, @ptrCast(an_z.ptr));
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
         defer c.xmlFree.?(v);
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
-    const node = getNodePtr(obj) orelse return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    const node = getNodePtr(obj) orelse return try NativeResult.copyString(ctx.allocator, "");
     // SimpleXML's __toString returns the direct text content of the element
     // (concatenation of immediate text children, not recursive)
     var out = std.ArrayList(u8){};
@@ -682,7 +683,7 @@ fn sxmlToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             }
         }
     }
-    return .{ .string = Value.String.borrowed(try dupString(ctx, out.items)) };
+    return try NativeResult.copyString(ctx.allocator, out.items);
 }
 
 // ---------------- magic __get / __set / iteration / offset ----------------
@@ -695,11 +696,11 @@ fn nodeInNs(n: *c.xmlNode, ns: []const u8) bool {
     return ns.len == 0;
 }
 
-fn sxmlIsset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn sxmlIsset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const ns_v = obj.get("__ns");
     const ns_filter: ?[]const u8 = if (ns_v == .string) ns_v.string.bytes() else null;
     var ch = node.children;
@@ -707,17 +708,17 @@ fn sxmlIsset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (ch.*.type != c.XML_ELEMENT_NODE) continue;
         if (!nameMatches(ch, name)) continue;
         if (ns_filter) |ns| if (!nodeInNs(ch, ns)) continue;
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn sxmlGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
+fn sxmlGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const name = args[0].string.bytes();
-    const node = getNodePtr(obj) orelse return .null;
-    const doc = getDocPtr(obj) orelse return .null;
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
 
     // honor namespace filter set by children($ns) / attributes($ns)
     const ns_v = obj.get("__ns");
@@ -731,7 +732,7 @@ fn sxmlGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             const owned = try dupString(ctx, ns);
             try wrap.set(ctx.allocator, "__attr_ns", .{ .string = Value.String.borrowed(owned) });
         }
-        return .{ .object = wrap };
+        return NativeResult.borrowed(.{ .object = wrap });
     }
 
     var ch = node.children;
@@ -746,22 +747,22 @@ fn sxmlGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try ctx.strings.append(ctx.allocator, owned);
             try wrapper.set(ctx.allocator, "__ns", .{ .string = Value.String.borrowed(owned) });
         }
-        return .{ .object = wrapper };
+        return NativeResult.borrowed(.{ .object = wrapper });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sxmlOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
-    const doc = getDocPtr(obj) orelse return .null;
+fn sxmlOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
 
     // numeric offset: walk same-named siblings starting from $this
     if (args[0] == .int) {
         const idx = args[0].int;
-        if (idx < 0) return .null;
-        if (node.name == null) return .null;
+        if (idx < 0) return NativeResult.scalar(.null);
+        if (node.name == null) return NativeResult.scalar(.null);
         const self_name = node.name[0..cstrLen(node.name)];
 
         // start from the first same-named sibling under parent
@@ -772,57 +773,57 @@ fn sxmlOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             if (cn.type == c.XML_ELEMENT_NODE and cn.name != null and std.mem.eql(u8, cn.name[0..cstrLen(cn.name)], self_name)) {
                 if (found == idx) {
                     const wrapper = try buildWrapper(ctx, doc, cn);
-                    return .{ .object = wrapper };
+                    return NativeResult.borrowed(.{ .object = wrapper });
                 }
                 found += 1;
             }
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
     // string offset: attribute access
     if (args[0] == .string) {
         const attr_z = try dupZ(ctx, args[0].string.bytes());
-        if (c.xmlHasProp(node, @ptrCast(attr_z.ptr)) == null) return .null;
+        if (c.xmlHasProp(node, @ptrCast(attr_z.ptr)) == null) return NativeResult.scalar(.null);
         const wrapper = try buildAttrWrapper(ctx, doc, node, args[0].string.bytes());
-        return .{ .object = wrapper };
+        return NativeResult.borrowed(.{ .object = wrapper });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sxmlOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const node = getNodePtr(obj) orelse return .{ .bool = false };
+fn sxmlOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.{ .bool = false });
     if (args[0] == .string) {
         const z = try dupZ(ctx, args[0].string.bytes());
-        return .{ .bool = c.xmlHasProp(node, @ptrCast(z.ptr)) != null };
+        return NativeResult.scalar(.{ .bool = c.xmlHasProp(node, @ptrCast(z.ptr)) != null });
     }
     if (args[0] == .int) {
         // numeric offset: counts same-named siblings of $this
         const idx = args[0].int;
-        if (idx < 0 or node.name == null) return .{ .bool = false };
+        if (idx < 0 or node.name == null) return NativeResult.scalar(.{ .bool = false });
         const self_name = node.name[0..cstrLen(node.name)];
         var n: ?*c.xmlNode = if (node.parent != null) node.parent.*.children else node;
         var found: i64 = 0;
         while (n != null) : (n = n.?.next) {
             const cn = n.?;
             if (cn.type == c.XML_ELEMENT_NODE and cn.name != null and std.mem.eql(u8, cn.name[0..cstrLen(cn.name)], self_name)) {
-                if (found == idx) return .{ .bool = true };
+                if (found == idx) return NativeResult.scalar(.{ .bool = true });
                 found += 1;
             }
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn sxmlOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn sxmlOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     // numeric offset: replace text content of the Nth same-named sibling
     if (args[0] == .int) {
         const idx = args[0].int;
-        if (idx < 0 or node.name == null) return .null;
+        if (idx < 0 or node.name == null) return NativeResult.scalar(.null);
         const self_name = node.name[0..cstrLen(node.name)];
         var n: ?*c.xmlNode = if (node.parent != null) node.parent.*.children else node;
         var found: i64 = 0;
@@ -831,18 +832,18 @@ fn sxmlOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             if (cn.type == c.XML_ELEMENT_NODE and cn.name != null and std.mem.eql(u8, cn.name[0..cstrLen(cn.name)], self_name)) {
                 if (found == idx) {
                     if (args[1] == .string) try setNodeText(ctx, cn, args[1].string.bytes());
-                    return .null;
+                    return NativeResult.scalar(.null);
                 }
                 found += 1;
             }
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
-    if (args[0] != .string or args[1] != .string) return .null;
+    if (args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const val_z = try dupZ(ctx, args[1].string.bytes());
     _ = c.xmlSetProp(node, @ptrCast(name_z.ptr), @ptrCast(val_z.ptr));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // replaces the text content of an element node with the supplied string.
@@ -861,10 +862,10 @@ fn setNodeText(ctx: *NativeContext, n: *c.xmlNode, text: []const u8) !void {
     if (txt_node != null) _ = c.xmlAddChild(n, txt_node);
 }
 
-fn sxmlSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn sxmlSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const new_text: []const u8 = switch (args[1]) {
         .string => |s| s.bytes(),
         .int => |i| blk: {
@@ -878,37 +879,37 @@ fn sxmlSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             break :blk try dupString(ctx, s);
         },
         .bool => |b| if (b) "1" else "",
-        else => return .null,
+        else => return NativeResult.scalar(.null),
     };
     // find existing child with this element name; if not found, create one
     var ch = node.children;
     while (ch != null) : (ch = ch.*.next) {
         if (ch.*.type == c.XML_ELEMENT_NODE and nameMatches(ch, args[0].string.bytes())) {
             try setNodeText(ctx, ch, new_text);
-            return .null;
+            return NativeResult.scalar(.null);
         }
     }
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const val_z = try dupZ(ctx, new_text);
     _ = c.xmlNewTextChild(node, null, @ptrCast(name_z.ptr), @ptrCast(val_z.ptr));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sxmlOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
+fn sxmlOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const name_z = try dupZ(ctx, args[0].string.bytes());
     _ = c.xmlUnsetProp(node, @ptrCast(name_z.ptr));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // iterator support: walks same-named siblings starting from this node,
 // or all children if used as `foreach ($root as $k => $v)`
-fn sxmlGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const node = getNodePtr(obj) orelse return .null;
-    const doc = getDocPtr(obj) orelse return .null;
+fn sxmlGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
 
     // attribute view still uses the ArrayIterator path because attribute names
     // are unique per element (so dedup in a PhpArray is harmless and the
@@ -945,7 +946,7 @@ fn sxmlGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try iter_obj.set(ctx.allocator, "__data", .{ .array = arr });
         try iter_obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
         try iter_obj.set(ctx.allocator, "__flags", .{ .int = 0 });
-        return .{ .object = iter_obj };
+        return NativeResult.borrowed(.{ .object = iter_obj });
     }
 
     // children / sibling iteration uses a custom xml-tree walker so duplicate-
@@ -963,13 +964,13 @@ fn sxmlGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try iter_obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("children") });
     } else {
         // sibling mode: start from $this and only emit same-named siblings
-        if (node.name == null) return .{ .object = iter_obj };
+        if (node.name == null) return NativeResult.borrowed(.{ .object = iter_obj });
         try iter_obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
         try iter_obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("siblings") });
         const name_copy = try dupString(ctx, node.name[0..cstrLen(node.name)]);
         try iter_obj.set(ctx.allocator, "__same_name", .{ .string = Value.String.borrowed(name_copy) });
     }
-    return .{ .object = iter_obj };
+    return NativeResult.borrowed(.{ .object = iter_obj });
 }
 
 // ---------------- registration ----------------
@@ -1069,20 +1070,20 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "SimpleXMLIterator::next", sxiNext);
 }
 
-fn sxmlIterRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn sxmlIterRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // SimpleXMLIterator iterates the children of $this. seed __mode and start
-    const obj = getThis(ctx) orelse return .null;
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("children") });
     try obj.set(ctx.allocator, "__same_name", .{ .string = Value.String.borrowed("") });
     return sxiRewind(ctx, &.{});
 }
 
-fn sxmlIterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn sxmlIterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // wrap the child node as another SimpleXMLIterator so the foreach value
     // also implements RecursiveIterator (needed by RecursiveIteratorIterator)
-    const obj = getThis(ctx) orelse return .null;
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return .null;
+    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
     const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
     const doc: *c.xmlDoc = @ptrFromInt(@as(usize, @intCast(obj.get("__doc").int)));
     const wrapper = try ctx.createObject("SimpleXMLIterator");
@@ -1090,37 +1091,37 @@ fn sxmlIterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try wrapper.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
     try wrapper.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try wrapper.set(ctx.allocator, "__iter_children", .{ .bool = true });
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
 // hasChildren / getChildren operate on the CURRENT iteration position (cursor)
 // not the wrapper's own __node. zphp's RecursiveIteratorIterator calls these
 // on the iterator itself between valid() and current(), expecting them to
 // describe the element about to be yielded
-fn sxmlIterHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn sxmlIterHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return .{ .bool = false };
+    if (cur != .int or cur.int == 0) return NativeResult.scalar(.{ .bool = false });
     const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
     var ch = node.children;
     while (ch != null) : (ch = ch.*.next) {
-        if (ch.*.type == c.XML_ELEMENT_NODE) return .{ .bool = true };
+        if (ch.*.type == c.XML_ELEMENT_NODE) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn sxmlIterGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sxmlIterGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return .null;
+    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
     const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
-    const doc = getDocPtr(obj) orelse return .null;
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const wrapper = try ctx.createObject("SimpleXMLIterator");
     try wrapper.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
     try wrapper.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
     try wrapper.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try wrapper.set(ctx.allocator, "__iter_children", .{ .bool = true });
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
 // these walk xml node siblings via the underlying libxml node pointers stored
@@ -1128,11 +1129,11 @@ fn sxmlIterGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value
 // __doc (xmlDoc), __mode ("children" | "siblings"), __cursor (current xmlNode*
 // or 0 when done), __same_name (the element name to filter by in sibling mode)
 
-fn sxiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sxiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const node = getIterStartPtr(obj) orelse {
         try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-        return .null;
+        return NativeResult.scalar(.null);
     };
     const mode = obj.get("__mode");
     const start_ptr: ?*c.xmlNode = if (mode == .string and std.mem.eql(u8, mode.string.bytes(), "children"))
@@ -1145,39 +1146,39 @@ fn sxiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     }
     const cur: usize = if (p) |np| @intFromPtr(np) else 0;
     try obj.set(ctx.allocator, "__cursor", .{ .int = @intCast(cur) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sxiValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn sxiValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const cur = obj.get("__cursor");
-    return .{ .bool = cur == .int and cur.int != 0 };
+    return NativeResult.scalar(.{ .bool = cur == .int and cur.int != 0 });
 }
 
-fn sxiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sxiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return .null;
+    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
     const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
     const doc: *c.xmlDoc = @ptrFromInt(@as(usize, @intCast(obj.get("__doc").int)));
     const wrapper = try buildWrapper(ctx, doc, node);
-    return .{ .object = wrapper };
+    return NativeResult.borrowed(.{ .object = wrapper });
 }
 
-fn sxiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sxiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return .null;
+    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
     const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
-    if (node.name == null) return .null;
+    if (node.name == null) return NativeResult.scalar(.null);
     const name = node.name[0..cstrLen(node.name)];
-    return .{ .string = Value.String.borrowed(try dupString(ctx, name)) };
+    return try NativeResult.copyString(ctx.allocator, name);
 }
 
-fn sxiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sxiNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return .null;
+    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
     var p: ?*c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
     if (p) |cp| p = @ptrCast(cp.next);
     while (p != null) : (p = @ptrCast(p.?.next)) {
@@ -1185,7 +1186,7 @@ fn sxiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     }
     const nxt: usize = if (p) |np| @intFromPtr(np) else 0;
     try obj.set(ctx.allocator, "__cursor", .{ .int = @intCast(nxt) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn sxiAcceptable(obj: *PhpObject, n: *c.xmlNode) bool {

--- a/src/stdlib/soap.zig
+++ b/src/stdlib/soap.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -244,8 +245,8 @@ fn parseWsdl(ctx: *NativeContext, obj: *PhpObject, source: []const u8) RuntimeEr
     try obj.set(ctx.allocator, "__types", .{ .array = types });
 }
 
-fn soapClientConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn soapClientConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
 
     const wsdl = if (args.len > 0) args[0] else .null;
     const opts: ?*PhpArray = if (args.len > 1 and args[1] == .array) args[1].array else null;
@@ -276,7 +277,7 @@ fn soapClientConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Va
     if (wsdl != .null and wsdl != .string) {
         // PHP throws SoapFault here. we accept null only for non-WSDL.
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn xmlEscape(allocator: Allocator, s: []const u8) ![]u8 {
@@ -480,7 +481,7 @@ fn extractBetween(haystack: []const u8, open: []const u8, close: []const u8) ?[]
 
 // best-effort SOAP response parser: returns innermost text content from the
 // response body, or an array of named children if the response has structure.
-fn parseSoapResponse(ctx: *NativeContext, xml: []const u8) RuntimeError!Value {
+fn parseSoapResponse(ctx: *NativeContext, xml: []const u8) RuntimeError!NativeResult {
     // find <SOAP-ENV:Body> or <soap:Body> or any *:Body
     var body_start: ?usize = null;
     var body_end: ?usize = null;
@@ -504,9 +505,7 @@ fn parseSoapResponse(ctx: *NativeContext, xml: []const u8) RuntimeError!Value {
     }
 
     if (body_start == null) {
-        const owned = try ctx.allocator.dupe(u8, xml);
-        try ctx.strings.append(ctx.allocator, owned);
-        return .{ .string = Value.String.borrowed(owned) };
+        return try NativeResult.copyString(ctx.allocator, xml);
     }
 
     const body = xml[body_start.?..(body_end orelse xml.len)];
@@ -520,7 +519,7 @@ fn parseSoapResponse(ctx: *NativeContext, xml: []const u8) RuntimeError!Value {
         try ctx.strings.append(ctx.allocator, owned_code);
         try ctx.strings.append(ctx.allocator, owned_str);
         try ctx.vm.setPendingException("SoapFault", owned_str);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     // first element inside Body is the response method; its children are the result fields
@@ -528,20 +527,18 @@ fn parseSoapResponse(ctx: *NativeContext, xml: []const u8) RuntimeError!Value {
     var p: usize = 0;
     while (p < body.len and std.ascii.isWhitespace(body[p])) p += 1;
     if (p >= body.len or body[p] != '<') {
-        const owned = try ctx.allocator.dupe(u8, body);
-        try ctx.strings.append(ctx.allocator, owned);
-        return .{ .string = Value.String.borrowed(owned) };
+        return try NativeResult.copyString(ctx.allocator, body);
     }
     // skip past response element tag
-    const tag_close = std.mem.indexOfScalarPos(u8, body, p, '>') orelse return .null;
+    const tag_close = std.mem.indexOfScalarPos(u8, body, p, '>') orelse return NativeResult.scalar(.null);
     const inner_start = tag_close + 1;
     // find matching close - approximate by looking for </tag>
     var tag_name_end = p + 1;
     while (tag_name_end < tag_close and body[tag_name_end] != ' ' and body[tag_name_end] != '>') tag_name_end += 1;
     const tag_name = body[p + 1 .. tag_name_end];
     var close_buf: [256]u8 = undefined;
-    const close_tag = std.fmt.bufPrint(&close_buf, "</{s}>", .{tag_name}) catch return .null;
-    const inner_end = std.mem.indexOfPos(u8, body, inner_start, close_tag) orelse return .null;
+    const close_tag = std.fmt.bufPrint(&close_buf, "</{s}>", .{tag_name}) catch return NativeResult.scalar(.null);
+    const inner_end = std.mem.indexOfPos(u8, body, inner_start, close_tag) orelse return NativeResult.scalar(.null);
     const inner = body[inner_start..inner_end];
 
     // parse first child of inner (the result) - many SOAP responses are <Foo><return>value</return></Foo>
@@ -551,33 +548,29 @@ fn parseSoapResponse(ctx: *NativeContext, xml: []const u8) RuntimeError!Value {
         // no children - return inner trimmed text
         var end = inner.len;
         while (end > 0 and std.ascii.isWhitespace(inner[end - 1])) end -= 1;
-        const owned = try ctx.allocator.dupe(u8, inner[rp..end]);
-        try ctx.strings.append(ctx.allocator, owned);
-        return .{ .string = Value.String.borrowed(owned) };
+        return try NativeResult.copyString(ctx.allocator, inner[rp..end]);
     }
-    const child_close = std.mem.indexOfScalarPos(u8, inner, rp, '>') orelse return .null;
+    const child_close = std.mem.indexOfScalarPos(u8, inner, rp, '>') orelse return NativeResult.scalar(.null);
     var child_name_end = rp + 1;
     while (child_name_end < child_close and inner[child_name_end] != ' ' and inner[child_name_end] != '>') child_name_end += 1;
     const child_name = inner[rp + 1 .. child_name_end];
     var ccbuf: [256]u8 = undefined;
-    const child_close_tag = std.fmt.bufPrint(&ccbuf, "</{s}>", .{child_name}) catch return .null;
+    const child_close_tag = std.fmt.bufPrint(&ccbuf, "</{s}>", .{child_name}) catch return NativeResult.scalar(.null);
     const child_inner_start = child_close + 1;
-    const child_inner_end = std.mem.indexOfPos(u8, inner, child_inner_start, child_close_tag) orelse return .null;
+    const child_inner_end = std.mem.indexOfPos(u8, inner, child_inner_start, child_close_tag) orelse return NativeResult.scalar(.null);
     const text = inner[child_inner_start..child_inner_end];
 
     // try to coerce numeric
     if (text.len > 0) {
-        if (std.fmt.parseInt(i64, text, 10)) |n| return .{ .int = n } else |_| {}
-        if (std.fmt.parseFloat(f64, text)) |f| return .{ .float = f } else |_| {}
+        if (std.fmt.parseInt(i64, text, 10)) |n| return NativeResult.scalar(.{ .int = n }) else |_| {}
+        if (std.fmt.parseFloat(f64, text)) |f| return NativeResult.scalar(.{ .float = f }) else |_| {}
     }
-    const owned = try ctx.allocator.dupe(u8, text);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return try NativeResult.copyString(ctx.allocator, text);
 }
 
-fn soapClientCall(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2 or args[0] != .string or args[1] != .array) return .null;
+fn soapClientCall(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2 or args[0] != .string or args[1] != .array) return NativeResult.scalar(.null);
     const method = args[0].string.bytes();
     const args_arr = args[1].array;
 
@@ -585,19 +578,19 @@ fn soapClientCall(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const uri_v = obj.get("__uri");
     if (loc_v != .string or uri_v != .string) {
         try ctx.vm.setPendingException("SoapFault", "SoapClient requires location and uri options for non-WSDL calls");
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const location = loc_v.string.bytes();
     const uri = uri_v.string.bytes();
 
     const envelope = buildEnvelope(ctx, obj, method, uri, args_arr) catch |e| switch (e) {
         error.OutOfMemory => return error.OutOfMemory,
-        else => return .null,
+        else => return NativeResult.scalar(.null),
     };
     defer ctx.allocator.free(envelope);
 
     var action_buf: [512]u8 = undefined;
-    const action = std.fmt.bufPrint(&action_buf, "{s}#{s}", .{ uri, method }) catch return .null;
+    const action = std.fmt.bufPrint(&action_buf, "{s}#{s}", .{ uri, method }) catch return NativeResult.scalar(.null);
 
     const env_owned = try ctx.allocator.dupe(u8, envelope);
     try ctx.strings.append(ctx.allocator, env_owned);
@@ -605,7 +598,7 @@ fn soapClientCall(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     const resp = httpPostSoap(ctx.allocator, location, action, envelope) catch {
         try ctx.vm.setPendingException("SoapFault", "SOAP HTTP request failed");
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     };
     defer ctx.allocator.free(resp.body);
     defer ctx.allocator.free(resp.headers);
@@ -620,73 +613,73 @@ fn soapClientCall(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return try parseSoapResponse(ctx, resp.body);
 }
 
-fn soapClientMagicCall(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn soapClientMagicCall(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // signature: __call($name, $arguments) - delegate to __soapCall
     return try soapClientCall(ctx, args);
 }
 
-fn soapClientGetLastRequest(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    return o.get("__last_request");
+fn soapClientGetLastRequest(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(o.get("__last_request"));
 }
-fn soapClientGetLastResponse(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    return o.get("__last_response");
+fn soapClientGetLastResponse(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(o.get("__last_response"));
 }
-fn soapClientGetLastRequestHeaders(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    return o.get("__last_request_headers");
+fn soapClientGetLastRequestHeaders(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(o.get("__last_request_headers"));
 }
-fn soapClientGetLastResponseHeaders(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    return o.get("__last_response_headers");
+fn soapClientGetLastResponseHeaders(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(o.get("__last_response_headers"));
 }
-fn soapClientSetLocation(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn soapClientSetLocation(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const prev = o.get("__location");
     try o.set(ctx.allocator, "__location", args[0]);
-    return if (o.get("__wsdl") == .string) .null else prev;
+    return if (o.get("__wsdl") == .string) NativeResult.scalar(.null) else NativeResult.share(prev);
 }
-fn soapClientSetSoapHeaders(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
+fn soapClientSetSoapHeaders(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     try o.set(ctx.allocator, "__headers", args[0]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
-fn soapClientGetFunctions(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    return o.get("__functions");
+fn soapClientGetFunctions(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(o.get("__functions"));
 }
-fn soapClientGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    return o.get("__types");
+fn soapClientGetTypes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(o.get("__types"));
 }
-fn soapClientSetCookie(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn soapClientSetCookie(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const cookies_v = o.get("__cookies");
-    if (cookies_v != .array) return .null;
-    if (args[0] != .string) return .null;
+    if (cookies_v != .array) return NativeResult.scalar(.null);
+    if (args[0] != .string) return NativeResult.scalar(.null);
     // PHP stores each cookie as a 3-element array: [value, autodelete, path].
     // a single arg deletes the cookie - matches PHP's __setCookie(name) semantic
     if (args.len == 1) {
         try cookies_v.array.set(ctx.allocator, .{ .string = Value.String.borrowed(args[0].string.bytes()) }, .null);
-        return .null;
+        return NativeResult.scalar(.null);
     }
     const inner = try ctx.createArray();
     try inner.set(ctx.allocator, .{ .int = 0 }, args[1]);
     try cookies_v.array.set(ctx.allocator, .{ .string = Value.String.borrowed(args[0].string.bytes()) }, .{ .array = inner });
-    return .null;
+    return NativeResult.scalar(.null);
 }
-fn soapClientGetCookies(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const o = getThis(ctx) orelse return .null;
-    return o.get("__cookies");
+fn soapClientGetCookies(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const o = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(o.get("__cookies"));
 }
 
 // SoapServer stubs - functional outline. real-world server use is rare from PHP scripts
-fn soapServerConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn soapServerConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const wsdl = if (args.len > 0) args[0] else .null;
     try obj.set(ctx.allocator, "__wsdl", wsdl);
     try obj.set(ctx.allocator, "__functions", .{ .array = try ctx.createArray() });
@@ -700,13 +693,13 @@ fn soapServerConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         if (u == .string) uri = u;
     }
     try obj.set(ctx.allocator, "__uri", uri);
-    return .null;
+    return NativeResult.scalar(.null);
 }
-fn soapServerAddFunction(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
+fn soapServerAddFunction(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     const fns_v = obj.get("__functions");
-    if (fns_v != .array) return .{ .bool = false };
+    if (fns_v != .array) return NativeResult.scalar(.{ .bool = false });
     if (args[0] == .string) {
         try fns_v.array.set(ctx.allocator, .{ .int = fns_v.array.next_int_key }, args[0]);
     } else if (args[0] == .array) {
@@ -714,19 +707,19 @@ fn soapServerAddFunction(ctx: *NativeContext, args: []const Value) RuntimeError!
             try fns_v.array.set(ctx.allocator, .{ .int = fns_v.array.next_int_key }, e.value);
         }
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
-fn soapServerSetObject(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
+fn soapServerSetObject(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     try obj.set(ctx.allocator, "__object", args[0]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
-fn soapServerSetClass(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
+fn soapServerSetClass(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     try obj.set(ctx.allocator, "__class", args[0]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 fn xmlUnescape(allocator: Allocator, s: []const u8) ![]u8 {
     var out = std.ArrayListUnmanaged(u8){};
@@ -913,8 +906,8 @@ fn dispatchSoap(ctx: *NativeContext, server: *PhpObject, method: []const u8, arg
     return .null;
 }
 
-fn soapServerHandle(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn soapServerHandle(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     // request XML: explicit arg, else the raw HTTP body (php://input)
     var req: []const u8 = "";
     if (args.len > 0 and args[0] == .string) {
@@ -922,14 +915,14 @@ fn soapServerHandle(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     } else if (ctx.vm.request_vars.get("__raw_body")) |body_val| {
         if (body_val == .string) req = body_val.string.bytes();
     }
-    if (req.len == 0) return .null;
+    if (req.len == 0) return NativeResult.scalar(.null);
 
     // locate the SOAP Body open tag's end ("...Body>"); the close tag
     // "</...Body>" appears later, so the first match is the open
-    const body_open = std.mem.indexOf(u8, req, "Body>") orelse return .null;
+    const body_open = std.mem.indexOf(u8, req, "Body>") orelse return NativeResult.scalar(.null);
     var p = body_open + "Body>".len;
     while (p < req.len and (req[p] == ' ' or req[p] == '\n' or req[p] == '\r' or req[p] == '\t')) : (p += 1) {}
-    if (p >= req.len or req[p] != '<') return .null;
+    if (p >= req.len or req[p] != '<') return NativeResult.scalar(.null);
 
     // method element start tag (full name keeps the ns prefix for the close)
     const mtag_start = p + 1;
@@ -1019,56 +1012,56 @@ fn soapServerHandle(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     try out.appendSlice(ctx.allocator, method);
     try out.appendSlice(ctx.allocator, "Response></SOAP-ENV:Body></SOAP-ENV:Envelope>\n");
     try ctx.vm.output.appendSlice(ctx.allocator, out.items);
-    return .null;
+    return NativeResult.scalar(.null);
 }
-fn soapServerFault(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn soapServerFault(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
-fn soapServerAddSoapHeader(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
+fn soapServerAddSoapHeader(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const headers = obj.get("__response_headers");
-    if (headers != .array) return .{ .bool = false };
+    if (headers != .array) return NativeResult.scalar(.{ .bool = false });
     try headers.array.set(ctx.allocator, .{ .int = headers.array.next_int_key }, args[0]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
-fn soapServerGetFunctions(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__functions");
+fn soapServerGetFunctions(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__functions"));
 }
-fn soapServerSetPersistence(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn soapServerSetPersistence(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn soapHeaderConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn soapHeaderConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0) try obj.set(ctx.allocator, "namespace", args[0]);
     if (args.len > 1) try obj.set(ctx.allocator, "name", args[1]);
     if (args.len > 2) try obj.set(ctx.allocator, "data", args[2]);
     if (args.len > 3) try obj.set(ctx.allocator, "mustUnderstand", args[3]);
     if (args.len > 4) try obj.set(ctx.allocator, "actor", args[4]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn soapVarConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn soapVarConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0) try obj.set(ctx.allocator, "enc_value", args[0]);
     if (args.len > 1) try obj.set(ctx.allocator, "enc_type", args[1]);
     if (args.len > 2) try obj.set(ctx.allocator, "enc_stype", args[2]);
     if (args.len > 3) try obj.set(ctx.allocator, "enc_ns", args[3]);
     if (args.len > 4) try obj.set(ctx.allocator, "enc_name", args[4]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn soapParamConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn soapParamConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0) try obj.set(ctx.allocator, "param_data", args[0]);
     if (args.len > 1) try obj.set(ctx.allocator, "param_name", args[1]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn soapFaultConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn soapFaultConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0) try obj.set(ctx.allocator, "faultcode", args[0]);
     if (args.len > 1) {
         try obj.set(ctx.allocator, "faultstring", args[1]);
@@ -1077,18 +1070,17 @@ fn soapFaultConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     if (args.len > 2) try obj.set(ctx.allocator, "faultactor", args[2]);
     if (args.len > 3) try obj.set(ctx.allocator, "detail", args[3]);
     if (args.len > 4) try obj.set(ctx.allocator, "faultname", args[4]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn soapFaultToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
+fn soapFaultToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
     const code = obj.get("faultcode");
     const str = obj.get("faultstring");
     const code_s = if (code == .string) code.string.bytes() else "Server";
     const str_s = if (str == .string) str.string.bytes() else "SOAP fault";
     const out = try std.fmt.allocPrint(ctx.allocator, "SoapFault: {s} ({s})", .{ str_s, code_s });
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
 test {}

--- a/src/stdlib/sodium.zig
+++ b/src/stdlib/sodium.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
+const PhpArray = @import("../runtime/value.zig").PhpArray;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
 const c = @cImport({
@@ -86,15 +88,19 @@ fn strBytes(v: Value) ?[]const u8 {
     return if (v == .string) v.string.bytes() else null;
 }
 
-fn allocStr(ctx: *NativeContext, src: []const u8) RuntimeError!Value {
-    const owned = try ctx.allocator.dupe(u8, src);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+fn allocStr(ctx: *NativeContext, src: []const u8) RuntimeError!NativeResult {
+    return NativeResult.copyString(ctx.allocator, src);
 }
 
-fn native_bin2hex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn setOwnedString(ctx: *NativeContext, arr: *PhpArray, idx: i64, bytes: []const u8) !void {
+    const s = try Value.String.create(ctx.allocator, bytes);
+    defer s.release();
+    try arr.set(ctx.allocator, .{ .int = idx }, .{ .string = s });
+}
+
+fn native_bin2hex(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+    if (args.len < 1 or args[0] != .string) return NativeResult.literal("");
     const bin = args[0].string.bytes();
     const out = try ctx.allocator.alloc(u8, bin.len * 2 + 1);
     defer ctx.allocator.free(out);
@@ -102,9 +108,9 @@ fn native_bin2hex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return try allocStr(ctx, out[0 .. bin.len * 2]);
 }
 
-fn native_hex2bin(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_hex2bin(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const hex = args[0].string.bytes();
     const ignore: ?[*:0]const u8 = if (args.len > 1 and args[1] == .string)
         (try ctx.allocator.dupeZ(u8, args[1].string.bytes())).ptr
@@ -114,13 +120,13 @@ fn native_hex2bin(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     defer ctx.allocator.free(out);
     var out_len: usize = 0;
     const rc = c.sodium_hex2bin(out.ptr, out.len, hex.ptr, hex.len, ignore, &out_len, null);
-    if (rc != 0) return .{ .bool = false };
+    if (rc != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out[0..out_len]);
 }
 
-fn native_bin2base64(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_bin2base64(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+    if (args.len < 1 or args[0] != .string) return NativeResult.literal("");
     const variant: c_int = if (args.len > 1 and args[1] == .int) @intCast(args[1].int) else 1;
     const bin = args[0].string.bytes();
     const out_max = c.sodium_base64_encoded_len(bin.len, variant);
@@ -133,9 +139,9 @@ fn native_bin2base64(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     return try allocStr(ctx, out[0..end]);
 }
 
-fn native_base642bin(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_base642bin(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const variant: c_int = if (args.len > 1 and args[1] == .int) @intCast(args[1].int) else 1;
     const ignore: ?[*:0]const u8 = if (args.len > 2 and args[2] == .string)
         (try ctx.allocator.dupeZ(u8, args[2].string.bytes())).ptr
@@ -146,56 +152,56 @@ fn native_base642bin(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     defer ctx.allocator.free(out);
     var out_len: usize = 0;
     const rc = c.sodium_base642bin(out.ptr, out.len, src.ptr, src.len, ignore, &out_len, null, variant);
-    if (rc != 0) return .{ .bool = false };
+    if (rc != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out[0..out_len]);
 }
 
-fn native_memzero(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn native_memzero(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn native_memcmp(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_memcmp(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .int = -1 };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .int = -1 });
     const a = args[0].string.bytes();
     const b = args[1].string.bytes();
-    if (a.len != b.len) return .{ .int = -1 };
-    return .{ .int = @intCast(c.sodium_memcmp(a.ptr, b.ptr, a.len)) };
+    if (a.len != b.len) return NativeResult.scalar(.{ .int = -1 });
+    return NativeResult.scalar(.{ .int = @intCast(c.sodium_memcmp(a.ptr, b.ptr, a.len)) });
 }
 
-fn native_compare(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_compare(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .int = 0 };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .int = 0 });
     const a = args[0].string.bytes();
     const b = args[1].string.bytes();
-    if (a.len != b.len) return .{ .int = if (a.len < b.len) -1 else 1 };
-    return .{ .int = @intCast(c.sodium_compare(a.ptr, b.ptr, a.len)) };
+    if (a.len != b.len) return NativeResult.scalar(.{ .int = if (a.len < b.len) -1 else 1 });
+    return NativeResult.scalar(.{ .int = @intCast(c.sodium_compare(a.ptr, b.ptr, a.len)) });
 }
 
-fn native_increment(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_increment(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .null;
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const s = args[0].string.bytes();
     const mut: [*]u8 = @ptrCast(@constCast(s.ptr));
     c.sodium_increment(mut, s.len);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_add(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_add(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .null;
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
     const a = args[0].string.bytes();
     const b = args[1].string.bytes();
-    if (a.len != b.len) return .null;
+    if (a.len != b.len) return NativeResult.scalar(.null);
     c.sodium_add(@ptrCast(@constCast(a.ptr)), b.ptr, a.len);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pad(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .int) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const block: usize = @intCast(args[1].int);
-    if (block == 0) return .{ .bool = false };
+    if (block == 0) return NativeResult.scalar(.{ .bool = false });
     const src = args[0].string.bytes();
     const padded_len = src.len + (block - (src.len % block));
     const out = try ctx.allocator.alloc(u8, padded_len);
@@ -203,50 +209,50 @@ fn native_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     @memcpy(out[0..src.len], src);
     var actual_len: usize = 0;
     const rc = c.sodium_pad(&actual_len, out.ptr, src.len, block, padded_len);
-    if (rc != 0) return .{ .bool = false };
+    if (rc != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out[0..actual_len]);
 }
 
-fn native_unpad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_unpad(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .int) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const block: usize = @intCast(args[1].int);
-    if (block == 0) return .{ .bool = false };
+    if (block == 0) return NativeResult.scalar(.{ .bool = false });
     const src = args[0].string.bytes();
     var unpadded_len: usize = 0;
     const rc = c.sodium_unpad(&unpadded_len, src.ptr, src.len, block);
-    if (rc != 0) return .{ .bool = false };
+    if (rc != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, src[0..unpadded_len]);
 }
 
-fn native_secretbox(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_secretbox(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const nonce = args[1].string.bytes();
     const key = args[2].string.bytes();
-    if (nonce.len != c.crypto_secretbox_NONCEBYTES or key.len != c.crypto_secretbox_KEYBYTES) return .{ .bool = false };
+    if (nonce.len != c.crypto_secretbox_NONCEBYTES or key.len != c.crypto_secretbox_KEYBYTES) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, msg.len + c.crypto_secretbox_MACBYTES);
     defer ctx.allocator.free(out);
-    if (c.crypto_secretbox_easy(out.ptr, msg.ptr, msg.len, nonce.ptr, key.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_secretbox_easy(out.ptr, msg.ptr, msg.len, nonce.ptr, key.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_secretbox_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_secretbox_open(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const ct = args[0].string.bytes();
     const nonce = args[1].string.bytes();
     const key = args[2].string.bytes();
-    if (ct.len < c.crypto_secretbox_MACBYTES) return .{ .bool = false };
-    if (nonce.len != c.crypto_secretbox_NONCEBYTES or key.len != c.crypto_secretbox_KEYBYTES) return .{ .bool = false };
+    if (ct.len < c.crypto_secretbox_MACBYTES) return NativeResult.scalar(.{ .bool = false });
+    if (nonce.len != c.crypto_secretbox_NONCEBYTES or key.len != c.crypto_secretbox_KEYBYTES) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, ct.len - c.crypto_secretbox_MACBYTES);
     defer ctx.allocator.free(out);
-    if (c.crypto_secretbox_open_easy(out.ptr, ct.ptr, ct.len, nonce.ptr, key.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_secretbox_open_easy(out.ptr, ct.ptr, ct.len, nonce.ptr, key.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn keygen(ctx: *NativeContext, len: usize) RuntimeError!Value {
+fn keygen(ctx: *NativeContext, len: usize) RuntimeError!NativeResult {
     ensureInit();
     const buf = try ctx.allocator.alloc(u8, len);
     defer ctx.allocator.free(buf);
@@ -254,11 +260,11 @@ fn keygen(ctx: *NativeContext, len: usize) RuntimeError!Value {
     return try allocStr(ctx, buf);
 }
 
-fn native_secretbox_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_secretbox_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_secretbox_KEYBYTES);
 }
 
-fn native_box_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_box_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureInit();
     var pk: [c.crypto_box_PUBLICKEYBYTES]u8 = undefined;
     var sk: [c.crypto_box_SECRETKEYBYTES]u8 = undefined;
@@ -269,11 +275,11 @@ fn native_box_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!Value 
     return try allocStr(ctx, &kp);
 }
 
-fn native_box_keypair_from_skpk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_box_keypair_from_skpk(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const sk = args[0].string.bytes();
     const pk = args[1].string.bytes();
-    if (sk.len != c.crypto_box_SECRETKEYBYTES or pk.len != c.crypto_box_PUBLICKEYBYTES) return .{ .bool = false };
+    if (sk.len != c.crypto_box_SECRETKEYBYTES or pk.len != c.crypto_box_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, sk.len + pk.len);
     defer ctx.allocator.free(out);
     @memcpy(out[0..sk.len], sk);
@@ -281,91 +287,91 @@ fn native_box_keypair_from_skpk(ctx: *NativeContext, args: []const Value) Runtim
     return try allocStr(ctx, out);
 }
 
-fn native_box_secretkey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_box_secretkey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
-    if (kp.len < c.crypto_box_SECRETKEYBYTES) return .{ .bool = false };
+    if (kp.len < c.crypto_box_SECRETKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, kp[0..c.crypto_box_SECRETKEYBYTES]);
 }
 
-fn native_box_publickey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_box_publickey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
-    if (kp.len < c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return .{ .bool = false };
+    if (kp.len < c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, kp[c.crypto_box_SECRETKEYBYTES..]);
 }
 
-fn native_box_pk_from_sk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_box_pk_from_sk(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const sk = args[0].string.bytes();
-    if (sk.len != c.crypto_box_SECRETKEYBYTES) return .{ .bool = false };
+    if (sk.len != c.crypto_box_SECRETKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     var pk: [c.crypto_box_PUBLICKEYBYTES]u8 = undefined;
     _ = c.crypto_scalarmult_base(&pk, sk.ptr);
     return try allocStr(ctx, &pk);
 }
 
-fn native_box(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_box(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const nonce = args[1].string.bytes();
     const kp = args[2].string.bytes();
-    if (kp.len != c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return .{ .bool = false };
-    if (nonce.len != c.crypto_box_NONCEBYTES) return .{ .bool = false };
+    if (kp.len != c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
+    if (nonce.len != c.crypto_box_NONCEBYTES) return NativeResult.scalar(.{ .bool = false });
     const sk = kp[0..c.crypto_box_SECRETKEYBYTES];
     const pk = kp[c.crypto_box_SECRETKEYBYTES..];
     const out = try ctx.allocator.alloc(u8, msg.len + c.crypto_box_MACBYTES);
     defer ctx.allocator.free(out);
-    if (c.crypto_box_easy(out.ptr, msg.ptr, msg.len, nonce.ptr, pk.ptr, sk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_box_easy(out.ptr, msg.ptr, msg.len, nonce.ptr, pk.ptr, sk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_box_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_box_open(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const ct = args[0].string.bytes();
     const nonce = args[1].string.bytes();
     const kp = args[2].string.bytes();
-    if (kp.len != c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return .{ .bool = false };
-    if (nonce.len != c.crypto_box_NONCEBYTES) return .{ .bool = false };
-    if (ct.len < c.crypto_box_MACBYTES) return .{ .bool = false };
+    if (kp.len != c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
+    if (nonce.len != c.crypto_box_NONCEBYTES) return NativeResult.scalar(.{ .bool = false });
+    if (ct.len < c.crypto_box_MACBYTES) return NativeResult.scalar(.{ .bool = false });
     const sk = kp[0..c.crypto_box_SECRETKEYBYTES];
     const pk = kp[c.crypto_box_SECRETKEYBYTES..];
     const out = try ctx.allocator.alloc(u8, ct.len - c.crypto_box_MACBYTES);
     defer ctx.allocator.free(out);
-    if (c.crypto_box_open_easy(out.ptr, ct.ptr, ct.len, nonce.ptr, pk.ptr, sk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_box_open_easy(out.ptr, ct.ptr, ct.len, nonce.ptr, pk.ptr, sk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_box_seal(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_box_seal(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const pk = args[1].string.bytes();
-    if (pk.len != c.crypto_box_PUBLICKEYBYTES) return .{ .bool = false };
+    if (pk.len != c.crypto_box_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, msg.len + c.crypto_box_SEALBYTES);
     defer ctx.allocator.free(out);
-    if (c.crypto_box_seal(out.ptr, msg.ptr, msg.len, pk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_box_seal(out.ptr, msg.ptr, msg.len, pk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_box_seal_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_box_seal_open(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const ct = args[0].string.bytes();
     const kp = args[1].string.bytes();
-    if (kp.len != c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return .{ .bool = false };
-    if (ct.len < c.crypto_box_SEALBYTES) return .{ .bool = false };
+    if (kp.len != c.crypto_box_SECRETKEYBYTES + c.crypto_box_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
+    if (ct.len < c.crypto_box_SEALBYTES) return NativeResult.scalar(.{ .bool = false });
     const sk = kp[0..c.crypto_box_SECRETKEYBYTES];
     const pk = kp[c.crypto_box_SECRETKEYBYTES..];
     const out = try ctx.allocator.alloc(u8, ct.len - c.crypto_box_SEALBYTES);
     defer ctx.allocator.free(out);
-    if (c.crypto_box_seal_open(out.ptr, ct.ptr, ct.len, pk.ptr, sk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_box_seal_open(out.ptr, ct.ptr, ct.len, pk.ptr, sk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_sign_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_sign_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureInit();
     var pk: [c.crypto_sign_PUBLICKEYBYTES]u8 = undefined;
     var sk: [c.crypto_sign_SECRETKEYBYTES]u8 = undefined;
@@ -376,190 +382,190 @@ fn native_sign_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!Value
     return try allocStr(ctx, &out);
 }
 
-fn native_sign_publickey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_sign_publickey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
-    if (kp.len < c.crypto_sign_SECRETKEYBYTES + c.crypto_sign_PUBLICKEYBYTES) return .{ .bool = false };
+    if (kp.len < c.crypto_sign_SECRETKEYBYTES + c.crypto_sign_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, kp[c.crypto_sign_SECRETKEYBYTES..]);
 }
 
-fn native_sign_secretkey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_sign_secretkey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
-    if (kp.len < c.crypto_sign_SECRETKEYBYTES) return .{ .bool = false };
+    if (kp.len < c.crypto_sign_SECRETKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, kp[0..c.crypto_sign_SECRETKEYBYTES]);
 }
 
-fn native_sign_pk_from_sk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_sign_pk_from_sk(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const sk = args[0].string.bytes();
-    if (sk.len != c.crypto_sign_SECRETKEYBYTES) return .{ .bool = false };
+    if (sk.len != c.crypto_sign_SECRETKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     var pk: [c.crypto_sign_PUBLICKEYBYTES]u8 = undefined;
-    if (c.crypto_sign_ed25519_sk_to_pk(&pk, sk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_sign_ed25519_sk_to_pk(&pk, sk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, &pk);
 }
 
-fn native_sign(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_sign(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const sk = args[1].string.bytes();
-    if (sk.len != c.crypto_sign_SECRETKEYBYTES) return .{ .bool = false };
+    if (sk.len != c.crypto_sign_SECRETKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, msg.len + c.crypto_sign_BYTES);
     defer ctx.allocator.free(out);
     var slen: c_ulonglong = 0;
-    if (c.crypto_sign(out.ptr, &slen, msg.ptr, msg.len, sk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_sign(out.ptr, &slen, msg.ptr, msg.len, sk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out[0..slen]);
 }
 
-fn native_sign_open(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_sign_open(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const signed = args[0].string.bytes();
     const pk = args[1].string.bytes();
-    if (pk.len != c.crypto_sign_PUBLICKEYBYTES) return .{ .bool = false };
+    if (pk.len != c.crypto_sign_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, signed.len);
     defer ctx.allocator.free(out);
     var mlen: c_ulonglong = 0;
-    if (c.crypto_sign_open(out.ptr, &mlen, signed.ptr, signed.len, pk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_sign_open(out.ptr, &mlen, signed.ptr, signed.len, pk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out[0..mlen]);
 }
 
-fn native_sign_detached(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_sign_detached(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const sk = args[1].string.bytes();
-    if (sk.len != c.crypto_sign_SECRETKEYBYTES) return .{ .bool = false };
+    if (sk.len != c.crypto_sign_SECRETKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     var sig: [c.crypto_sign_BYTES]u8 = undefined;
     var slen: c_ulonglong = 0;
-    if (c.crypto_sign_detached(&sig, &slen, msg.ptr, msg.len, sk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_sign_detached(&sig, &slen, msg.ptr, msg.len, sk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, sig[0..slen]);
 }
 
-fn native_sign_verify_detached(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_sign_verify_detached(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const sig = args[0].string.bytes();
     const msg = args[1].string.bytes();
     const pk = args[2].string.bytes();
-    if (sig.len != c.crypto_sign_BYTES or pk.len != c.crypto_sign_PUBLICKEYBYTES) return .{ .bool = false };
-    return .{ .bool = c.crypto_sign_verify_detached(sig.ptr, msg.ptr, msg.len, pk.ptr) == 0 };
+    if (sig.len != c.crypto_sign_BYTES or pk.len != c.crypto_sign_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.crypto_sign_verify_detached(sig.ptr, msg.ptr, msg.len, pk.ptr) == 0 });
 }
 
-fn native_generichash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_generichash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const key: ?[*]const u8 = if (args.len > 1 and args[1] == .string and args[1].string.bytes().len > 0) args[1].string.bytes().ptr else null;
     const klen: usize = if (args.len > 1 and args[1] == .string) args[1].string.bytes().len else 0;
     const out_len: usize = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else c.crypto_generichash_BYTES;
     const out = try ctx.allocator.alloc(u8, out_len);
     defer ctx.allocator.free(out);
-    if (c.crypto_generichash(out.ptr, out.len, msg.ptr, msg.len, key, klen) != 0) return .{ .bool = false };
+    if (c.crypto_generichash(out.ptr, out.len, msg.ptr, msg.len, key, klen) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_generichash_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_generichash_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_generichash_KEYBYTES);
 }
 
-fn native_shorthash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_shorthash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const key = args[1].string.bytes();
-    if (key.len != c.crypto_shorthash_KEYBYTES) return .{ .bool = false };
+    if (key.len != c.crypto_shorthash_KEYBYTES) return NativeResult.scalar(.{ .bool = false });
     var out: [c.crypto_shorthash_BYTES]u8 = undefined;
-    if (c.crypto_shorthash(&out, msg.ptr, msg.len, key.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_shorthash(&out, msg.ptr, msg.len, key.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, &out);
 }
 
-fn native_shorthash_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_shorthash_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_shorthash_KEYBYTES);
 }
 
-fn native_pwhash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pwhash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 5) return .{ .bool = false };
-    if (args[0] != .int or args[1] != .string or args[2] != .string or args[3] != .int or args[4] != .int) return .{ .bool = false };
+    if (args.len < 5) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] != .int or args[1] != .string or args[2] != .string or args[3] != .int or args[4] != .int) return NativeResult.scalar(.{ .bool = false });
     const out_len: usize = @intCast(args[0].int);
     const pass = args[1].string.bytes();
     const salt = args[2].string.bytes();
-    if (salt.len != c.crypto_pwhash_SALTBYTES) return .{ .bool = false };
+    if (salt.len != c.crypto_pwhash_SALTBYTES) return NativeResult.scalar(.{ .bool = false });
     const ops: c_ulonglong = @intCast(args[3].int);
     const mem: usize = @intCast(args[4].int);
     const alg: c_int = if (args.len > 5 and args[5] == .int) @intCast(args[5].int) else c.crypto_pwhash_ALG_DEFAULT;
     const out = try ctx.allocator.alloc(u8, out_len);
     defer ctx.allocator.free(out);
-    if (c.crypto_pwhash(out.ptr, out_len, pass.ptr, pass.len, salt.ptr, ops, mem, alg) != 0) return .{ .bool = false };
+    if (c.crypto_pwhash(out.ptr, out_len, pass.ptr, pass.len, salt.ptr, ops, mem, alg) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_pwhash_str(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pwhash_str(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .int or args[2] != .int) return .{ .bool = false };
+    if (args.len < 3 or args[0] != .string or args[1] != .int or args[2] != .int) return NativeResult.scalar(.{ .bool = false });
     const pass = args[0].string.bytes();
     const ops: c_ulonglong = @intCast(args[1].int);
     const mem: usize = @intCast(args[2].int);
     var out: [c.crypto_pwhash_STRBYTES]u8 = undefined;
-    if (c.crypto_pwhash_str(&out, pass.ptr, pass.len, ops, mem) != 0) return .{ .bool = false };
+    if (c.crypto_pwhash_str(&out, pass.ptr, pass.len, ops, mem) != 0) return NativeResult.scalar(.{ .bool = false });
     const slen = std.mem.indexOfScalar(u8, &out, 0) orelse out.len;
     return try allocStr(ctx, out[0..slen]);
 }
 
-fn native_pwhash_str_verify(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pwhash_str_verify(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const hash_z = try ctx.allocator.dupeZ(u8, args[0].string.bytes());
     defer ctx.allocator.free(hash_z);
     const pass = args[1].string.bytes();
-    return .{ .bool = c.crypto_pwhash_str_verify(hash_z.ptr, pass.ptr, pass.len) == 0 };
+    return NativeResult.scalar(.{ .bool = c.crypto_pwhash_str_verify(hash_z.ptr, pass.ptr, pass.len) == 0 });
 }
 
-fn native_pwhash_str_needs_rehash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_pwhash_str_needs_rehash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .int or args[2] != .int) return .{ .bool = true };
+    if (args.len < 3 or args[0] != .string or args[1] != .int or args[2] != .int) return NativeResult.scalar(.{ .bool = true });
     const hash_z = try ctx.allocator.dupeZ(u8, args[0].string.bytes());
     defer ctx.allocator.free(hash_z);
     const ops: c_ulonglong = @intCast(args[1].int);
     const mem: usize = @intCast(args[2].int);
-    return .{ .bool = c.crypto_pwhash_str_needs_rehash(hash_z.ptr, ops, mem) != 0 };
+    return NativeResult.scalar(.{ .bool = c.crypto_pwhash_str_needs_rehash(hash_z.ptr, ops, mem) != 0 });
 }
 
-fn aeadEncrypt(comptime klen: usize, comptime nlen: usize, comptime alen: usize, comptime enc: anytype, ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn aeadEncrypt(comptime klen: usize, comptime nlen: usize, comptime alen: usize, comptime enc: anytype, ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 4 or args[0] != .string or args[1] != .string or args[2] != .string or args[3] != .string) return .{ .bool = false };
+    if (args.len < 4 or args[0] != .string or args[1] != .string or args[2] != .string or args[3] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const ad = args[1].string.bytes();
     const nonce = args[2].string.bytes();
     const key = args[3].string.bytes();
-    if (nonce.len != nlen or key.len != klen) return .{ .bool = false };
+    if (nonce.len != nlen or key.len != klen) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, msg.len + alen);
     defer ctx.allocator.free(out);
     var clen: c_ulonglong = 0;
-    if (enc(out.ptr, &clen, msg.ptr, msg.len, ad.ptr, ad.len, null, nonce.ptr, key.ptr) != 0) return .{ .bool = false };
-    return try allocStr(ctx, out[0..clen]);
+    if (enc(out.ptr, &clen, msg.ptr, msg.len, ad.ptr, ad.len, null, nonce.ptr, key.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, out[0..clen]);
 }
 
-fn aeadDecrypt(comptime klen: usize, comptime nlen: usize, comptime alen: usize, comptime dec: anytype, ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn aeadDecrypt(comptime klen: usize, comptime nlen: usize, comptime alen: usize, comptime dec: anytype, ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 4 or args[0] != .string or args[1] != .string or args[2] != .string or args[3] != .string) return .{ .bool = false };
+    if (args.len < 4 or args[0] != .string or args[1] != .string or args[2] != .string or args[3] != .string) return NativeResult.scalar(.{ .bool = false });
     const ct = args[0].string.bytes();
     const ad = args[1].string.bytes();
     const nonce = args[2].string.bytes();
     const key = args[3].string.bytes();
-    if (nonce.len != nlen or key.len != klen) return .{ .bool = false };
-    if (ct.len < alen) return .{ .bool = false };
+    if (nonce.len != nlen or key.len != klen) return NativeResult.scalar(.{ .bool = false });
+    if (ct.len < alen) return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.alloc(u8, ct.len - alen);
     defer ctx.allocator.free(out);
     var mlen: c_ulonglong = 0;
-    if (dec(out.ptr, &mlen, null, ct.ptr, ct.len, ad.ptr, ad.len, nonce.ptr, key.ptr) != 0) return .{ .bool = false };
-    return try allocStr(ctx, out[0..mlen]);
+    if (dec(out.ptr, &mlen, null, ct.ptr, ct.len, ad.ptr, ad.len, nonce.ptr, key.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, out[0..mlen]);
 }
 
-fn native_aead_chacha_ietf_enc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_aead_chacha_ietf_enc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return aeadEncrypt(
         c.crypto_aead_chacha20poly1305_IETF_KEYBYTES,
         c.crypto_aead_chacha20poly1305_IETF_NPUBBYTES,
@@ -569,7 +575,7 @@ fn native_aead_chacha_ietf_enc(ctx: *NativeContext, args: []const Value) Runtime
         args,
     );
 }
-fn native_aead_chacha_ietf_dec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_aead_chacha_ietf_dec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return aeadDecrypt(
         c.crypto_aead_chacha20poly1305_IETF_KEYBYTES,
         c.crypto_aead_chacha20poly1305_IETF_NPUBBYTES,
@@ -579,11 +585,11 @@ fn native_aead_chacha_ietf_dec(ctx: *NativeContext, args: []const Value) Runtime
         args,
     );
 }
-fn native_aead_chacha_ietf_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_aead_chacha_ietf_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_aead_chacha20poly1305_IETF_KEYBYTES);
 }
 
-fn native_aead_xchacha_ietf_enc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_aead_xchacha_ietf_enc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return aeadEncrypt(
         c.crypto_aead_xchacha20poly1305_IETF_KEYBYTES,
         c.crypto_aead_xchacha20poly1305_IETF_NPUBBYTES,
@@ -593,7 +599,7 @@ fn native_aead_xchacha_ietf_enc(ctx: *NativeContext, args: []const Value) Runtim
         args,
     );
 }
-fn native_aead_xchacha_ietf_dec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_aead_xchacha_ietf_dec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return aeadDecrypt(
         c.crypto_aead_xchacha20poly1305_IETF_KEYBYTES,
         c.crypto_aead_xchacha20poly1305_IETF_NPUBBYTES,
@@ -603,15 +609,15 @@ fn native_aead_xchacha_ietf_dec(ctx: *NativeContext, args: []const Value) Runtim
         args,
     );
 }
-fn native_aead_xchacha_ietf_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_aead_xchacha_ietf_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_aead_xchacha20poly1305_IETF_KEYBYTES);
 }
 
-fn native_aes256gcm_avail(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_aes256gcm_avail(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    return .{ .bool = c.crypto_aead_aes256gcm_is_available() == 1 };
+    return NativeResult.scalar(.{ .bool = c.crypto_aead_aes256gcm_is_available() == 1 });
 }
-fn native_aes256gcm_enc(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_aes256gcm_enc(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return aeadEncrypt(
         c.crypto_aead_aes256gcm_KEYBYTES,
         c.crypto_aead_aes256gcm_NPUBBYTES,
@@ -621,7 +627,7 @@ fn native_aes256gcm_enc(ctx: *NativeContext, args: []const Value) RuntimeError!V
         args,
     );
 }
-fn native_aes256gcm_dec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_aes256gcm_dec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return aeadDecrypt(
         c.crypto_aead_aes256gcm_KEYBYTES,
         c.crypto_aead_aes256gcm_NPUBBYTES,
@@ -631,36 +637,36 @@ fn native_aes256gcm_dec(ctx: *NativeContext, args: []const Value) RuntimeError!V
         args,
     );
 }
-fn native_aes256gcm_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_aes256gcm_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_aead_aes256gcm_KEYBYTES);
 }
 
-fn native_auth(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_auth(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const msg = args[0].string.bytes();
     const key = args[1].string.bytes();
-    if (key.len != c.crypto_auth_KEYBYTES) return .{ .bool = false };
+    if (key.len != c.crypto_auth_KEYBYTES) return NativeResult.scalar(.{ .bool = false });
     var out: [c.crypto_auth_BYTES]u8 = undefined;
-    if (c.crypto_auth(&out, msg.ptr, msg.len, key.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_auth(&out, msg.ptr, msg.len, key.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, &out);
 }
 
-fn native_auth_verify(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_auth_verify(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const mac = args[0].string.bytes();
     const msg = args[1].string.bytes();
     const key = args[2].string.bytes();
-    if (mac.len != c.crypto_auth_BYTES or key.len != c.crypto_auth_KEYBYTES) return .{ .bool = false };
-    return .{ .bool = c.crypto_auth_verify(mac.ptr, msg.ptr, msg.len, key.ptr) == 0 };
+    if (mac.len != c.crypto_auth_BYTES or key.len != c.crypto_auth_KEYBYTES) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.crypto_auth_verify(mac.ptr, msg.ptr, msg.len, key.ptr) == 0 });
 }
 
-fn native_auth_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_auth_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_auth_KEYBYTES);
 }
 
-fn native_kx_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_kx_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureInit();
     var pk: [c.crypto_kx_PUBLICKEYBYTES]u8 = undefined;
     var sk: [c.crypto_kx_SECRETKEYBYTES]u8 = undefined;
@@ -671,116 +677,116 @@ fn native_kx_keypair(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     return try allocStr(ctx, &out);
 }
 
-fn native_kx_publickey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_kx_publickey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
-    if (kp.len < c.crypto_kx_SECRETKEYBYTES + c.crypto_kx_PUBLICKEYBYTES) return .{ .bool = false };
+    if (kp.len < c.crypto_kx_SECRETKEYBYTES + c.crypto_kx_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, kp[c.crypto_kx_SECRETKEYBYTES..]);
 }
 
-fn native_kx_secretkey(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_kx_secretkey(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
-    if (kp.len < c.crypto_kx_SECRETKEYBYTES) return .{ .bool = false };
+    if (kp.len < c.crypto_kx_SECRETKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, kp[0..c.crypto_kx_SECRETKEYBYTES]);
 }
 
-fn native_kx_client_session_keys(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_kx_client_session_keys(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
     const server_pk = args[1].string.bytes();
-    if (kp.len != c.crypto_kx_SECRETKEYBYTES + c.crypto_kx_PUBLICKEYBYTES) return .{ .bool = false };
-    if (server_pk.len != c.crypto_kx_PUBLICKEYBYTES) return .{ .bool = false };
+    if (kp.len != c.crypto_kx_SECRETKEYBYTES + c.crypto_kx_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
+    if (server_pk.len != c.crypto_kx_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     var rx: [c.crypto_kx_SESSIONKEYBYTES]u8 = undefined;
     var tx: [c.crypto_kx_SESSIONKEYBYTES]u8 = undefined;
-    if (c.crypto_kx_client_session_keys(&rx, &tx, kp[c.crypto_kx_SECRETKEYBYTES..].ptr, kp[0..c.crypto_kx_SECRETKEYBYTES].ptr, server_pk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_kx_client_session_keys(&rx, &tx, kp[c.crypto_kx_SECRETKEYBYTES..].ptr, kp[0..c.crypto_kx_SECRETKEYBYTES].ptr, server_pk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
-    try arr.set(ctx.allocator, .{ .int = 0 }, try allocStr(ctx, &rx));
-    try arr.set(ctx.allocator, .{ .int = 1 }, try allocStr(ctx, &tx));
-    return .{ .array = arr };
+    try setOwnedString(ctx, arr, 0, &rx);
+    try setOwnedString(ctx, arr, 1, &tx);
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_kx_server_session_keys(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_kx_server_session_keys(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const kp = args[0].string.bytes();
     const client_pk = args[1].string.bytes();
-    if (kp.len != c.crypto_kx_SECRETKEYBYTES + c.crypto_kx_PUBLICKEYBYTES) return .{ .bool = false };
-    if (client_pk.len != c.crypto_kx_PUBLICKEYBYTES) return .{ .bool = false };
+    if (kp.len != c.crypto_kx_SECRETKEYBYTES + c.crypto_kx_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
+    if (client_pk.len != c.crypto_kx_PUBLICKEYBYTES) return NativeResult.scalar(.{ .bool = false });
     var rx: [c.crypto_kx_SESSIONKEYBYTES]u8 = undefined;
     var tx: [c.crypto_kx_SESSIONKEYBYTES]u8 = undefined;
-    if (c.crypto_kx_server_session_keys(&rx, &tx, kp[c.crypto_kx_SECRETKEYBYTES..].ptr, kp[0..c.crypto_kx_SECRETKEYBYTES].ptr, client_pk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_kx_server_session_keys(&rx, &tx, kp[c.crypto_kx_SECRETKEYBYTES..].ptr, kp[0..c.crypto_kx_SECRETKEYBYTES].ptr, client_pk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
-    try arr.set(ctx.allocator, .{ .int = 0 }, try allocStr(ctx, &rx));
-    try arr.set(ctx.allocator, .{ .int = 1 }, try allocStr(ctx, &tx));
-    return .{ .array = arr };
+    try setOwnedString(ctx, arr, 0, &rx);
+    try setOwnedString(ctx, arr, 1, &tx);
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_scalarmult(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_scalarmult(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const sk = args[0].string.bytes();
     const pk = args[1].string.bytes();
-    if (sk.len != c.crypto_scalarmult_SCALARBYTES or pk.len != c.crypto_scalarmult_BYTES) return .{ .bool = false };
+    if (sk.len != c.crypto_scalarmult_SCALARBYTES or pk.len != c.crypto_scalarmult_BYTES) return NativeResult.scalar(.{ .bool = false });
     var out: [c.crypto_scalarmult_BYTES]u8 = undefined;
-    if (c.crypto_scalarmult(&out, sk.ptr, pk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_scalarmult(&out, sk.ptr, pk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, &out);
 }
 
-fn native_scalarmult_base(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_scalarmult_base(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const sk = args[0].string.bytes();
-    if (sk.len != c.crypto_scalarmult_SCALARBYTES) return .{ .bool = false };
+    if (sk.len != c.crypto_scalarmult_SCALARBYTES) return NativeResult.scalar(.{ .bool = false });
     var out: [c.crypto_scalarmult_BYTES]u8 = undefined;
-    if (c.crypto_scalarmult_base(&out, sk.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_scalarmult_base(&out, sk.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, &out);
 }
 
-fn native_kdf_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_kdf_keygen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return try keygen(ctx, c.crypto_kdf_KEYBYTES);
 }
 
-fn native_kdf_derive(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_kdf_derive(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 4 or args[0] != .int or args[1] != .int or args[2] != .string or args[3] != .string) return .{ .bool = false };
+    if (args.len < 4 or args[0] != .int or args[1] != .int or args[2] != .string or args[3] != .string) return NativeResult.scalar(.{ .bool = false });
     const out_len: usize = @intCast(args[0].int);
     const subkey_id: u64 = @intCast(args[1].int);
     const context = args[2].string.bytes();
     const key = args[3].string.bytes();
     if (key.len != c.crypto_kdf_KEYBYTES) {
         try ctx.vm.setPendingException("SodiumException", "sodium_crypto_kdf_derive_from_key(): Argument #4 ($key) must be SODIUM_CRYPTO_KDF_KEYBYTES bytes long");
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     if (context.len != c.crypto_kdf_CONTEXTBYTES) {
         try ctx.vm.setPendingException("SodiumException", "sodium_crypto_kdf_derive_from_key(): Argument #3 ($context) must be SODIUM_CRYPTO_KDF_CONTEXTBYTES bytes long");
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     var ctx_buf: [c.crypto_kdf_CONTEXTBYTES]u8 = undefined;
     @memcpy(&ctx_buf, context[0..c.crypto_kdf_CONTEXTBYTES]);
     const out = try ctx.allocator.alloc(u8, out_len);
     defer ctx.allocator.free(out);
-    if (c.crypto_kdf_derive_from_key(out.ptr, out.len, subkey_id, &ctx_buf, key.ptr) != 0) return .{ .bool = false };
+    if (c.crypto_kdf_derive_from_key(out.ptr, out.len, subkey_id, &ctx_buf, key.ptr) != 0) return NativeResult.scalar(.{ .bool = false });
     return try allocStr(ctx, out);
 }
 
-fn native_randombytes_buf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_randombytes_buf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .int) return .{ .string = Value.String.borrowed("") };
+    if (args.len < 1 or args[0] != .int) return NativeResult.literal("");
     const n: usize = @intCast(args[0].int);
     return try keygen(ctx, n);
 }
 
-fn native_randombytes_random16(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_randombytes_random16(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    return .{ .int = @intCast(c.randombytes_random()) };
+    return NativeResult.scalar(.{ .int = @intCast(c.randombytes_random()) });
 }
 
-fn native_randombytes_uniform(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_randombytes_uniform(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureInit();
-    if (args.len < 1 or args[0] != .int) return .{ .int = 0 };
-    return .{ .int = @intCast(c.randombytes_uniform(@intCast(args[0].int))) };
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(c.randombytes_uniform(@intCast(args[0].int))) });
 }
 
 test {}

--- a/src/stdlib/spl.zig
+++ b/src/stdlib/spl.zig
@@ -4,6 +4,7 @@ const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
 const VM = vm_mod.VM;
+const NativeResult = vm_mod.NativeResult;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 
@@ -645,60 +646,60 @@ fn wmiCursorObj(this: *PhpObject) ?*PhpObject {
     return v.object;
 }
 
-fn wmiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const target = wmiCursorObj(this) orelse return .null;
+fn wmiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const target = wmiCursorObj(this) orelse return NativeResult.scalar(.null);
     const info_v = this.get("__info");
-    if (info_v != .array) return .null;
-    return retainReturned(info_v.array.get(.{ .int = sosObjKey(target) }));
+    if (info_v != .array) return NativeResult.scalar(.null);
+    return NativeResult.share(info_v.array.get(.{ .int = sosObjKey(target) }));
 }
 
-fn wmiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const target = wmiCursorObj(this) orelse return .null;
-    return .{ .object = target };
+fn wmiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const target = wmiCursorObj(this) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .object = target });
 }
 
-fn wmiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn wmiNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur = Value.toInt(this.get("__cursor"));
     try this.set(ctx.allocator, "__cursor", .{ .int = cur + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn wmiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn wmiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     try this.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn wmiValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
+fn wmiValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const objs_v = this.get("__objs");
-    if (objs_v != .array) return .{ .bool = false };
+    if (objs_v != .array) return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(this.get("__cursor"));
-    return .{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(objs_v.array.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(objs_v.array.entries.items.len)) });
 }
 
 // =========================================================
 // WeakReference
 // =========================================================
 
-fn weakRefCreate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .null;
+fn weakRefCreate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
     const ref = try ctx.vm.allocator.create(PhpObject);
     ref.* = .{ .class_name = "WeakReference" };
     try ctx.vm.objects.append(ctx.vm.allocator, ref);
     try ref.set(ctx.vm.allocator, "__target", args[0]);
-    return .{ .object = ref };
+    return NativeResult.borrowed(.{ .object = ref });
 }
 
-fn weakRefGet(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    return retainReturned(this.get("__target"));
+fn weakRefGet(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("__target"));
 }
 
-fn weakRefConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn weakRefConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     try ctx.vm.setPendingException("Error", "Cannot directly construct WeakReference, use WeakReference::create() instead");
     return error.RuntimeError;
 }
@@ -707,8 +708,8 @@ fn weakRefConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 // WeakMap
 // =========================================================
 
-fn weakMapGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn weakMapGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const keys_v = obj.get("__keys");
     const data_v = obj.get("__data");
     const iter = try ctx.vm.allocator.create(PhpObject);
@@ -717,7 +718,7 @@ fn weakMapGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value 
     if (keys_v == .array) try iter.set(ctx.allocator, "__objs", keys_v);
     if (data_v == .array) try iter.set(ctx.allocator, "__info", data_v);
     try iter.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .{ .object = iter };
+    return NativeResult.borrowed(.{ .object = iter });
 }
 
 fn getThis(ctx: *NativeContext) ?*PhpObject {
@@ -743,68 +744,68 @@ fn ensureData(ctx: *NativeContext, obj: *PhpObject) !*PhpArray {
 
 // --- SplStack ---
 
-fn stackConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stackConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = try ensureData(ctx, obj);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try obj.set(ctx.allocator, "__it_mode", .{ .int = DLL_IT_MODE_LIFO | DLL_IT_MODE_KEEP | 4 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stackPush(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stackPush(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
     if (args.len >= 1) try arr.append(ctx.allocator, args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stackPop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn stackPop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
     const last = arr.entries.items[arr.entries.items.len - 1].value;
     arr.entries.items.len -= 1;
-    return last;
+    return if (last == .string and last.string.owner != null) NativeResult.takeString(last.string) else NativeResult.share(last);
 }
 
-fn stackTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn stackTop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[arr.entries.items.len - 1].value);
+    return NativeResult.share(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
-fn stackBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn stackBottom(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[0].value);
+    return NativeResult.share(arr.entries.items[0].value);
 }
 
-fn stackCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = arr.length() };
+fn stackCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = arr.length() });
 }
 
-fn stackIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = true };
-    const arr = getData(obj) orelse return .{ .bool = true };
-    return .{ .bool = arr.entries.items.len == 0 };
+fn stackIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = arr.entries.items.len == 0 });
 }
 
-fn stackShift(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn stackShift(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
@@ -812,70 +813,69 @@ fn stackShift(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const first = arr.entries.items[0].value;
     std.mem.copyForwards(PhpArray.Entry, arr.entries.items[0 .. arr.entries.items.len - 1], arr.entries.items[1..arr.entries.items.len]);
     arr.entries.items.len -= 1;
-    return first;
+    return if (first == .string and first.string.owner != null) NativeResult.takeString(first.string) else NativeResult.share(first);
 }
 
-fn stackUnshift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stackUnshift(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len == 0) return .null;
+    if (args.len == 0) return NativeResult.scalar(.null);
     try arr.entries.insert(ctx.allocator, 0, .{ .key = .{ .int = 0 }, .value = args[0] });
-    return .null;
+    VM.retainValue(args[0]);
+    return NativeResult.scalar(.null);
 }
 
 // iterator: SplStack iterates in LIFO order (top to bottom)
-fn stackRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stackRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = getData(obj) orelse {
         try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-        return .null;
+        return NativeResult.scalar(.null);
     };
     // cursor starts at end (top of stack)
     try obj.set(ctx.allocator, "__cursor", .{ .int = @as(i64, @intCast(arr.entries.items.len)) - 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stackCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn stackCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
-    if (cursor < 0 or cursor >= arr.length()) return .{ .bool = false };
-    return retainReturned(arr.entries.items[@intCast(cursor)].value);
+    if (cursor < 0 or cursor >= arr.length()) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(arr.entries.items[@intCast(cursor)].value);
 }
 
-fn stackKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn stackKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
     const len = arr.length();
-    if (cursor < 0 or cursor >= len) return .null;
+    if (cursor < 0 or cursor >= len) return NativeResult.scalar(.null);
     // key is the underlying array index (the cursor itself). PHP's LIFO
     // iteration starts with the top element's original push position (len-1)
     // and counts down to 0 as the cursor decreases
-    return .{ .int = cursor };
+    return NativeResult.scalar(.{ .int = cursor });
 }
 
-fn stackNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stackNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
     try obj.set(ctx.allocator, "__cursor", .{ .int = cursor - 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stackValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn stackValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    return .{ .bool = cursor >= 0 and cursor < arr.length() };
+    return NativeResult.scalar(.{ .bool = cursor >= 0 and cursor < arr.length() });
 }
 
-fn stackToArray(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stackToArray(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = getData(obj) orelse {
-        const empty = try ctx.allocator.create(PhpArray);
-        empty.* = .{};
-        try ctx.vm.arrays.append(ctx.allocator, empty);
-        return .{ .array = empty };
+        const empty = try ctx.createArray();
+        return NativeResult.borrowed(.{ .array = empty });
     };
     // return a copy in LIFO order
     const copy = try ctx.allocator.create(PhpArray);
@@ -888,19 +888,19 @@ fn stackToArray(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try copy.set(ctx.allocator, .{ .int = key }, arr.entries.items[i].value);
         key += 1;
     }
-    return .{ .array = copy };
+    return NativeResult.borrowed(.{ .array = copy });
 }
 
 // --- ArrayObject ---
 
-fn aoSerializeState(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoSerializeState(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (obj.get("__data") == .null) _ = try ensureData(ctx, obj);
     return @import("serialize.zig").splArrayState(ctx, obj);
 }
 
-fn aoUnserializeState(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoUnserializeState(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len == 0 or args[0] != .array) {
         try ctx.vm.setPendingException("TypeError", "__unserialize(): Argument #1 ($data) must be of type array");
         return error.RuntimeError;
@@ -908,14 +908,14 @@ fn aoUnserializeState(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     return @import("serialize.zig").restoreSplArrayState(ctx, obj, args[0]);
 }
 
-fn aoSerialize(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoSerialize(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (obj.get("__data") == .null) _ = try ensureData(ctx, obj);
     return @import("serialize.zig").serializeSplArray(ctx, obj);
 }
 
-fn aoUnserialize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoUnserialize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len == 0 or args[0] != .string) {
         try ctx.vm.setPendingException("TypeError", "unserialize(): Argument #1 ($data) must be of type string");
         return error.RuntimeError;
@@ -923,8 +923,8 @@ fn aoUnserialize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return @import("serialize.zig").unserializeSplArray(ctx, obj, args[0].string.bytes());
 }
 
-fn aoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and (args[0] == .array or args[0] == .object)) {
         try obj.set(ctx.allocator, "__data", args[0]);
     } else {
@@ -935,113 +935,113 @@ fn aoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (args.len >= 3 and args[2] == .string) {
         try obj.set(ctx.allocator, "__iter_class", args[2]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoMagicGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0) return .null;
+fn aoMagicGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const flags = obj.get("__flags");
     const has_props = flags == .int and (flags.int & 2) != 0; // ArrayObject::ARRAY_AS_PROPS
-    if (!has_props) return .null;
-    const arr = getData(obj) orelse return .null;
-    return retainReturned(arr.get(args[0].toArrayKey()));
+    if (!has_props) return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(arr.get(args[0].toArrayKey()));
 }
 
-fn aoMagicSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 2) return .null;
+fn aoMagicSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.scalar(.null);
     const flags = obj.get("__flags");
     const has_props = flags == .int and (flags.int & 2) != 0;
     if (!has_props) {
         try obj.set(ctx.allocator, args[0].string.bytes(), args[1]);
-        return .null;
+        return NativeResult.scalar(.null);
     }
     const arr = try ensureData(ctx, obj);
     try arr.set(ctx.allocator, args[0].toArrayKey(), args[1]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoMagicIsset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len == 0) return .{ .bool = false };
+fn aoMagicIsset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const flags = obj.get("__flags");
     const has_props = flags == .int and (flags.int & 2) != 0;
-    if (!has_props) return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+    if (!has_props) return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const v = arr.get(args[0].toArrayKey());
-    return .{ .bool = v != .null };
+    return NativeResult.scalar(.{ .bool = v != .null });
 }
 
-fn aoMagicUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0) return .null;
+fn aoMagicUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const flags = obj.get("__flags");
     const has_props = flags == .int and (flags.int & 2) != 0;
-    if (!has_props) return .null;
-    const arr = getData(obj) orelse return .null;
+    if (!has_props) return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const key = args[0].toArrayKey();
     ctx.vm.arrayRemoveOwned(arr, key);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0 and obj.get("__data") == .object and args[0] == .string)
-        return retainReturned(obj.get("__data").object.get(args[0].string.bytes()));
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
-    return retainReturned(arr.get(args[0].toArrayKey()));
+        return NativeResult.share(obj.get("__data").object.get(args[0].string.bytes()));
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
+    return NativeResult.share(arr.get(args[0].toArrayKey()));
 }
 
-fn aoOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len < 2) return .null;
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (args[0] == .null) {
         try arr.append(ctx.allocator, args[1]);
     } else {
         detachSplReference(ctx, arr, args[0].toArrayKey());
         try arr.set(ctx.allocator, args[0].toArrayKey(), args[1]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len == 0) return .{ .bool = false };
+fn aoOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const key = args[0].toArrayKey();
     for (arr.entries.items) |entry| {
-        if (entry.key.eql(key)) return .{ .bool = true };
+        if (entry.key.eql(key)) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn aoOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn aoOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const key = args[0].toArrayKey();
     ctx.vm.arrayRemoveOwned(arr, key);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = arr.length() };
+fn aoCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = arr.length() });
 }
 
-fn aoAppend(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoAppend(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
     if (args.len >= 1) try arr.append(ctx.allocator, args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (obj.get("__data") == .object) {
         const storage = obj.get("__data").object;
         const copy = try ctx.createArray();
@@ -1052,148 +1052,143 @@ fn aoGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         }
         var it = storage.properties.iterator();
         while (it.next()) |entry| try copy.set(ctx.allocator, .{ .string = Value.String.borrowed(entry.key_ptr.*) }, entry.value_ptr.*);
-        return .{ .array = copy };
+        return NativeResult.borrowed(.{ .array = copy });
     }
     const arr = getData(obj) orelse {
-        const empty = try ctx.allocator.create(PhpArray);
-        empty.* = .{};
-        try ctx.vm.arrays.append(ctx.allocator, empty);
-        return .{ .array = empty };
+        const empty = try ctx.createArray();
+        return NativeResult.borrowed(.{ .array = empty });
     };
     // independent deep snapshot: ArrayObject mutates its internal array in place,
     // and under COW a shallow copy would share nested arrays with it (a later
     // $ao[k][..]=v would leak into this copy). a deep clone isolates the snapshot,
     // matching PHP's copy-on-write independence
-    return .{ .array = try ctx.vm.cloneArray(arr) };
+    return NativeResult.borrowed(.{ .array = try ctx.vm.cloneArray(arr) });
 }
 
-fn aoKsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aoKsort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortKeysWithFlags(arr, flags, false);
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoKrsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aoKrsort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortKeysWithFlags(arr, flags, true);
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoAsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aoAsort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortWithFlags(arr, flags, false);
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoArsort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aoArsort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     arrays_mod.sortWithFlags(arr, flags, true);
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoUasort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
+fn aoUasort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     try arrays_mod.mergeSort(PhpArray.Entry, arr.entries.items, ctx, args[0], .value);
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoUksort(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
+fn aoUksort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     try arrays_mod.mergeSort(PhpArray.Entry, arr.entries.items, ctx, args[0], .key);
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoNatsort(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aoNatsort(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     arrays_mod.sortWithFlags(arr, 6, false); // SORT_NATURAL
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoNatcasesort(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aoNatcasesort(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     arrays_mod.sortWithFlags(arr, 6 | 8, false); // SORT_NATURAL | SORT_FLAG_CASE
     arr.rebuildStringIndexAssumeCapacity();
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn aoExchangeArray(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1 or args[0] != .array) return .{ .bool = false };
+fn aoExchangeArray(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const old = getData(obj);
     const old_copy = try ctx.createArray();
     if (old) |o| {
         for (o.entries.items) |e| try old_copy.set(ctx.allocator, e.key, e.value);
     }
     try obj.set(ctx.allocator, "__data", .{ .array = args[0].array });
-    return .{ .array = old_copy };
+    return NativeResult.borrowed(.{ .array = old_copy });
 }
 
-fn aoSetIteratorClass(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoSetIteratorClass(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and args[0] == .string) {
         try obj.set(ctx.allocator, "__iter_class", .{ .string = args[0].string });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn aoGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const ic = obj.get("__iter_class");
     const cls_name = if (ic == .string and ic.string.bytes().len > 0) ic.string.bytes() else "ArrayIterator";
-    const it = try ctx.allocator.create(PhpObject);
-    it.* = .{ .class_name = cls_name };
-    try ctx.vm.objects.append(ctx.allocator, it);
-    try ctx.vm.initObjectProperties(it, cls_name);
+    const it = try ctx.createObject(cls_name);
     try it.set(ctx.allocator, "__data", .{ .array = arr });
     try it.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try it.set(ctx.allocator, "__flags", .{ .int = 0 });
-    return .{ .object = it };
+    return NativeResult.borrowed(.{ .object = it });
 }
 
-fn aoGetIteratorClass(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("ArrayIterator") };
+fn aoGetIteratorClass(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("ArrayIterator");
     const ic = obj.get("__iter_class");
-    if (ic == .string and ic.string.bytes().len > 0) return ic;
-    return .{ .string = Value.String.borrowed("ArrayIterator") };
+    if (ic == .string and ic.string.bytes().len > 0) return NativeResult.shareString(ic.string);
+    return NativeResult.literal("ArrayIterator");
 }
 
-fn aoSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aoSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1) try obj.set(ctx.allocator, "__flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aoGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = Value.toInt(obj.get("__flags")) };
+fn aoGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = Value.toInt(obj.get("__flags")) });
 }
 
 // --- ArrayIterator ---
 
-fn aiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and (args[0] == .array or args[0] == .object)) {
         try obj.set(ctx.allocator, "__data", args[0]);
     } else {
@@ -1201,112 +1196,111 @@ fn aiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try obj.set(ctx.allocator, "__flags", .{ .int = if (args.len >= 2) args[1].toInt() else 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
-    if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return retainReturned(arr.entries.items[cursor].value);
+    if (cursor >= arr.entries.items.len) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(arr.entries.items[cursor].value);
 }
 
-fn aiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn aiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
-    if (cursor >= arr.entries.items.len) return .null;
+    if (cursor >= arr.entries.items.len) return NativeResult.scalar(.null);
     const key = arr.entries.items[cursor].key;
-    if (key == .string) key.string.retain();
     return switch (key) {
-        .int => |i| .{ .int = i },
-        .string => |s| .{ .string = s },
+        .int => |i| NativeResult.scalar(.{ .int = i }),
+        .string => |value| NativeResult.shareString(value),
     };
 }
 
-fn aiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
     try obj.set(ctx.allocator, "__cursor", .{ .int = cursor + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aiValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn aiValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    return .{ .bool = cursor >= 0 and cursor < arr.length() };
+    return NativeResult.scalar(.{ .bool = cursor >= 0 and cursor < arr.length() });
 }
 
-fn aiSeek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn aiSeek(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const pos = if (args.len >= 1) Value.toInt(args[0]) else 0;
     if (pos < 0 or pos >= arr.length()) {
         try ctx.vm.setPendingException("OutOfBoundsException", "Seek position is out of range");
         return error.RuntimeError;
     }
     try obj.set(ctx.allocator, "__cursor", .{ .int = pos });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aiCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = arr.length() };
+fn aiCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = arr.length() });
 }
 
-fn aiOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len > 0 and obj.get("__data") == .object and args[0] == .string)
-        return retainReturned(obj.get("__data").object.get(args[0].string.bytes()));
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
-    return retainReturned(arr.get(args[0].toArrayKey()));
+        return NativeResult.share(obj.get("__data").object.get(args[0].string.bytes()));
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
+    return NativeResult.share(arr.get(args[0].toArrayKey()));
 }
 
-fn aiOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len < 2) return .null;
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (args[0] == .null) {
         try arr.append(ctx.allocator, args[1]);
     } else {
         detachSplReference(ctx, arr, args[0].toArrayKey());
         try arr.set(ctx.allocator, args[0].toArrayKey(), args[1]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aiOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len == 0) return .{ .bool = false };
+fn aiOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const key = args[0].toArrayKey();
     for (arr.entries.items) |entry| {
-        if (entry.key.eql(key)) return .{ .bool = true };
+        if (entry.key.eql(key)) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn aiOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn aiOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const key = args[0].toArrayKey();
     ctx.vm.arrayRemoveOwned(arr, key);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aiGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (obj.get("__data") == .object) {
         const storage = obj.get("__data").object;
         const copy = try ctx.createArray();
@@ -1317,35 +1311,33 @@ fn aiGetArrayCopy(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         }
         var it = storage.properties.iterator();
         while (it.next()) |entry| try copy.set(ctx.allocator, .{ .string = Value.String.borrowed(entry.key_ptr.*) }, entry.value_ptr.*);
-        return .{ .array = copy };
+        return NativeResult.borrowed(.{ .array = copy });
     }
     const arr = getData(obj) orelse {
-        const empty = try ctx.allocator.create(PhpArray);
-        empty.* = .{};
-        try ctx.vm.arrays.append(ctx.allocator, empty);
-        return .{ .array = empty };
+        const empty = try ctx.createArray();
+        return NativeResult.borrowed(.{ .array = empty });
     };
     // independent deep snapshot (see aoGetArrayCopy) - avoids nested-array COW
     // sharing with the iterator's mutable internal array
-    return .{ .array = try ctx.vm.cloneArray(arr) };
+    return NativeResult.borrowed(.{ .array = try ctx.vm.cloneArray(arr) });
 }
 
-fn aiAppend(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiAppend(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
     if (args.len >= 1) try arr.append(ctx.allocator, args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn aiGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = Value.toInt(obj.get("__flags")) };
+fn aiGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = Value.toInt(obj.get("__flags")) });
 }
 
-fn aiSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn aiSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1) try obj.set(ctx.allocator, "__flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // --- WeakMap ---
@@ -1355,50 +1347,49 @@ fn wmObjKey(arg: Value) ?i64 {
     return null;
 }
 
-fn wmConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn wmConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = try ensureData(ctx, obj);
     // __keys parallel-tracks the object references in insertion order so that
     // iteration can yield real object keys (the int-keyed __data only has pointers)
     if (obj.get("__keys") != .array) {
-        const keys = try ctx.allocator.create(PhpArray);
-        keys.* = .{ .weak = true };
-        try ctx.vm.arrays.append(ctx.allocator, keys);
+        const keys = try ctx.createArray();
+        keys.weak = true;
         try obj.set(ctx.allocator, "__keys", .{ .array = keys });
     }
     // register for weak-key cleanup on object destruct
     try ctx.vm.weakmaps.append(ctx.allocator, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn wmOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len == 0) return .{ .bool = false };
-    const key = wmObjKey(args[0]) orelse return .{ .bool = false };
+fn wmOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const key = wmObjKey(args[0]) orelse return NativeResult.scalar(.{ .bool = false });
     const k = PhpArray.Key{ .int = key };
-    return .{ .bool = arr.get(k) != .null };
+    return NativeResult.scalar(.{ .bool = arr.get(k) != .null });
 }
 
-fn wmOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
-    const key = wmObjKey(args[0]) orelse return .null;
-    return retainReturned(arr.get(.{ .int = key }));
+fn wmOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const key = wmObjKey(args[0]) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(arr.get(.{ .int = key }));
 }
 
-fn wmOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn wmOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len < 2) return .null;
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (args[0] != .object) {
         try ctx.vm.setPendingException("TypeError", "WeakMap key must be an object");
         return error.RuntimeError;
     }
-    const key = wmObjKey(args[0]) orelse return .null;
+    const key = wmObjKey(args[0]) orelse return NativeResult.scalar(.null);
     const is_new = arr.get(.{ .int = key }) == .null;
-    try arr.set(ctx.allocator, .{ .int = key }, args[1]);
+    try ctx.vm.arraySetOwned(arr, .{ .int = key }, args[1]);
     if (is_new and args[0] == .object) {
         const keys_v = obj.get("__keys");
         // __keys is a weak array: appending takes no reference, and the
@@ -1406,14 +1397,14 @@ fn wmOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         // when the key object becomes unreachable
         if (keys_v == .array) try keys_v.array.append(ctx.allocator, args[0]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn wmOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
-    const key = wmObjKey(args[0]) orelse return .null;
+fn wmOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const key = wmObjKey(args[0]) orelse return NativeResult.scalar(.null);
     ctx.vm.arrayRemoveOwned(arr, .{ .int = key });
     if (args[0] == .object) {
         const keys_v = obj.get("__keys");
@@ -1427,13 +1418,13 @@ fn wmOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn wmCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(arr.entries.items.len) };
+fn wmCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(arr.entries.items.len) });
 }
 
 // --- SplPriorityQueue ---
@@ -1443,12 +1434,12 @@ const EXTR_DATA: i64 = 1;
 const EXTR_PRIORITY: i64 = 2;
 const EXTR_BOTH: i64 = 3;
 
-fn pqConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pqConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = try ensureData(ctx, obj);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try obj.set(ctx.allocator, "__flags", .{ .int = EXTR_DATA });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // SplPriorityQueue stores pairs as a binary max-heap. element at index i has
@@ -1512,10 +1503,10 @@ fn pqSiftDown(ctx: *NativeContext, obj: *PhpObject, arr: *PhpArray, start: usize
     }
 }
 
-fn pqInsert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pqInsert(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len < 2) return .null;
+    if (args.len < 2) return NativeResult.scalar(.null);
     const pair = try ctx.allocator.create(PhpArray);
     pair.* = .{};
     try ctx.vm.arrays.append(ctx.allocator, pair);
@@ -1525,11 +1516,11 @@ fn pqInsert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const new_idx = arr.entries.items.len;
     try arr.entries.append(ctx.allocator, .{ .key = .{ .int = @intCast(new_idx) }, .value = .{ .array = pair } });
     try pqSiftUp(ctx, obj, arr, new_idx);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn pqExtractValue(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
-    const arr = getData(obj) orelse return .null;
+fn pqExtractValue(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
@@ -1544,30 +1535,28 @@ fn pqExtractValue(ctx: *NativeContext, obj: *PhpObject) RuntimeError!Value {
     return pqFormatEntry(ctx, obj, top);
 }
 
-fn pqFormatEntry(ctx: *NativeContext, obj: *PhpObject, entry: Value) Value {
+fn pqFormatEntry(ctx: *NativeContext, obj: *PhpObject, entry: Value) RuntimeError!NativeResult {
     const flags = Value.toInt(obj.get("__flags"));
-    if (entry != .array) return entry;
+    if (entry != .array) return NativeResult.share(entry);
     const pair = entry.array;
-    if (flags == EXTR_PRIORITY) return retainReturned(pair.get(.{ .int = 1 }));
+    if (flags == EXTR_PRIORITY) return NativeResult.share(pair.get(.{ .int = 1 }));
     if (flags == EXTR_BOTH) {
-        const result = ctx.allocator.create(PhpArray) catch return entry;
-        result.* = .{};
-        ctx.vm.arrays.append(ctx.allocator, result) catch return entry;
-        result.set(ctx.allocator, .{ .string = Value.String.borrowed("data") }, pair.get(.{ .int = 0 })) catch return entry;
-        result.set(ctx.allocator, .{ .string = Value.String.borrowed("priority") }, pair.get(.{ .int = 1 })) catch return entry;
-        return .{ .array = result };
+        const result = try ctx.createArray();
+        try result.set(ctx.allocator, .{ .string = Value.String.borrowed("data") }, pair.get(.{ .int = 0 }));
+        try result.set(ctx.allocator, .{ .string = Value.String.borrowed("priority") }, pair.get(.{ .int = 1 }));
+        return NativeResult.borrowed(.{ .array = result });
     }
-    return retainReturned(pair.get(.{ .int = 0 }));
+    return NativeResult.share(pair.get(.{ .int = 0 }));
 }
 
-fn pqExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pqExtract(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     return pqExtractValue(ctx, obj);
 }
 
-fn pqTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn pqTop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
@@ -1575,70 +1564,71 @@ fn pqTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     return pqFormatEntry(ctx, obj, arr.entries.items[0].value);
 }
 
-fn pqCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(arr.entries.items.len) };
+fn pqCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(arr.entries.items.len) });
 }
 
-fn pqIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = true };
-    const arr = getData(obj) orelse return .{ .bool = true };
-    return .{ .bool = arr.entries.items.len == 0 };
+fn pqIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = arr.entries.items.len == 0 });
 }
 
-fn pqSetExtractFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn pqSetExtractFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1) try obj.set(ctx.allocator, "__flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // pq iteration is destructive: current = top, next = extract, key = remaining-1
-fn pqCurrent(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn pqCurrent(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return pqTop(ctx, args);
 }
 
-fn pqKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn pqKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return .{ .int = @intCast(arr.entries.items.len - 1) };
+    return NativeResult.scalar(.{ .int = @intCast(arr.entries.items.len - 1) });
 }
 
-fn pqNext(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    _ = try pqExtract(ctx, args);
-    return .null;
+fn pqNext(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const discarded = try pqExtract(ctx, args);
+    if (discarded.value == .string) discarded.value.string.release();
+    return NativeResult.scalar(.null);
 }
 
-fn pqRewind(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn pqRewind(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn pqValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    return .{ .bool = arr.entries.items.len > 0 };
+fn pqValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = arr.entries.items.len > 0 });
 }
 
 // --- SplMinHeap / SplMaxHeap ---
 // stored as flat array in __data, heap-ordered
 
-fn heapConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn heapConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = try ensureData(ctx, obj);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn heapInsert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn heapInsert(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len == 0) return .null;
+    if (args.len == 0) return NativeResult.scalar(.null);
     try arr.append(ctx.allocator, args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn findMinIdx(arr: *PhpArray) ?usize {
@@ -1659,11 +1649,11 @@ fn findMaxIdx(arr: *PhpArray) ?usize {
     return best;
 }
 
-fn heapRemoveAt(arr: *PhpArray, idx: usize) Value {
+fn heapRemoveAt(arr: *PhpArray, idx: usize) NativeResult {
     const val = arr.entries.items[idx].value;
     std.mem.copyForwards(PhpArray.Entry, arr.entries.items[idx .. arr.entries.items.len - 1], arr.entries.items[idx + 1 .. arr.entries.items.len]);
     arr.entries.items.len -= 1;
-    return val;
+    return if (val == .string and val.string.owner != null) NativeResult.takeString(val.string) else NativeResult.share(val);
 }
 
 fn findUserBestIdx(ctx: *NativeContext, obj: *PhpObject, arr: *PhpArray) !?usize {
@@ -1677,23 +1667,23 @@ fn findUserBestIdx(ctx: *NativeContext, obj: *PhpObject, arr: *PhpArray) !?usize
     return best;
 }
 
-fn userHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    const idx = (findUserBestIdx(ctx, obj, arr) catch return .null) orelse return .null;
+fn userHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    const idx = (findUserBestIdx(ctx, obj, arr) catch return NativeResult.scalar(.null)) orelse return NativeResult.scalar(.null);
     return heapRemoveAt(arr, idx);
 }
 
-fn userHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    const idx = (findUserBestIdx(ctx, obj, arr) catch return .null) orelse return .null;
-    return retainReturned(arr.entries.items[idx].value);
+fn userHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    const idx = (findUserBestIdx(ctx, obj, arr) catch return NativeResult.scalar(.null)) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(arr.entries.items[idx].value);
 }
 
-fn minHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn minHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const idx = findMinIdx(arr) orelse {
         try ctx.vm.setPendingException("RuntimeException", "Can't extract from an empty heap");
         return error.RuntimeError;
@@ -1701,19 +1691,19 @@ fn minHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     return heapRemoveAt(arr, idx);
 }
 
-fn minHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn minHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const idx = findMinIdx(arr) orelse {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty heap");
         return error.RuntimeError;
     };
-    return retainReturned(arr.entries.items[idx].value);
+    return NativeResult.share(arr.entries.items[idx].value);
 }
 
-fn maxHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn maxHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const idx = findMaxIdx(arr) orelse {
         try ctx.vm.setPendingException("RuntimeException", "Can't extract from an empty heap");
         return error.RuntimeError;
@@ -1721,69 +1711,69 @@ fn maxHeapExtract(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     return heapRemoveAt(arr, idx);
 }
 
-fn maxHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn maxHeapTop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const idx = findMaxIdx(arr) orelse {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty heap");
         return error.RuntimeError;
     };
-    return retainReturned(arr.entries.items[idx].value);
+    return NativeResult.share(arr.entries.items[idx].value);
 }
 
-fn heapCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(arr.entries.items.len) };
+fn heapCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(arr.entries.items.len) });
 }
 
-fn heapIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = true };
-    const arr = getData(obj) orelse return .{ .bool = true };
-    return .{ .bool = arr.entries.items.len == 0 };
+fn heapIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = arr.entries.items.len == 0 });
 }
 
-fn heapCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn heapCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
-    if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return retainReturned(arr.entries.items[cursor].value);
+    if (cursor >= arr.entries.items.len) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(arr.entries.items[cursor].value);
 }
 
-fn heapKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn heapKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return .{ .int = @intCast(arr.entries.items.len - 1) };
+    return NativeResult.scalar(.{ .int = @intCast(arr.entries.items.len - 1) });
 }
 
-fn heapNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn heapNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
     try obj.set(ctx.allocator, "__cursor", .{ .int = cursor + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn heapRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn heapRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn heapValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    return .{ .bool = arr.entries.items.len > 0 };
+fn heapValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = arr.entries.items.len > 0 });
 }
 
 // --- SplFixedArray ---
 
-fn faConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn faConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
     const raw_size: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     if (raw_size < 0) {
@@ -1797,18 +1787,18 @@ fn faConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     try obj.set(ctx.allocator, "__size", .{ .int = @intCast(size) });
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn faGetSize(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = Value.toInt(obj.get("__size")) };
+fn faGetSize(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = Value.toInt(obj.get("__size")) });
 }
 
-fn faSetSize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn faSetSize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len == 0) return .null;
+    if (args.len == 0) return NativeResult.scalar(.null);
     const new_size: usize = @intCast(@max(Value.toInt(args[0]), 0));
     const cur_len = arr.entries.items.len;
     if (new_size > cur_len) {
@@ -1821,39 +1811,35 @@ fn faSetSize(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         arr.entries.items.len = new_size;
     }
     try obj.set(ctx.allocator, "__size", .{ .int = @intCast(new_size) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn faCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = Value.toInt(obj.get("__size")) };
+fn faCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = Value.toInt(obj.get("__size")) });
 }
 
-fn faToArray(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn faToArray(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = getData(obj) orelse {
-        const empty = try ctx.allocator.create(PhpArray);
-        empty.* = .{};
-        try ctx.vm.arrays.append(ctx.allocator, empty);
-        return .{ .array = empty };
+        const empty = try ctx.createArray();
+        return NativeResult.borrowed(.{ .array = empty });
     };
-    const copy = try ctx.allocator.create(PhpArray);
-    copy.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, copy);
+    const copy = try ctx.createArray();
     for (arr.entries.items, 0..) |entry, i| {
         try copy.set(ctx.allocator, .{ .int = @intCast(i) }, entry.value);
     }
-    return .{ .array = copy };
+    return NativeResult.borrowed(.{ .array = copy });
 }
 
-fn faFromArray(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn faFromArray(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0 or args[0] != .array) {
         const obj = try ctx.createObject("SplFixedArray");
         const arr = try ensureData(ctx, obj);
         try obj.set(ctx.allocator, "__size", .{ .int = 0 });
         try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
         _ = arr;
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     const src = args[0].array;
     // PHP default: preserveKeys = true (sparse keys produce padded array)
@@ -1891,7 +1877,7 @@ fn faFromArray(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     }
     try obj.set(ctx.allocator, "__size", .{ .int = @intCast(size) });
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 fn faRejectNonIntKey(ctx: *NativeContext, key: Value) !bool {
@@ -1916,23 +1902,23 @@ fn faRejectNonIntKey(ctx: *NativeContext, key: Value) !bool {
     return true;
 }
 
-fn faOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn faOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     if (try faRejectNonIntKey(ctx, args[0])) return error.RuntimeError;
     const raw = Value.toInt(args[0]);
     if (raw < 0 or @as(usize, @intCast(raw)) >= arr.entries.items.len) {
         try ctx.vm.setPendingException("OutOfBoundsException", "Index invalid or out of range");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[@intCast(raw)].value);
+    return NativeResult.share(arr.entries.items[@intCast(raw)].value);
 }
 
-fn faOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len < 2) return .null;
+fn faOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (try faRejectNonIntKey(ctx, args[0])) return error.RuntimeError;
     const raw = Value.toInt(args[0]);
     if (raw < 0 or @as(usize, @intCast(raw)) >= arr.entries.items.len) {
@@ -1944,86 +1930,86 @@ fn faOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     VM.retainValue(args[1]);
     arr.entries.items[idx].value = args[1];
     ctx.vm.releaseValue(old);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn faOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len == 0) return .{ .bool = false };
+fn faOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const idx: usize = @intCast(@max(Value.toInt(args[0]), 0));
-    if (idx >= arr.entries.items.len) return .{ .bool = false };
-    return .{ .bool = arr.entries.items[idx].value != .null };
+    if (idx >= arr.entries.items.len) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = arr.entries.items[idx].value != .null });
 }
 
-fn faOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn faOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const idx: usize = @intCast(@max(Value.toInt(args[0]), 0));
-    if (idx >= arr.entries.items.len) return .null;
+    if (idx >= arr.entries.items.len) return NativeResult.scalar(.null);
     const old = arr.entries.items[idx].value;
     arr.entries.items[idx].value = .null;
     ctx.vm.releaseValue(old);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn faCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn faCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
-    if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return retainReturned(arr.entries.items[cursor].value);
+    if (cursor >= arr.entries.items.len) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(arr.entries.items[cursor].value);
 }
 
-fn faKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn faKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
-    if (cursor < 0 or cursor >= @as(i64, @intCast(arr.entries.items.len))) return .null;
-    return .{ .int = cursor };
+    if (cursor < 0 or cursor >= @as(i64, @intCast(arr.entries.items.len))) return NativeResult.scalar(.null);
+    return NativeResult.scalar(.{ .int = cursor });
 }
 
-fn faNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn faNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
     try obj.set(ctx.allocator, "__cursor", .{ .int = cursor + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn faRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn faRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn faValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn faValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    return .{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(arr.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(arr.entries.items.len)) });
 }
 
 // --- SplQueue ---
 
-fn sqConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sqConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = try ensureData(ctx, obj);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try obj.set(ctx.allocator, "__it_mode", .{ .int = DLL_IT_MODE_FIFO | DLL_IT_MODE_KEEP | 4 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sqEnqueue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sqEnqueue(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
     if (args.len >= 1) try arr.append(ctx.allocator, args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sqDequeue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn sqDequeue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
@@ -2031,75 +2017,75 @@ fn sqDequeue(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const first = arr.entries.items[0].value;
     std.mem.copyForwards(PhpArray.Entry, arr.entries.items[0 .. arr.entries.items.len - 1], arr.entries.items[1..arr.entries.items.len]);
     arr.entries.items.len -= 1;
-    return first;
+    return if (first == .string and first.string.owner != null) NativeResult.takeString(first.string) else NativeResult.share(first);
 }
 
-fn sqBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn sqBottom(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[0].value);
+    return NativeResult.share(arr.entries.items[0].value);
 }
 
-fn sqTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn sqTop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[arr.entries.items.len - 1].value);
+    return NativeResult.share(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
-fn sqCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(arr.entries.items.len) };
+fn sqCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(arr.entries.items.len) });
 }
 
-fn sqIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = true };
-    const arr = getData(obj) orelse return .{ .bool = true };
-    return .{ .bool = arr.entries.items.len == 0 };
+fn sqIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = arr.entries.items.len == 0 });
 }
 
-fn sqCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn sqCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor: usize = @intCast(@max(Value.toInt(obj.get("__cursor")), 0));
-    if (cursor >= arr.entries.items.len) return .{ .bool = false };
-    return retainReturned(arr.entries.items[cursor].value);
+    if (cursor >= arr.entries.items.len) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(arr.entries.items[cursor].value);
 }
 
-fn sqKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn sqKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
-    if (cursor < 0 or cursor >= @as(i64, @intCast(arr.entries.items.len))) return .null;
-    return .{ .int = cursor };
+    if (cursor < 0 or cursor >= @as(i64, @intCast(arr.entries.items.len))) return NativeResult.scalar(.null);
+    return NativeResult.scalar(.{ .int = cursor });
 }
 
-fn sqNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sqNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
     try obj.set(ctx.allocator, "__cursor", .{ .int = cursor + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sqRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sqRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sqValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn sqValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    return .{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(arr.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(arr.entries.items.len)) });
 }
 
 // --- SplDoublyLinkedList ---
@@ -2109,48 +2095,49 @@ const DLL_IT_MODE_FIFO: i64 = 0;
 const DLL_IT_MODE_DELETE: i64 = 1;
 const DLL_IT_MODE_KEEP: i64 = 0;
 
-fn dllConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = try ensureData(ctx, obj);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     try obj.set(ctx.allocator, "__it_mode", .{ .int = DLL_IT_MODE_FIFO | DLL_IT_MODE_KEEP });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllPush(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllPush(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
     if (args.len >= 1) try arr.append(ctx.allocator, args[0]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllPop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn dllPop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
     const last = arr.entries.items[arr.entries.items.len - 1].value;
     arr.entries.items.len -= 1;
-    return last;
+    return if (last == .string and last.string.owner != null) NativeResult.takeString(last.string) else NativeResult.share(last);
 }
 
-fn dllUnshift(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllUnshift(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len == 0) return .null;
+    if (args.len == 0) return NativeResult.scalar(.null);
     try arr.entries.insert(ctx.allocator, 0, .{ .key = .{ .int = 0 }, .value = args[0] });
+    VM.retainValue(args[0]);
     for (arr.entries.items, 0..) |*entry, i| {
         entry.key = .{ .int = @intCast(i) };
     }
     arr.next_int_key = @intCast(arr.entries.items.len);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllShift(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn dllShift(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
@@ -2158,98 +2145,103 @@ fn dllShift(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     const first = arr.entries.items[0].value;
     std.mem.copyForwards(PhpArray.Entry, arr.entries.items[0 .. arr.entries.items.len - 1], arr.entries.items[1..arr.entries.items.len]);
     arr.entries.items.len -= 1;
-    return first;
+    return if (first == .string and first.string.owner != null) NativeResult.takeString(first.string) else NativeResult.share(first);
 }
 
-fn dllTop(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn dllTop(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[arr.entries.items.len - 1].value);
+    return NativeResult.share(arr.entries.items[arr.entries.items.len - 1].value);
 }
 
-fn dllBottom(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
+fn dllBottom(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
     if (arr.entries.items.len == 0) {
         try ctx.vm.setPendingException("RuntimeException", "Can't peek at an empty datastructure");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[0].value);
+    return NativeResult.share(arr.entries.items[0].value);
 }
 
-fn dllCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const arr = getData(obj) orelse return .{ .int = 0 };
-    return .{ .int = arr.length() };
+fn dllCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = arr.length() });
 }
 
-fn dllIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = true };
-    const arr = getData(obj) orelse return .{ .bool = true };
-    return .{ .bool = arr.entries.items.len == 0 };
+fn dllIsEmpty(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = arr.entries.items.len == 0 });
 }
 
-fn dllSetIteratorMode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllSetIteratorMode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     if (args.len >= 1 and args[0] == .int) {
         try obj.set(ctx.allocator, "__it_mode", args[0]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllGetIteratorMode(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return obj.get("__it_mode");
+fn dllGetIteratorMode(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(obj.get("__it_mode"));
 }
 
-fn dllRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const mode = Value.toInt(obj.get("__it_mode"));
     const is_lifo = (mode & DLL_IT_MODE_LIFO) != 0;
     if (is_lifo) {
         const arr = getData(obj) orelse {
             try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-            return .null;
+            return NativeResult.scalar(.null);
         };
         try obj.set(ctx.allocator, "__cursor", .{ .int = @as(i64, @intCast(arr.entries.items.len)) - 1 });
     } else {
         try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn dllCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    if (cursor < 0 or cursor >= @as(i64, @intCast(arr.entries.items.len))) return .{ .bool = false };
-    return retainReturned(arr.entries.items[@intCast(cursor)].value);
+    if (cursor < 0 or cursor >= @as(i64, @intCast(arr.entries.items.len))) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(arr.entries.items[@intCast(cursor)].value);
 }
 
-fn dllKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__cursor");
+fn dllKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.scalar(obj.get("__cursor"));
 }
 
-fn dllNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const mode = Value.toInt(obj.get("__it_mode"));
     const is_lifo = (mode & DLL_IT_MODE_LIFO) != 0;
     const is_delete = (mode & DLL_IT_MODE_DELETE) != 0;
     if (is_delete) {
         if (getData(obj)) |arr| {
             if (is_lifo) {
-                if (arr.entries.items.len > 0) _ = arr.entries.pop();
+                if (arr.entries.pop()) |removed| {
+                    if (removed.key == .string) removed.key.string.release();
+                    ctx.vm.releaseValue(removed.value);
+                }
                 try obj.set(ctx.allocator, "__cursor", .{ .int = @as(i64, @intCast(arr.entries.items.len)) - 1 });
             } else if (arr.entries.items.len > 0) {
-                _ = arr.entries.orderedRemove(0);
+                const removed = arr.entries.orderedRemove(0);
+                if (removed.key == .string) removed.key.string.release();
+                ctx.vm.releaseValue(removed.value);
             }
         }
-        return .null;
+        return NativeResult.scalar(.null);
     }
     const cursor = Value.toInt(obj.get("__cursor"));
     if (is_lifo) {
@@ -2257,11 +2249,11 @@ fn dllNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     } else {
         try obj.set(ctx.allocator, "__cursor", .{ .int = cursor + 1 });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllPrev(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllPrev(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const mode = Value.toInt(obj.get("__it_mode"));
     const is_lifo = (mode & DLL_IT_MODE_LIFO) != 0;
     const cursor = Value.toInt(obj.get("__cursor"));
@@ -2270,134 +2262,139 @@ fn dllPrev(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     } else {
         try obj.set(ctx.allocator, "__cursor", .{ .int = cursor - 1 });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
+fn dllValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    return .{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(arr.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(arr.entries.items.len)) });
 }
 
-fn stackOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn stackOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const n: i64 = @intCast(arr.entries.items.len);
     const idx = Value.toInt(args[0]);
     if (idx < 0 or idx >= n) {
         try ctx.vm.setPendingException("OutOfRangeException", "Offset invalid or out of range");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[@intCast(n - 1 - idx)].value);
+    return NativeResult.share(arr.entries.items[@intCast(n - 1 - idx)].value);
 }
 
-fn stackOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn stackOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len < 2) return .null;
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (args[0] == .null) {
         try arr.append(ctx.allocator, args[1]);
-        return .null;
+        return NativeResult.scalar(.null);
     }
     const n: i64 = @intCast(arr.entries.items.len);
     const idx = Value.toInt(args[0]);
     if (idx >= 0 and idx < n) {
-        try arr.set(ctx.allocator, arr.entries.items[@intCast(n - 1 - idx)].key, args[1]);
+        try ctx.vm.arraySetOwned(arr, arr.entries.items[@intCast(n - 1 - idx)].key, args[1]);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stackOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len == 0) return .{ .bool = false };
+fn stackOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const idx = Value.toInt(args[0]);
-    return .{ .bool = idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len)) });
 }
 
-fn stackOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn stackOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const n: i64 = @intCast(arr.entries.items.len);
     const idx = Value.toInt(args[0]);
     if (idx >= 0 and idx < n) {
-        _ = arr.entries.orderedRemove(@intCast(n - 1 - idx));
+        const removed = arr.entries.orderedRemove(@intCast(n - 1 - idx));
+        if (removed.key == .string) removed.key.string.release();
+        ctx.vm.releaseValue(removed.value);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn dllOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const idx = Value.toInt(args[0]);
     if (idx < 0 or idx >= @as(i64, @intCast(arr.entries.items.len))) {
         try ctx.vm.setPendingException("OutOfRangeException", "Offset invalid or out of range");
         return error.RuntimeError;
     }
-    return retainReturned(arr.entries.items[@intCast(idx)].value);
+    return NativeResult.share(arr.entries.items[@intCast(idx)].value);
 }
 
-fn dllOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len < 2) return .null;
+    if (args.len < 2) return NativeResult.scalar(.null);
     if (args[0] == .null) {
         try arr.append(ctx.allocator, args[1]);
     } else {
         const idx = Value.toInt(args[0]);
         if (idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len))) {
-            try arr.set(ctx.allocator, arr.entries.items[@intCast(idx)].key, args[1]);
+            try ctx.vm.arraySetOwned(arr, arr.entries.items[@intCast(idx)].key, args[1]);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const arr = getData(obj) orelse return .{ .bool = false };
-    if (args.len == 0) return .{ .bool = false };
+fn dllOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const arr = getData(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const idx = Value.toInt(args[0]);
-    return .{ .bool = idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len)) });
 }
 
-fn dllOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = getData(obj) orelse return .null;
-    if (args.len == 0) return .null;
+fn dllOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = getData(obj) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     const idx = Value.toInt(args[0]);
     if (idx >= 0 and idx < @as(i64, @intCast(arr.entries.items.len))) {
-        _ = arr.entries.orderedRemove(@intCast(idx));
+        const removed = arr.entries.orderedRemove(@intCast(idx));
+        if (removed.key == .string) removed.key.string.release();
+        ctx.vm.releaseValue(removed.value);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn dllAdd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllAdd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = try ensureData(ctx, obj);
-    if (args.len < 2) return .null;
+    if (args.len < 2) return NativeResult.scalar(.null);
     const idx = Value.toInt(args[0]);
-    if (idx < 0) return .null;
+    if (idx < 0) return NativeResult.scalar(.null);
     const uidx: usize = @intCast(idx);
-    if (uidx > arr.entries.items.len) return .null;
+    if (uidx > arr.entries.items.len) return NativeResult.scalar(.null);
     try arr.entries.insert(ctx.allocator, uidx, .{ .key = .{ .int = idx }, .value = args[1] });
-    return .null;
+    VM.retainValue(args[1]);
+    return NativeResult.scalar(.null);
 }
 
-fn dllToArray(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn dllToArray(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const arr = getData(obj) orelse {
         const new_arr = try ctx.createArray();
-        return .{ .array = new_arr };
+        return NativeResult.borrowed(.{ .array = new_arr });
     };
     const result = try ctx.createArray();
     for (arr.entries.items, 0..) |entry, i| {
         try result.set(ctx.allocator, .{ .int = @intCast(i) }, entry.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 // --- SplObjectStorage ---
@@ -2414,9 +2411,7 @@ fn sosHashKey(ctx: *NativeContext, sos: *PhpObject, target: *PhpObject) !PhpArra
             if (!std.mem.eql(u8, r, "SplObjectStorage::getHash")) {
                 const result = try ctx.vm.callMethod(sos, "getHash", &.{.{ .object = target }});
                 if (result == .string) {
-                    const owned = try ctx.allocator.dupe(u8, result.string.bytes());
-                    try ctx.vm.strings.append(ctx.allocator, owned);
-                    return .{ .string = Value.String.borrowed(owned) };
+                    return .{ .string = try Value.String.create(ctx.allocator, result.string.bytes()) };
                 }
             }
         }
@@ -2444,21 +2439,17 @@ fn sosLookupKey(objs: *PhpArray, key: PhpArray.Key, target: *PhpObject) ?PhpArra
     return null;
 }
 
-fn sosConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sosConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     _ = try ensureData(ctx, obj);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
     // __info stores associated data keyed by object pointer as string
-    const info_arr = try ctx.allocator.create(PhpArray);
-    info_arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, info_arr);
+    const info_arr = try ctx.createArray();
     try obj.set(ctx.allocator, "__info", .{ .array = info_arr });
     // __objs stores object references in insertion order for iteration
-    const objs_arr = try ctx.allocator.create(PhpArray);
-    objs_arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, objs_arr);
+    const objs_arr = try ctx.createArray();
     try obj.set(ctx.allocator, "__objs", .{ .array = objs_arr });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn sosGetObjs(obj: *PhpObject) ?*PhpArray {
@@ -2475,132 +2466,147 @@ fn sosGetInfo(obj: *PhpObject) ?*PhpArray {
 
 fn sosFindIndex(ctx: *NativeContext, sos: *PhpObject, objs: *PhpArray, target: *PhpObject) !?usize {
     const key = try sosHashKey(ctx, sos, target);
+    defer if (key == .string) key.string.release();
     return sosFindIndexByKey(objs, key);
 }
 
-fn sosAttach(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .null;
+fn sosAttach(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const target = args[0].object;
     const data = if (args.len >= 2) args[1] else Value.null;
-    const objs = sosGetObjs(obj) orelse return .null;
-    const info = sosGetInfo(obj) orelse return .null;
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
+    const info = sosGetInfo(obj) orelse return NativeResult.scalar(.null);
     const key = try sosHashKey(ctx, obj, target);
+    defer if (key == .string) key.string.release();
 
-    try objs.set(ctx.allocator, key, .{ .object = target });
-    try info.set(ctx.allocator, key, data);
-    return .null;
+    try ctx.vm.arraySetOwned(objs, key, .{ .object = target });
+    try ctx.vm.arraySetOwned(info, key, data);
+    return NativeResult.scalar(.null);
 }
 
-fn sosDetach(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .null;
+fn sosDetach(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const target = args[0].object;
-    const objs = sosGetObjs(obj) orelse return .null;
-    const info = sosGetInfo(obj) orelse return .null;
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
+    const info = sosGetInfo(obj) orelse return NativeResult.scalar(.null);
     const key = try sosHashKey(ctx, obj, target);
+    defer if (key == .string) key.string.release();
 
     const lookup = sosLookupKey(objs, key, target);
     if (lookup) |real_key| {
         const idx = sosFindIndexByKey(objs, real_key).?;
-        _ = objs.entries.orderedRemove(idx);
+        const removed = objs.entries.orderedRemove(idx);
+        defer {
+            if (removed.key == .string) removed.key.string.release();
+            ctx.vm.releaseValue(removed.value);
+        }
         if (real_key == .string) _ = objs.string_index.remove(real_key.string.bytes());
         ctx.vm.arrayRemoveOwned(info, real_key);
         if (real_key == .string) {
             objs.rebuildStringIndexAssumeCapacity();
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sosContains(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len == 0 or args[0] != .object) return .{ .bool = false };
-    const objs = sosGetObjs(obj) orelse return .{ .bool = false };
+fn sosContains(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const key = try sosHashKey(ctx, obj, args[0].object);
-    return .{ .bool = sosLookupKey(objs, key, args[0].object) != null };
+    defer if (key == .string) key.string.release();
+    return NativeResult.scalar(.{ .bool = sosLookupKey(objs, key, args[0].object) != null });
 }
 
-fn sosCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const objs = sosGetObjs(obj) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(objs.entries.items.len) };
+fn sosCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(objs.entries.items.len) });
 }
 
-fn sosGetInfoMethod(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const objs = sosGetObjs(obj) orelse return .null;
-    const info = sosGetInfo(obj) orelse return .null;
+fn sosGetInfoMethod(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
+    const info = sosGetInfo(obj) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
-    if (cursor < 0 or cursor >= @as(i64, @intCast(objs.entries.items.len))) return .null;
-    return retainReturned(info.get(objs.entries.items[@intCast(cursor)].key));
+    if (cursor < 0 or cursor >= @as(i64, @intCast(objs.entries.items.len))) return NativeResult.scalar(.null);
+    return NativeResult.share(info.get(objs.entries.items[@intCast(cursor)].key));
 }
 
-fn sosSetInfoMethod(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0) return .null;
-    const objs = sosGetObjs(obj) orelse return .null;
-    const info = sosGetInfo(obj) orelse return .null;
+fn sosSetInfoMethod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
+    const info = sosGetInfo(obj) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
-    if (cursor < 0 or cursor >= @as(i64, @intCast(objs.entries.items.len))) return .null;
-    try info.set(ctx.allocator, objs.entries.items[@intCast(cursor)].key, args[0]);
-    return .null;
+    if (cursor < 0 or cursor >= @as(i64, @intCast(objs.entries.items.len))) return NativeResult.scalar(.null);
+    try ctx.vm.arraySetOwned(info, objs.entries.items[@intCast(cursor)].key, args[0]);
+    return NativeResult.scalar(.null);
 }
 
-fn sosGetHash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .object) return .null;
+fn sosGetHash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const ptr: usize = @intFromPtr(args[0].object);
-    const hash = std.fmt.allocPrint(ctx.allocator, "{x:0>32}", .{ptr}) catch return .null;
-    ctx.vm.strings.append(ctx.allocator, hash) catch {};
-    return .{ .string = Value.String.borrowed(hash) };
+    const hash = try std.fmt.allocPrint(ctx.allocator, "{x:0>32}", .{ptr});
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, hash));
 }
 
-fn sosRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sosRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sosCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const objs = sosGetObjs(obj) orelse return .{ .bool = false };
+fn sosCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    if (cursor < 0 or cursor >= @as(i64, @intCast(objs.entries.items.len))) return .{ .bool = false };
-    return objs.entries.items[@intCast(cursor)].value;
+    if (cursor < 0 or cursor >= @as(i64, @intCast(objs.entries.items.len))) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(objs.entries.items[@intCast(cursor)].value);
 }
 
-fn sosKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__cursor");
+fn sosKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.scalar(obj.get("__cursor"));
 }
 
-fn sosNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sosNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cursor = Value.toInt(obj.get("__cursor"));
     try obj.set(ctx.allocator, "__cursor", .{ .int = cursor + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sosValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const objs = sosGetObjs(obj) orelse return .{ .bool = false };
+fn sosValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const cursor = Value.toInt(obj.get("__cursor"));
-    return .{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(objs.entries.items.len)) };
+    return NativeResult.scalar(.{ .bool = cursor >= 0 and cursor < @as(i64, @intCast(objs.entries.items.len)) });
 }
 
-fn sosRemoveAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .null;
+fn sosRemoveAll(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const other_this = args[0].object;
-    const other_objs = sosGetObjs(other_this) orelse return .null;
-    const objs = sosGetObjs(obj) orelse return .null;
-    const info = sosGetInfo(obj) orelse return .null;
+    const other_objs = sosGetObjs(other_this) orelse return NativeResult.scalar(.null);
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
+    const info = sosGetInfo(obj) orelse return NativeResult.scalar(.null);
 
-    for (other_objs.entries.items) |o_entry| {
+    const snapshot = try ctx.vm.cloneArray(other_objs);
+    VM.arrayRetain(snapshot);
+    defer ctx.vm.arrayRelease(snapshot);
+    for (snapshot.entries.items) |o_entry| {
         if (o_entry.value != .object) continue;
         const key = try sosHashKey(ctx, obj, o_entry.value.object);
+        defer if (key == .string) key.string.release();
         if (sosFindIndexByKey(objs, key)) |idx| {
-            _ = objs.entries.orderedRemove(idx);
+            const removed = objs.entries.orderedRemove(idx);
+            defer {
+                if (removed.key == .string) removed.key.string.release();
+                ctx.vm.releaseValue(removed.value);
+            }
             if (key == .string) {
                 _ = objs.string_index.remove(key.string.bytes());
                 objs.rebuildStringIndexAssumeCapacity();
@@ -2608,16 +2614,16 @@ fn sosRemoveAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             ctx.vm.arrayRemoveOwned(info, key);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sosRemoveAllExcept(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .null;
+fn sosRemoveAllExcept(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const other_this = args[0].object;
-    const other_objs = sosGetObjs(other_this) orelse return .null;
-    const objs = sosGetObjs(obj) orelse return .null;
-    const info = sosGetInfo(obj) orelse return .null;
+    const other_objs = sosGetObjs(other_this) orelse return NativeResult.scalar(.null);
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
+    const info = sosGetInfo(obj) orelse return NativeResult.scalar(.null);
 
     var i: usize = 0;
     while (i < objs.entries.items.len) {
@@ -2631,6 +2637,7 @@ fn sosRemoveAllExcept(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         for (other_objs.entries.items) |o_entry| {
             if (o_entry.value != .object) continue;
             const other_key = try sosHashKey(ctx, obj, o_entry.value.object);
+            defer if (other_key == .string) other_key.string.release();
             if (entry.key.eql(other_key)) {
                 found = true;
                 break;
@@ -2638,7 +2645,11 @@ fn sosRemoveAllExcept(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         }
         if (!found) {
             const key = entry.key;
-            _ = objs.entries.orderedRemove(i);
+            const removed = objs.entries.orderedRemove(i);
+            defer {
+                if (removed.key == .string) removed.key.string.release();
+                ctx.vm.releaseValue(removed.value);
+            }
             if (key == .string) {
                 _ = objs.string_index.remove(key.string.bytes());
             }
@@ -2648,64 +2659,66 @@ fn sosRemoveAllExcept(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         }
     }
     objs.rebuildStringIndexAssumeCapacity();
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sosAddAll(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0 or args[0] != .object) return .null;
+fn sosAddAll(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.null);
     const other_this = args[0].object;
-    const other_objs = sosGetObjs(other_this) orelse return .null;
-    const other_info = sosGetInfo(other_this) orelse return .null;
-    const objs = sosGetObjs(obj) orelse return .null;
-    const info = sosGetInfo(obj) orelse return .null;
+    const other_objs = sosGetObjs(other_this) orelse return NativeResult.scalar(.null);
+    const other_info = sosGetInfo(other_this) orelse return NativeResult.scalar(.null);
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
+    const info = sosGetInfo(obj) orelse return NativeResult.scalar(.null);
 
     for (other_objs.entries.items) |entry| {
         if (entry.value == .object) {
             const target = entry.value.object;
             const self_key = try sosHashKey(ctx, obj, target);
-            try objs.set(ctx.allocator, self_key, .{ .object = target });
+            defer if (self_key == .string) self_key.string.release();
+            try ctx.vm.arraySetOwned(objs, self_key, .{ .object = target });
             const data = other_info.get(entry.key);
-            try info.set(ctx.allocator, self_key, data);
+            try ctx.vm.arraySetOwned(info, self_key, data);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sosOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len == 0) return .null;
+fn sosOffsetGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len == 0) return NativeResult.scalar(.null);
     if (!try sosRequireObjectKey(ctx, "offsetGet", args[0])) return error.RuntimeError;
     const info = sosGetInfo(obj) orelse {
         try ctx.vm.setPendingException("UnexpectedValueException", "Object not found");
         return error.RuntimeError;
     };
-    const objs = sosGetObjs(obj) orelse return .null;
+    const objs = sosGetObjs(obj) orelse return NativeResult.scalar(.null);
     const key = try sosHashKey(ctx, obj, args[0].object);
+    defer if (key == .string) key.string.release();
     const real_key = sosLookupKey(objs, key, args[0].object) orelse {
         try ctx.vm.setPendingException("UnexpectedValueException", "Object not found");
         return error.RuntimeError;
     };
-    return retainReturned(info.get(real_key));
+    return NativeResult.share(info.get(real_key));
 }
 
-fn sosOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn sosOffsetSet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // offsetSet($obj, $data) is equivalent to attach($obj, $data) but the
     // offset* variant uses a TypeError-throwing key check (attach is now
     // deprecated and tolerant of non-objects)
-    if (args.len == 0) return .null;
+    if (args.len == 0) return NativeResult.scalar(.null);
     if (!try sosRequireObjectKey(ctx, "offsetSet", args[0])) return error.RuntimeError;
     return sosAttach(ctx, args);
 }
 
-fn sosOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn sosOffsetExists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     if (!try sosRequireObjectKey(ctx, "offsetExists", args[0])) return error.RuntimeError;
     return sosContains(ctx, args);
 }
 
-fn sosOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn sosOffsetUnset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     if (!try sosRequireObjectKey(ctx, "offsetUnset", args[0])) return error.RuntimeError;
     return sosDetach(ctx, args);
 }

--- a/src/stdlib/spl_file.zig
+++ b/src/stdlib/spl_file.zig
@@ -4,6 +4,7 @@ const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
 const VM = vm_mod.VM;
+const NativeResult = vm_mod.NativeResult;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 
@@ -95,12 +96,6 @@ fn objGetInt(obj: *PhpObject, key: []const u8) i64 {
     return 0;
 }
 
-fn createString(ctx: *NativeContext, s: []const u8) ![]const u8 {
-    const copy = try ctx.allocator.dupe(u8, s);
-    try ctx.vm.strings.append(ctx.allocator, copy);
-    return copy;
-}
-
 fn getHandle(obj: *PhpObject) ?Value {
     const fh = obj.get("__sfo_fh");
     if (fh == .object) return fh;
@@ -108,46 +103,45 @@ fn getHandle(obj: *PhpObject) ?Value {
 }
 
 fn defaultCsvControl(ctx: *NativeContext) RuntimeError!*PhpArray {
-    const arr = try ctx.allocator.create(PhpArray);
-    arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, arr);
+    const arr = try ctx.createArray();
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(",") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("\"") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("\\") });
     return arr;
 }
 
-fn sfoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
+fn sfoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const mode: Value = if (args.len >= 2 and args[1] == .string) args[1] else .{ .string = Value.String.borrowed("r") };
     const fh = try ctx.vm.callByName("fopen", &.{ args[0], mode });
     if (fh != .object) {
         const msg = try std.fmt.allocPrint(ctx.allocator, "SplFileObject::__construct(): Failed to open stream: {s}", .{args[0].string.bytes()});
         try ctx.vm.strings.append(ctx.allocator, msg);
-        if (try ctx.vm.throwBuiltinException("RuntimeException", msg)) return .null;
+        if (try ctx.vm.throwBuiltinException("RuntimeException", msg)) return NativeResult.scalar(.null);
         return error.RuntimeError;
     }
     try obj.set(ctx.allocator, "__sfo_fh", fh);
-    try obj.set(ctx.allocator, "__pathname", .{ .string = Value.String.borrowed(try createString(ctx, args[0].string.bytes())) });
+    try obj.set(ctx.allocator, "__pathname", args[0]);
     try obj.set(ctx.allocator, "__sfo_line", .{ .int = 0 });
     try obj.set(ctx.allocator, "__sfo_flags", .{ .int = 0 });
     try obj.set(ctx.allocator, "__sfo_max", .{ .int = 0 });
     try obj.set(ctx.allocator, "__sfo_csv", .{ .array = try defaultCsvControl(ctx) });
     try obj.set(ctx.allocator, "__sfo_current", .null);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn stfoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    _ = getThis(ctx) orelse return .null;
+fn stfoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    _ = getThis(ctx) orelse return NativeResult.scalar(.null);
     var path_buf: [64]u8 = undefined;
     const path = if (args.len >= 1 and args[0] != .null) blk: {
         const max = Value.toInt(args[0]);
         const s = std.fmt.bufPrint(&path_buf, "php://temp/maxmemory:{d}", .{max}) catch "php://temp";
         break :blk s;
     } else "php://temp";
-    const path_str = try createString(ctx, path);
-    return sfoConstruct(ctx, &.{ .{ .string = Value.String.borrowed(path_str) }, .{ .string = Value.String.borrowed("w+") } });
+    const path_str = try Value.String.create(ctx.allocator, path);
+    defer path_str.release();
+    return sfoConstruct(ctx, &.{ .{ .string = path_str }, .{ .string = Value.String.borrowed("w+") } });
 }
 
 fn readOneLine(ctx: *NativeContext, obj: *PhpObject) RuntimeError!void {
@@ -158,6 +152,8 @@ fn readOneLine(ctx: *NativeContext, obj: *PhpObject) RuntimeError!void {
     const flags = objGetInt(obj, "__sfo_flags");
     while (true) {
         var line: Value = undefined;
+        var trimmed: ?Value.String = null;
+        defer if (trimmed) |value| value.release();
         if ((flags & FLAG_READ_CSV) != 0) {
             const csv_v = obj.get("__sfo_csv");
             const sep_v: Value = if (csv_v == .array) csv_v.array.get(.{ .int = 0 }) else .{ .string = Value.String.borrowed(",") };
@@ -174,7 +170,8 @@ fn readOneLine(ctx: *NativeContext, obj: *PhpObject) RuntimeError!void {
         if ((flags & FLAG_READ_CSV) == 0 and (flags & FLAG_DROP_NEW_LINE) != 0 and line == .string) {
             var s = line.string.bytes();
             while (s.len > 0 and (s[s.len - 1] == '\n' or s[s.len - 1] == '\r')) s = s[0 .. s.len - 1];
-            line = .{ .string = Value.String.borrowed(try createString(ctx, s)) };
+            trimmed = try Value.String.create(ctx.allocator, s);
+            line = .{ .string = trimmed.? };
         }
         if ((flags & FLAG_SKIP_EMPTY) != 0) {
             const is_empty = blk: {
@@ -198,14 +195,14 @@ fn readOneLine(ctx: *NativeContext, obj: *PhpObject) RuntimeError!void {
     }
 }
 
-fn sfoRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const fh = getHandle(obj) orelse return .null;
+fn sfoRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callByName("fseek", &.{ fh, .{ .int = 0 } });
     try obj.set(ctx.allocator, "__sfo_line", .{ .int = 0 });
     // mark current as "unread" so the first current()/valid() call lazily fetches
     try obj.set(ctx.allocator, "__sfo_current", .null);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn ensureCurrent(ctx: *NativeContext, obj: *@import("../runtime/value.zig").PhpObject) !void {
@@ -213,108 +210,108 @@ fn ensureCurrent(ctx: *NativeContext, obj: *@import("../runtime/value.zig").PhpO
     if (cur == .null) try readOneLine(ctx, obj);
 }
 
-fn sfoValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn sfoValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     try ensureCurrent(ctx, obj);
     const cur = obj.get("__sfo_current");
-    if (cur == .bool and !cur.bool) return .{ .bool = false };
-    if (cur == .null) return .{ .bool = false };
-    return .{ .bool = true };
+    if (cur == .bool and !cur.bool) return NativeResult.scalar(.{ .bool = false });
+    if (cur == .null) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn sfoCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sfoCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try ensureCurrent(ctx, obj);
-    return obj.get("__sfo_current");
+    return NativeResult.share(obj.get("__sfo_current"));
 }
 
-fn sfoKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__sfo_line") };
+fn sfoKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__sfo_line") });
 }
 
-fn sfoNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn sfoNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__sfo_line", .{ .int = objGetInt(obj, "__sfo_line") + 1 });
     try readOneLine(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sfoFgets(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
+fn sfoFgets(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
     try obj.set(ctx.allocator, "__sfo_line", .{ .int = objGetInt(obj, "__sfo_line") + 1 });
-    return ctx.vm.callByName("fgets", &.{fh});
+    return NativeResult.share(try ctx.vm.callByName("fgets", &.{fh}));
 }
 
-fn sfoFgetcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
+fn sfoFgetcsv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const csv_v = obj.get("__sfo_csv");
     const sep: Value = if (args.len >= 1 and args[0] == .string) args[0] else if (csv_v == .array) csv_v.array.get(.{ .int = 0 }) else .{ .string = Value.String.borrowed(",") };
     const enc: Value = if (args.len >= 2 and args[1] == .string) args[1] else if (csv_v == .array) csv_v.array.get(.{ .int = 1 }) else .{ .string = Value.String.borrowed("\"") };
     const esc: Value = if (args.len >= 3 and args[2] == .string) args[2] else if (csv_v == .array) csv_v.array.get(.{ .int = 2 }) else .{ .string = Value.String.borrowed("\\") };
     try obj.set(ctx.allocator, "__sfo_line", .{ .int = objGetInt(obj, "__sfo_line") + 1 });
-    return ctx.vm.callByName("fgetcsv", &.{ fh, .{ .int = 0 }, sep, enc, esc });
+    return NativeResult.share(try ctx.vm.callByName("fgetcsv", &.{ fh, .{ .int = 0 }, sep, enc, esc }));
 }
 
-fn sfoFputcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    if (args.len < 1 or args[0] != .array) return .{ .bool = false };
+fn sfoFputcsv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const csv_v = obj.get("__sfo_csv");
     const sep: Value = if (args.len >= 2 and args[1] == .string) args[1] else if (csv_v == .array) csv_v.array.get(.{ .int = 0 }) else .{ .string = Value.String.borrowed(",") };
     const enc: Value = if (args.len >= 3 and args[2] == .string) args[2] else if (csv_v == .array) csv_v.array.get(.{ .int = 1 }) else .{ .string = Value.String.borrowed("\"") };
     const esc: Value = if (args.len >= 4 and args[3] == .string) args[3] else if (csv_v == .array) csv_v.array.get(.{ .int = 2 }) else .{ .string = Value.String.borrowed("\\") };
     const eol: Value = if (args.len >= 5 and args[4] == .string) args[4] else .{ .string = Value.String.borrowed("\n") };
-    return ctx.vm.callByName("fputcsv", &.{ fh, args[0], sep, enc, esc, eol });
+    return NativeResult.share(try ctx.vm.callByName("fputcsv", &.{ fh, args[0], sep, enc, esc, eol }));
 }
 
-fn sfoFread(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
-    return ctx.vm.callByName("fread", &.{ fh, args[0] });
+fn sfoFread(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callByName("fread", &.{ fh, args[0] }));
 }
 
-fn sfoFwrite(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
-    if (args.len >= 2) return ctx.vm.callByName("fwrite", &.{ fh, args[0], args[1] });
-    return ctx.vm.callByName("fwrite", &.{ fh, args[0] });
+fn sfoFwrite(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    if (args.len >= 2) return NativeResult.share(try ctx.vm.callByName("fwrite", &.{ fh, args[0], args[1] }));
+    return NativeResult.share(try ctx.vm.callByName("fwrite", &.{ fh, args[0] }));
 }
 
-fn sfoFseek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = -1 };
-    const fh = getHandle(obj) orelse return .{ .int = -1 };
-    if (args.len < 1) return .{ .int = -1 };
+fn sfoFseek(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = -1 });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .int = -1 });
+    if (args.len < 1) return NativeResult.scalar(.{ .int = -1 });
     const whence: Value = if (args.len >= 2) args[1] else .{ .int = 0 };
-    return ctx.vm.callByName("fseek", &.{ fh, args[0], whence });
+    return NativeResult.share(try ctx.vm.callByName("fseek", &.{ fh, args[0], whence }));
 }
 
-fn sfoFtell(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    return ctx.vm.callByName("ftell", &.{fh});
+fn sfoFtell(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callByName("ftell", &.{fh}));
 }
 
-fn sfoFeof(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = true };
-    const fh = getHandle(obj) orelse return .{ .bool = true };
-    return ctx.vm.callByName("feof", &.{fh});
+fn sfoFeof(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = true });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.share(try ctx.vm.callByName("feof", &.{fh}));
 }
 
-fn sfoFgetc(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    return ctx.vm.callByName("fgetc", &.{fh});
+fn sfoFgetc(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callByName("fgetc", &.{fh}));
 }
 
-fn sfoFpassthru(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const fh = getHandle(obj) orelse return .{ .int = 0 };
-    if (ctx.vm.native_fns.get("fpassthru")) |_| return ctx.vm.callByName("fpassthru", &.{fh});
+fn sfoFpassthru(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .int = 0 });
+    if (ctx.vm.native_fns.get("fpassthru")) |_| return NativeResult.share(try ctx.vm.callByName("fpassthru", &.{fh}));
     var total: i64 = 0;
     while (true) {
         const chunk = try ctx.vm.callByName("fread", &.{ fh, .{ .int = 8192 } });
@@ -322,42 +319,40 @@ fn sfoFpassthru(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         try ctx.vm.output.appendSlice(ctx.allocator, chunk.string.bytes());
         total += @intCast(chunk.string.bytes().len);
     }
-    return .{ .int = total };
+    return NativeResult.scalar(.{ .int = total });
 }
 
-fn sfoFflush(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    if (ctx.vm.native_fns.get("fflush")) |_| return ctx.vm.callByName("fflush", &.{fh});
-    return .{ .bool = true };
+fn sfoFflush(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.native_fns.get("fflush")) |_| return NativeResult.share(try ctx.vm.callByName("fflush", &.{fh}));
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn sfoFtruncate(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
-    if (ctx.vm.native_fns.get("ftruncate")) |_| return ctx.vm.callByName("ftruncate", &.{ fh, args[0] });
-    return .{ .bool = false };
+fn sfoFtruncate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.native_fns.get("ftruncate")) |_| return NativeResult.share(try ctx.vm.callByName("ftruncate", &.{ fh, args[0] }));
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn sfoFlock(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const fh = getHandle(obj) orelse return .{ .bool = false };
-    if (args.len < 1) return .{ .bool = false };
-    if (ctx.vm.native_fns.get("flock")) |_| return ctx.vm.callByName("flock", &.{ fh, args[0] });
-    return .{ .bool = true };
+fn sfoFlock(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const fh = getHandle(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.native_fns.get("flock")) |_| return NativeResult.share(try ctx.vm.callByName("flock", &.{ fh, args[0] }));
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn sfoGetCsvControl(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__sfo_csv");
+fn sfoGetCsvControl(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__sfo_csv"));
 }
 
-fn sfoSetCsvControl(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = try ctx.allocator.create(PhpArray);
-    arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, arr);
+fn sfoSetCsvControl(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = try ctx.createArray();
     const sep: Value = if (args.len >= 1 and args[0] == .string) args[0] else .{ .string = Value.String.borrowed(",") };
     const enc: Value = if (args.len >= 2 and args[1] == .string) args[1] else .{ .string = Value.String.borrowed("\"") };
     const esc: Value = if (args.len >= 3 and args[2] == .string) args[2] else .{ .string = Value.String.borrowed("\\") };
@@ -365,36 +360,36 @@ fn sfoSetCsvControl(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     try arr.append(ctx.allocator, enc);
     try arr.append(ctx.allocator, esc);
     try obj.set(ctx.allocator, "__sfo_csv", .{ .array = arr });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sfoGetMaxLineLen(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__sfo_max") };
+fn sfoGetMaxLineLen(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__sfo_max") });
 }
 
-fn sfoSetMaxLineLen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn sfoSetMaxLineLen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__sfo_max", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sfoGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__sfo_flags") };
+fn sfoGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__sfo_flags") });
 }
 
-fn sfoSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn sfoSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__sfo_flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sfoSeek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn sfoSeek(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const target = Value.toInt(args[0]);
     _ = try sfoRewind(ctx, &.{});
     // rewind leaves the file handle at byte 0 and __sfo_line at 0 / current
@@ -409,13 +404,13 @@ fn sfoSeek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             _ = try sfoNext(ctx, &.{});
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn sfoHasChildren(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = false };
+fn sfoHasChildren(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn sfoGetChildren(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn sfoGetChildren(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }

--- a/src/stdlib/spl_iterators.zig
+++ b/src/stdlib/spl_iterators.zig
@@ -4,6 +4,7 @@ const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
 const VM = vm_mod.VM;
+const NativeResult = vm_mod.NativeResult;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 
@@ -461,12 +462,6 @@ fn getThis(ctx: *NativeContext) ?*PhpObject {
     return v.object;
 }
 
-fn createString(ctx: *NativeContext, s: []const u8) ![]const u8 {
-    const copy = try ctx.allocator.dupe(u8, s);
-    try ctx.vm.strings.append(ctx.allocator, copy);
-    return copy;
-}
-
 fn objGetStr(obj: *PhpObject, key: []const u8) []const u8 {
     const v = obj.get(key);
     if (v == .string) return v.string.bytes();
@@ -480,10 +475,10 @@ fn objGetInt(obj: *PhpObject, key: []const u8) i64 {
 }
 
 fn createFileInfoObj(ctx: *NativeContext, pathname: []const u8) !*PhpObject {
-    const obj = try ctx.allocator.create(PhpObject);
-    obj.* = .{ .class_name = "SplFileInfo" };
-    try ctx.vm.objects.append(ctx.allocator, obj);
-    try obj.set(ctx.allocator, "__pathname", .{ .string = Value.String.borrowed(try createString(ctx, pathname)) });
+    const obj = try ctx.createObject("SplFileInfo");
+    const path = try Value.String.create(ctx.allocator, pathname);
+    defer path.release();
+    try obj.set(ctx.allocator, "__pathname", .{ .string = path });
     return obj;
 }
 
@@ -517,30 +512,30 @@ fn statPath(path: []const u8) ?std.fs.File.Stat {
 // SplFileInfo
 // ==========================================
 
-fn fiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
-    try obj.set(ctx.allocator, "__pathname", .{ .string = Value.String.borrowed(try createString(ctx, args[0].string.bytes())) });
-    return .null;
+fn fiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    try obj.set(ctx.allocator, "__pathname", args[0]);
+    return NativeResult.scalar(.null);
 }
 
-fn fiGetFilename(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn fiGetFilename(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const path = objGetStr(obj, "__pathname");
-    return .{ .string = Value.String.borrowed(try createString(ctx, basename(path))) };
+    return NativeResult.copyString(ctx.allocator, basename(path));
 }
 
-fn fiGetExtension(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn fiGetExtension(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const name = basename(objGetStr(obj, "__pathname"));
     if (std.mem.lastIndexOfScalar(u8, name, '.')) |idx| {
-        return .{ .string = Value.String.borrowed(try createString(ctx, name[idx + 1 ..])) };
+        return NativeResult.copyString(ctx.allocator, name[idx + 1 ..]);
     }
-    return .{ .string = Value.String.borrowed("") };
+    return NativeResult.literal("");
 }
 
-fn fiGetBasename(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn fiGetBasename(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     var name = basename(objGetStr(obj, "__pathname"));
     if (args.len >= 1 and args[0] == .string) {
         const suffix = args[0].string.bytes();
@@ -548,132 +543,126 @@ fn fiGetBasename(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             name = name[0 .. name.len - suffix.len];
         }
     }
-    return .{ .string = Value.String.borrowed(try createString(ctx, name)) };
+    return NativeResult.copyString(ctx.allocator, name);
 }
 
-fn fiGetPathname(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return .{ .string = Value.String.borrowed(objGetStr(obj, "__pathname")) };
+fn fiGetPathname(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__pathname"));
 }
 
-fn fiGetPath(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return .{ .string = Value.String.borrowed(try createString(ctx, dirname(objGetStr(obj, "__pathname")))) };
+fn fiGetPath(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.copyString(ctx.allocator, dirname(objGetStr(obj, "__pathname")));
 }
 
-fn fiGetRealPath(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn fiGetRealPath(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const path = objGetStr(obj, "__pathname");
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const real = std.fs.cwd().realpath(path, &buf) catch return .{ .bool = false };
-    return .{ .string = Value.String.borrowed(try createString(ctx, real)) };
+    const real = std.fs.cwd().realpath(path, &buf) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.copyString(ctx.allocator, real);
 }
 
-fn fiGetSize(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const stat = statPath(objGetStr(obj, "__pathname")) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(stat.size) };
+fn fiGetSize(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const stat = statPath(objGetStr(obj, "__pathname")) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(stat.size) });
 }
 
-fn fiIsDir(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn fiIsDir(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const path = objGetStr(obj, "__pathname");
-    const stat = statPath(path) orelse return .{ .bool = false };
-    return .{ .bool = stat.kind == .directory };
+    const stat = statPath(path) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = stat.kind == .directory });
 }
 
-fn fiIsFile(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn fiIsFile(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const path = objGetStr(obj, "__pathname");
-    const stat = statPath(path) orelse return .{ .bool = false };
-    return .{ .bool = stat.kind == .file };
+    const stat = statPath(path) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = stat.kind == .file });
 }
 
-fn fiIsLink(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn fiIsLink(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const path = objGetStr(obj, "__pathname");
-    const stat = statPath(path) orelse return .{ .bool = false };
-    return .{ .bool = stat.kind == .sym_link };
+    const stat = statPath(path) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = stat.kind == .sym_link });
 }
 
-fn fiIsReadable(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn fiIsReadable(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn fiIsWritable(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn fiIsWritable(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn fiGetMTime(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const stat = statPath(objGetStr(obj, "__pathname")) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(@divTrunc(stat.mtime, std.time.ns_per_s)) };
+fn fiGetMTime(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const stat = statPath(objGetStr(obj, "__pathname")) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(@divTrunc(stat.mtime, std.time.ns_per_s)) });
 }
 
-fn fiGetCTime(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const stat = statPath(objGetStr(obj, "__pathname")) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(@divTrunc(stat.ctime, std.time.ns_per_s)) };
+fn fiGetCTime(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const stat = statPath(objGetStr(obj, "__pathname")) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(@divTrunc(stat.ctime, std.time.ns_per_s)) });
 }
 
-fn fiGetATime(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const stat = statPath(objGetStr(obj, "__pathname")) orelse return .{ .int = 0 };
-    return .{ .int = @intCast(@divTrunc(stat.atime, std.time.ns_per_s)) };
+fn fiGetATime(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const stat = statPath(objGetStr(obj, "__pathname")) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = @intCast(@divTrunc(stat.atime, std.time.ns_per_s)) });
 }
 
-fn fiGetType(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("unknown") };
-    const stat = statPath(objGetStr(obj, "__pathname")) orelse return .{ .string = Value.String.borrowed("unknown") };
-    return .{ .string = Value.String.borrowed(switch (stat.kind) {
-        .directory => "dir",
-        .file => "file",
-        .sym_link => "link",
-        else => "unknown",
-    }) };
+fn fiGetType(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("unknown");
+    const stat = statPath(objGetStr(obj, "__pathname")) orelse return NativeResult.literal("unknown");
+    return switch (stat.kind) {
+        .directory => NativeResult.literal("dir"),
+        .file => NativeResult.literal("file"),
+        .sym_link => NativeResult.literal("link"),
+        else => NativeResult.literal("unknown"),
+    };
 }
 
-fn fiToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(objGetStr(obj, "__pathname")) };
+fn fiToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
+    return NativeResult.share(obj.get("__pathname"));
 }
 
-fn fiOpenFile(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
+fn fiOpenFile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
     const path = objGetStr(this, "__pathname");
     const mode: Value = if (args.len >= 1 and args[0] == .string) args[0] else .{ .string = Value.String.borrowed("r") };
-    const class_name = try createString(ctx, "SplFileObject");
-    const obj = try ctx.vm.allocator.create(@import("../runtime/value.zig").PhpObject);
-    obj.* = .{ .class_name = class_name };
-    try ctx.vm.objects.append(ctx.vm.allocator, obj);
-    try ctx.vm.initObjectProperties(obj, class_name);
+    const obj = try ctx.createObject("SplFileObject");
     _ = try ctx.vm.callMethod(obj, "__construct", &.{ .{ .string = Value.String.borrowed(path) }, mode });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
 // ==========================================
 // DirectoryIterator
 // ==========================================
 
-fn diConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
+fn diConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const path = args[0].string.bytes();
-    try obj.set(ctx.allocator, "__di_path", .{ .string = Value.String.borrowed(try createString(ctx, path)) });
+    try obj.set(ctx.allocator, "__di_path", args[0]);
     try obj.set(ctx.allocator, "__di_idx", .{ .int = 0 });
 
     const entries = try loadDirectoryEntries(ctx, path, 0);
     try obj.set(ctx.allocator, "__di_entries", .{ .array = entries });
     try syncCurrentEntry(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 const SKIP_DOTS: i64 = 0x1000;
 
 fn loadDirectoryEntries(ctx: *NativeContext, path: []const u8, flags: i64) RuntimeError!*PhpArray {
-    const arr = try ctx.allocator.create(PhpArray);
-    arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, arr);
+    const arr = try ctx.createArray();
 
     var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch return arr;
     defer dir.close();
@@ -682,12 +671,11 @@ fn loadDirectoryEntries(ctx: *NativeContext, path: []const u8, flags: i64) Runti
     if (!skip_dots) {
         inline for (.{ ".", ".." }) |dot_name| {
             const dot_full = try std.fmt.allocPrint(ctx.allocator, "{s}/{s}", .{ path, dot_name });
-            try ctx.vm.strings.append(ctx.allocator, dot_full);
-            const dot_entry = try ctx.allocator.create(PhpArray);
-            dot_entry.* = .{};
-            try ctx.vm.arrays.append(ctx.allocator, dot_entry);
+            const dot_full_owned = try Value.String.adopt(ctx.allocator, dot_full);
+            defer dot_full_owned.release();
+            const dot_entry = try ctx.createArray();
             try dot_entry.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = Value.String.borrowed(dot_name) });
-            try dot_entry.set(ctx.allocator, .{ .string = Value.String.borrowed("path") }, .{ .string = Value.String.borrowed(dot_full) });
+            try dot_entry.set(ctx.allocator, .{ .string = Value.String.borrowed("path") }, .{ .string = dot_full_owned });
             try dot_entry.set(ctx.allocator, .{ .string = Value.String.borrowed("is_dir") }, .{ .bool = true });
             try arr.append(ctx.allocator, .{ .array = dot_entry });
         }
@@ -698,14 +686,15 @@ fn loadDirectoryEntries(ctx: *NativeContext, path: []const u8, flags: i64) Runti
         if (skip_dots and (std.mem.eql(u8, entry.name, ".") or std.mem.eql(u8, entry.name, ".."))) continue;
 
         const full = try std.fmt.allocPrint(ctx.allocator, "{s}/{s}", .{ path, entry.name });
-        try ctx.vm.strings.append(ctx.allocator, full);
+        const full_owned = try Value.String.adopt(ctx.allocator, full);
+        defer full_owned.release();
 
         const is_dir: bool = entry.kind == .directory;
-        const entry_arr = try ctx.allocator.create(PhpArray);
-        entry_arr.* = .{};
-        try ctx.vm.arrays.append(ctx.allocator, entry_arr);
-        try entry_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = Value.String.borrowed(try createString(ctx, entry.name)) });
-        try entry_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("path") }, .{ .string = Value.String.borrowed(full) });
+        const entry_arr = try ctx.createArray();
+        const name = try Value.String.create(ctx.allocator, entry.name);
+        defer name.release();
+        try entry_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = name });
+        try entry_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("path") }, .{ .string = full_owned });
         try entry_arr.set(ctx.allocator, .{ .string = Value.String.borrowed("is_dir") }, .{ .bool = is_dir });
 
         try arr.append(ctx.allocator, .{ .array = entry_arr });
@@ -721,92 +710,92 @@ fn syncCurrentEntry(ctx: *NativeContext, obj: *PhpObject) !void {
     if (entry != .array) return;
     const path_val = entry.array.get(.{ .string = Value.String.borrowed("path") });
     if (path_val == .string) {
-        try obj.set(ctx.allocator, "__pathname", .{ .string = path_val.string });
+        try obj.set(ctx.allocator, "__pathname", path_val);
     }
 }
 
-fn fsiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
+fn fsiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const path = args[0].string.bytes();
-    try obj.set(ctx.allocator, "__di_path", .{ .string = Value.String.borrowed(try createString(ctx, path)) });
+    try obj.set(ctx.allocator, "__di_path", args[0]);
     try obj.set(ctx.allocator, "__di_idx", .{ .int = 0 });
     // FilesystemIterator skips dots by default
     const entries = try loadDirectoryEntries(ctx, path, SKIP_DOTS);
     try obj.set(ctx.allocator, "__di_entries", .{ .array = entries });
     try syncCurrentEntry(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn diRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn diRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__di_idx", .{ .int = 0 });
     try syncCurrentEntry(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn diCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn diCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP's DirectoryIterator::current() returns the iterator itself
     // so methods like isDot(), getFilename(), getPathname() work on $entry
-    const obj = getThis(ctx) orelse return .null;
-    const entries = if (obj.get("__di_entries") == .array) obj.get("__di_entries").array else return .null;
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const entries = if (obj.get("__di_entries") == .array) obj.get("__di_entries").array else return NativeResult.scalar(.null);
     const idx: usize = @intCast(@max(0, objGetInt(obj, "__di_idx")));
-    if (idx >= entries.length()) return .{ .bool = false };
-    return .{ .object = obj };
+    if (idx >= entries.length()) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn diKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return .{ .int = objGetInt(obj, "__di_idx") };
+fn diKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__di_idx") });
 }
 
-fn diNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn diNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const idx = objGetInt(obj, "__di_idx");
     try obj.set(ctx.allocator, "__di_idx", .{ .int = idx + 1 });
     try syncCurrentEntry(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn diValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const entries = if (obj.get("__di_entries") == .array) obj.get("__di_entries").array else return .{ .bool = false };
+fn diValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const entries = if (obj.get("__di_entries") == .array) obj.get("__di_entries").array else return NativeResult.scalar(.{ .bool = false });
     const idx: usize = @intCast(@max(0, objGetInt(obj, "__di_idx")));
-    return .{ .bool = idx < entries.length() };
+    return NativeResult.scalar(.{ .bool = idx < entries.length() });
 }
 
-fn diIsDot(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const entries = if (obj.get("__di_entries") == .array) obj.get("__di_entries").array else return .{ .bool = false };
+fn diIsDot(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const entries = if (obj.get("__di_entries") == .array) obj.get("__di_entries").array else return NativeResult.scalar(.{ .bool = false });
     const idx: usize = @intCast(@max(0, objGetInt(obj, "__di_idx")));
-    if (idx >= entries.length()) return .{ .bool = false };
+    if (idx >= entries.length()) return NativeResult.scalar(.{ .bool = false });
     const entry = entries.get(.{ .int = @intCast(idx) });
-    if (entry != .array) return .{ .bool = false };
+    if (entry != .array) return NativeResult.scalar(.{ .bool = false });
     const name = entry.array.get(.{ .string = Value.String.borrowed("name") });
-    if (name != .string) return .{ .bool = false };
-    return .{ .bool = std.mem.eql(u8, name.string.bytes(), ".") or std.mem.eql(u8, name.string.bytes(), "..") };
+    if (name != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = std.mem.eql(u8, name.string.bytes(), ".") or std.mem.eql(u8, name.string.bytes(), "..") });
 }
 
 // ==========================================
 // RecursiveDirectoryIterator
 // ==========================================
 
-fn rdiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
+fn rdiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const path = args[0].string.bytes();
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
 
-    try obj.set(ctx.allocator, "__di_path", .{ .string = Value.String.borrowed(try createString(ctx, path)) });
+    try obj.set(ctx.allocator, "__di_path", args[0]);
     try obj.set(ctx.allocator, "__di_flags", .{ .int = flags });
     try obj.set(ctx.allocator, "__di_idx", .{ .int = 0 });
-    try obj.set(ctx.allocator, "__pathname", .{ .string = Value.String.borrowed(try createString(ctx, path)) });
-    try obj.set(ctx.allocator, "__rdi_root", .{ .string = Value.String.borrowed(try createString(ctx, path)) });
+    try obj.set(ctx.allocator, "__pathname", args[0]);
+    try obj.set(ctx.allocator, "__rdi_root", args[0]);
 
     const entries = try loadDirectoryEntries(ctx, path, flags);
     try obj.set(ctx.allocator, "__di_entries", .{ .array = entries });
     try syncCurrentEntry(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn rdiGetCurrentEntry(obj: *PhpObject) ?*PhpArray {
@@ -818,18 +807,18 @@ fn rdiGetCurrentEntry(obj: *PhpObject) ?*PhpArray {
     return entry.array;
 }
 
-fn rdiHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const entry = rdiGetCurrentEntry(obj) orelse return .{ .bool = false };
+fn rdiHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const entry = rdiGetCurrentEntry(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const is_dir = entry.get(.{ .string = Value.String.borrowed("is_dir") });
-    return .{ .bool = is_dir == .bool and is_dir.bool };
+    return NativeResult.scalar(.{ .bool = is_dir == .bool and is_dir.bool });
 }
 
-fn rdiGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const entry = rdiGetCurrentEntry(obj) orelse return .null;
+fn rdiGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const entry = rdiGetCurrentEntry(obj) orelse return NativeResult.scalar(.null);
     const path_val = entry.get(.{ .string = Value.String.borrowed("path") });
-    if (path_val != .string) return .null;
+    if (path_val != .string) return NativeResult.scalar(.null);
     const flags = objGetInt(obj, "__di_flags");
 
     const child = try ctx.createObject(obj.class_name);
@@ -847,63 +836,64 @@ fn rdiGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try child.set(ctx.allocator, "__di_entries", .{ .array = entries });
     try syncCurrentEntry(ctx, child);
 
-    return .{ .object = child };
+    return NativeResult.borrowed(.{ .object = child });
 }
 
-fn rdiGetSubPath(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
+fn rdiGetSubPath(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
     // subpath is relative path from root to current directory
     const path = objGetStr(obj, "__di_path");
     const root = objGetStr(obj, "__rdi_root");
     if (root.len > 0 and std.mem.startsWith(u8, path, root)) {
         var sub = path[root.len..];
         if (sub.len > 0 and sub[0] == '/') sub = sub[1..];
-        return .{ .string = Value.String.borrowed(try createString(ctx, sub)) };
+        return NativeResult.copyString(ctx.allocator, sub);
     }
-    return .{ .string = Value.String.borrowed("") };
+    return NativeResult.literal("");
 }
 
-fn rdiGetSubPathname(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
-    const entry = rdiGetCurrentEntry(obj) orelse return .{ .string = Value.String.borrowed("") };
+fn rdiGetSubPathname(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
+    const entry = rdiGetCurrentEntry(obj) orelse return NativeResult.literal("");
     const name = entry.get(.{ .string = Value.String.borrowed("name") });
-    const sub_path = try rdiGetSubPath(ctx, &.{});
+    const sub_result = try rdiGetSubPath(ctx, &.{});
+    const sub_path = sub_result.value;
+    defer if (sub_path == .string) sub_path.string.release();
     if (sub_path != .string or sub_path.string.bytes().len == 0) {
-        if (name == .string) return .{ .string = name.string };
-        return .{ .string = Value.String.borrowed("") };
+        if (name == .string) return NativeResult.shareString(name.string);
+        return NativeResult.literal("");
     }
-    if (name != .string) return sub_path;
+    if (name != .string) return NativeResult.share(sub_path);
     const result = try std.fmt.allocPrint(ctx.allocator, "{s}/{s}", .{ sub_path.string.bytes(), name.string.bytes() });
-    try ctx.vm.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn rdiRewind(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rdiRewind(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return diRewind(ctx, args);
 }
 
-fn rdiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const entry = rdiGetCurrentEntry(obj) orelse return .{ .bool = false };
+fn rdiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const entry = rdiGetCurrentEntry(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const path_val = entry.get(.{ .string = Value.String.borrowed("path") });
-    if (path_val != .string) return .null;
+    if (path_val != .string) return NativeResult.scalar(.null);
     const fi = try createFileInfoObj(ctx, path_val.string.bytes());
-    return .{ .object = fi };
+    return NativeResult.borrowed(.{ .object = fi });
 }
 
-fn rdiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
-    const entry = rdiGetCurrentEntry(obj) orelse return .{ .string = Value.String.borrowed("") };
+fn rdiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
+    const entry = rdiGetCurrentEntry(obj) orelse return NativeResult.literal("");
     const path_val = entry.get(.{ .string = Value.String.borrowed("path") });
-    if (path_val != .string) return .{ .string = Value.String.borrowed("") };
-    return path_val;
+    if (path_val != .string) return NativeResult.literal("");
+    return NativeResult.share(path_val);
 }
 
-fn rdiNext(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rdiNext(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return diNext(ctx, args);
 }
 
-fn rdiValid(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn rdiValid(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return diValid(ctx, args);
 }
 
@@ -932,51 +922,49 @@ fn gwGenerator(this: *PhpObject) ?*@import("../runtime/value.zig").Generator {
     return v.generator;
 }
 
-fn gwRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const gen = gwGenerator(this) orelse return .null;
+fn gwRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = gwGenerator(this) orelse return NativeResult.scalar(.null);
     if (gen.state == .created) try ctx.vm.resumeGenerator(gen, .null);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn gwCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const gen = gwGenerator(this) orelse return .null;
+fn gwCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = gwGenerator(this) orelse return NativeResult.scalar(.null);
     if (gen.state == .created) try ctx.vm.resumeGenerator(gen, .null);
-    ctx.returnShared(gen.current_value);
-    return gen.current_value;
+    return NativeResult.share(gen.current_value);
 }
 
-fn gwKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const gen = gwGenerator(this) orelse return .null;
+fn gwKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = gwGenerator(this) orelse return NativeResult.scalar(.null);
     if (gen.state == .created) try ctx.vm.resumeGenerator(gen, .null);
-    ctx.returnShared(gen.current_key);
-    return gen.current_key;
+    return NativeResult.share(gen.current_key);
 }
 
-fn gwNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .null;
-    const gen = gwGenerator(this) orelse return .null;
+fn gwNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const gen = gwGenerator(this) orelse return NativeResult.scalar(.null);
     if (gen.state == .created) try ctx.vm.resumeGenerator(gen, .null);
     try ctx.vm.resumeGenerator(gen, .null);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn gwValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const this = getThis(ctx) orelse return .{ .bool = false };
-    const gen = gwGenerator(this) orelse return .{ .bool = false };
+fn gwValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const gen = gwGenerator(this) orelse return NativeResult.scalar(.{ .bool = false });
     if (gen.state == .created) try ctx.vm.resumeGenerator(gen, .null);
-    return .{ .bool = gen.state != .completed };
+    return NativeResult.scalar(.{ .bool = gen.state != .completed });
 }
 
-fn filterConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn filterConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const inner = try wrapAsIterator(ctx, args[0]);
-    if (inner != .object) return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__fi_inner", inner);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn filterGetInnerIterator(obj: *PhpObject) ?*PhpObject {
@@ -985,13 +973,13 @@ fn filterGetInnerIterator(obj: *PhpObject) ?*PhpObject {
     return null;
 }
 
-fn filterRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = filterGetInnerIterator(obj) orelse return .null;
+fn filterRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "rewind", &.{});
     // advance to first accepted element
     try filterAdvanceToAccepted(ctx, obj, inner);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn filterAdvanceToAccepted(ctx: *NativeContext, obj: *PhpObject, inner: *PhpObject) !void {
@@ -1004,52 +992,52 @@ fn filterAdvanceToAccepted(ctx: *NativeContext, obj: *PhpObject, inner: *PhpObje
     }
 }
 
-fn filterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = filterGetInnerIterator(obj) orelse return .null;
-    return ctx.vm.callMethod(inner, "current", &.{});
+fn filterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(inner, "current", &.{}));
 }
 
-fn filterKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = filterGetInnerIterator(obj) orelse return .null;
-    return ctx.vm.callMethod(inner, "key", &.{});
+fn filterKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(inner, "key", &.{}));
 }
 
-fn filterNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = filterGetInnerIterator(obj) orelse return .null;
+fn filterNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "next", &.{});
     try filterAdvanceToAccepted(ctx, obj, inner);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn filterValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const inner = filterGetInnerIterator(obj) orelse return .{ .bool = false };
-    return ctx.vm.callMethod(inner, "valid", &.{});
+fn filterValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callMethod(inner, "valid", &.{}));
 }
 
-fn filterGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = filterGetInnerIterator(obj) orelse return .null;
-    return .{ .object = inner };
+fn filterGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .object = inner });
 }
 
-fn filterGetFilename(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = filterGetInnerIterator(obj) orelse return .null;
-    if (ctx.vm.hasMethod(inner.class_name, "getFilename")) return ctx.vm.callMethod(inner, "getFilename", &.{});
+fn filterGetFilename(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.null);
+    if (ctx.vm.hasMethod(inner.class_name, "getFilename")) return NativeResult.share(try ctx.vm.callMethod(inner, "getFilename", &.{}));
     const current = try ctx.vm.callMethod(inner, "current", &.{});
-    return if (current == .object) ctx.vm.callMethod(current.object, "getFilename", &.{}) else .null;
+    return if (current == .object) NativeResult.share(try ctx.vm.callMethod(current.object, "getFilename", &.{})) else NativeResult.scalar(.null);
 }
 
-fn filterIsDir(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const inner = filterGetInnerIterator(obj) orelse return .{ .bool = false };
-    if (ctx.vm.hasMethod(inner.class_name, "isDir")) return ctx.vm.callMethod(inner, "isDir", &.{});
+fn filterIsDir(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const inner = filterGetInnerIterator(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.hasMethod(inner.class_name, "isDir")) return NativeResult.share(try ctx.vm.callMethod(inner, "isDir", &.{}));
     const current = try ctx.vm.callMethod(inner, "current", &.{});
-    return if (current == .object) ctx.vm.callMethod(current.object, "isDir", &.{}) else .{ .bool = false };
+    return if (current == .object) NativeResult.share(try ctx.vm.callMethod(current.object, "isDir", &.{})) else NativeResult.scalar(.{ .bool = false });
 }
 
 // ==========================================
@@ -1059,25 +1047,23 @@ fn filterIsDir(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
 // stores a stack of iterators to flatten recursive iteration
 // mode: 0=LEAVES_ONLY, 1=SELF_FIRST, 2=CHILD_FIRST
 
-fn riiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn riiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const inner = try wrapAsIterator(ctx, args[0]);
-    if (inner != .object) return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
     const mode: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
 
     try obj.set(ctx.allocator, "__rii_mode", .{ .int = mode });
     try obj.set(ctx.allocator, "__rii_depth", .{ .int = 0 });
 
     // store iterator stack as an array of objects
-    const stack = try ctx.allocator.create(PhpArray);
-    stack.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, stack);
+    const stack = try ctx.createArray();
     try stack.append(ctx.allocator, inner);
     try obj.set(ctx.allocator, "__rii_stack", .{ .array = stack });
     try obj.set(ctx.allocator, "__rii_valid", .{ .bool = false });
 
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn riiGetStack(obj: *PhpObject) ?*PhpArray {
@@ -1094,19 +1080,19 @@ fn riiCurrentIterator(obj: *PhpObject) ?*PhpObject {
     return null;
 }
 
-fn riiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const stack = riiGetStack(obj) orelse return .null;
+fn riiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const stack = riiGetStack(obj) orelse return NativeResult.scalar(.null);
 
     // reset stack to just the root iterator
-    if (stack.length() == 0) return .null;
+    if (stack.length() == 0) return NativeResult.scalar(.null);
     const root = stack.get(.{ .int = 0 });
     stack.entries.items.len = 0;
     stack.next_int_key = 0;
     try stack.append(ctx.allocator, root);
     try obj.set(ctx.allocator, "__rii_depth", .{ .int = 0 });
 
-    if (root != .object) return .null;
+    if (root != .object) return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(root.object, "rewind", &.{});
 
     const valid = try ctx.vm.callMethod(root.object, "valid", &.{});
@@ -1122,7 +1108,7 @@ fn riiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             try riiDescend(ctx, obj);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn riiDescend(ctx: *NativeContext, obj: *PhpObject) !void {
@@ -1167,22 +1153,22 @@ fn riiDescend(ctx: *NativeContext, obj: *PhpObject) !void {
     }
 }
 
-fn riiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iter_obj = riiCurrentIterator(obj) orelse return .null;
-    return ctx.vm.callMethod(iter_obj, "current", &.{});
+fn riiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iter_obj = riiCurrentIterator(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(iter_obj, "current", &.{}));
 }
 
-fn riiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iter_obj = riiCurrentIterator(obj) orelse return .null;
-    return ctx.vm.callMethod(iter_obj, "key", &.{});
+fn riiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iter_obj = riiCurrentIterator(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(iter_obj, "key", &.{}));
 }
 
-fn riiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn riiNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try riiAdvance(ctx, obj);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn riiAdvance(ctx: *NativeContext, obj: *PhpObject) !void {
@@ -1249,52 +1235,52 @@ fn riiAdvanceFlat(ctx: *NativeContext, obj: *PhpObject, stack: *PhpArray) !void 
     try obj.set(ctx.allocator, "__rii_valid", .{ .bool = false });
 }
 
-fn riiValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    return obj.get("__rii_valid");
+fn riiValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(obj.get("__rii_valid"));
 }
 
-fn riiSetMaxDepth(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn riiSetMaxDepth(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const v: i64 = if (args.len >= 1) Value.toInt(args[0]) else -1;
     try obj.set(ctx.allocator, "__rii_max_depth", .{ .int = v });
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn riiGetMaxDepth(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn riiGetMaxDepth(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const v = obj.get("__rii_max_depth");
-    if (v == .int and v.int < 0) return .{ .bool = false };
-    if (v == .null) return .{ .bool = false };
-    return v;
+    if (v == .int and v.int < 0) return NativeResult.scalar(.{ .bool = false });
+    if (v == .null) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(v);
 }
 
-fn riiGetDepth(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__rii_depth") };
+fn riiGetDepth(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__rii_depth") });
 }
 
-fn riiGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iter_obj = riiCurrentIterator(obj) orelse return .null;
-    return .{ .object = iter_obj };
+fn riiGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iter_obj = riiCurrentIterator(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .object = iter_obj });
 }
 
-fn riiGetSubIterator(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const stack = riiGetStack(obj) orelse return .null;
+fn riiGetSubIterator(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const stack = riiGetStack(obj) orelse return NativeResult.scalar(.null);
     const depth: usize = if (args.len >= 1) @intCast(@max(0, Value.toInt(args[0]))) else @intCast(@max(0, objGetInt(obj, "__rii_depth")));
-    if (depth >= stack.length()) return .null;
-    return stack.get(.{ .int = @intCast(depth) });
+    if (depth >= stack.length()) return NativeResult.scalar(.null);
+    return NativeResult.borrowed(stack.get(.{ .int = @intCast(depth) }));
 }
 
 // ==========================================
 // IteratorIterator
 // ==========================================
 
-fn iiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn iiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     var inner = try wrapAsIterator(ctx, args[0]);
     // unwrap IteratorAggregate chains (PHP follows getIterator until it reaches
     // a real Iterator; depth-limit guards against runaway recursion)
@@ -1304,9 +1290,9 @@ fn iiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (!ctx.vm.isInstanceOf(inner.object.class_name, "IteratorAggregate")) break;
         inner = try ctx.vm.callMethod(inner.object, "getIterator", &.{});
     }
-    if (inner != .object) return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__ii_inner", inner);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn iiGetInnerObj(obj: *PhpObject) ?*PhpObject {
@@ -1315,81 +1301,81 @@ fn iiGetInnerObj(obj: *PhpObject) ?*PhpObject {
     return null;
 }
 
-fn iiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+fn iiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "rewind", &.{});
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn iiValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const inner = iiGetInnerObj(obj) orelse return .{ .bool = false };
-    return ctx.vm.callMethod(inner, "valid", &.{});
+fn iiValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callMethod(inner, "valid", &.{}));
 }
 
-fn iiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
-    return ctx.vm.callMethod(inner, "current", &.{});
+fn iiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(inner, "current", &.{}));
 }
 
-fn iiKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
-    return ctx.vm.callMethod(inner, "key", &.{});
+fn iiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(inner, "key", &.{}));
 }
 
-fn iiNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+fn iiNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "next", &.{});
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn iiGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
-    return .{ .object = inner };
+fn iiGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .object = inner });
 }
 
 // ==========================================
 // EmptyIterator
 // ==========================================
 
-fn emptyNoop(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn emptyNoop(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn emptyValid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = false };
+fn emptyValid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn emptyCurrent(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn emptyCurrent(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
 // ==========================================
 // LimitIterator
 // ==========================================
 
-fn limitConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn limitConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const inner = try wrapAsIterator(ctx, args[0]);
-    if (inner != .object) return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__ii_inner", inner);
     const offset: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     const count: i64 = if (args.len >= 3) Value.toInt(args[2]) else -1;
     try obj.set(ctx.allocator, "__li_offset", .{ .int = offset });
     try obj.set(ctx.allocator, "__li_count", .{ .int = count });
     try obj.set(ctx.allocator, "__li_pos", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn limitRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+fn limitRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "rewind", &.{});
     const offset = objGetInt(obj, "__li_offset");
     var i: i64 = 0;
@@ -1399,40 +1385,40 @@ fn limitRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
         _ = try ctx.vm.callMethod(inner, "next", &.{});
     }
     try obj.set(ctx.allocator, "__li_pos", .{ .int = offset });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn limitValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const inner = iiGetInnerObj(obj) orelse return .{ .bool = false };
+fn limitValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const count = objGetInt(obj, "__li_count");
     const offset = objGetInt(obj, "__li_offset");
     const pos = objGetInt(obj, "__li_pos");
-    if (count >= 0 and (pos - offset) >= count) return .{ .bool = false };
-    return ctx.vm.callMethod(inner, "valid", &.{});
+    if (count >= 0 and (pos - offset) >= count) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callMethod(inner, "valid", &.{}));
 }
 
-fn limitNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+fn limitNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "next", &.{});
     try obj.set(ctx.allocator, "__li_pos", .{ .int = objGetInt(obj, "__li_pos") + 1 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn limitGetPosition(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__li_pos") };
+fn limitGetPosition(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__li_pos") });
 }
 
-fn limitSeek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn limitSeek(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const target = Value.toInt(args[0]);
     const offset = objGetInt(obj, "__li_offset");
     const count = objGetInt(obj, "__li_count");
-    if (target < offset or (count >= 0 and target >= offset + count)) return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+    if (target < offset or (count >= 0 and target >= offset + count)) return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     const cur = objGetInt(obj, "__li_pos");
     if (target < cur) {
         _ = try limitRewind(ctx, &.{});
@@ -1443,36 +1429,34 @@ fn limitSeek(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         _ = try ctx.vm.callMethod(inner, "next", &.{});
         try obj.set(ctx.allocator, "__li_pos", .{ .int = objGetInt(obj, "__li_pos") + 1 });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ==========================================
 // InfiniteIterator
 // ==========================================
 
-fn infiniteNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+fn infiniteNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "next", &.{});
     const valid = try ctx.vm.callMethod(inner, "valid", &.{});
     if (!valid.isTruthy()) {
         _ = try ctx.vm.callMethod(inner, "rewind", &.{});
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ==========================================
 // AppendIterator
 // ==========================================
 
-fn appConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const arr = try ctx.allocator.create(PhpArray);
-    arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, arr);
+fn appConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = try ctx.createArray();
     try obj.set(ctx.allocator, "__app_iters", .{ .array = arr });
     try obj.set(ctx.allocator, "__app_idx", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn appGetIters(obj: *PhpObject) ?*PhpArray {
@@ -1481,18 +1465,18 @@ fn appGetIters(obj: *PhpObject) ?*PhpArray {
     return null;
 }
 
-fn appAppend(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn appAppend(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const inner = try wrapAsIterator(ctx, args[0]);
-    if (inner != .object) return .null;
-    const iters = appGetIters(obj) orelse return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
+    const iters = appGetIters(obj) orelse return NativeResult.scalar(.null);
     try iters.append(ctx.allocator, inner);
     // if this is the first iterator and we haven't started, rewind it
     if (iters.length() == 1) {
         _ = try ctx.vm.callMethod(inner.object, "rewind", &.{});
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn appCurrentIter(obj: *PhpObject) ?*PhpObject {
@@ -1504,24 +1488,24 @@ fn appCurrentIter(obj: *PhpObject) ?*PhpObject {
     return null;
 }
 
-fn appRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn appRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__app_idx", .{ .int = 0 });
-    const iter = appCurrentIter(obj) orelse return .null;
+    const iter = appCurrentIter(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(iter, "rewind", &.{});
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn appValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const iters = appGetIters(obj) orelse return .{ .bool = false };
+fn appValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const iters = appGetIters(obj) orelse return NativeResult.scalar(.{ .bool = false });
     while (true) {
         const idx = objGetInt(obj, "__app_idx");
-        if (idx < 0 or idx >= iters.length()) return .{ .bool = false };
+        if (idx < 0 or idx >= iters.length()) return NativeResult.scalar(.{ .bool = false });
         const v = iters.get(.{ .int = idx });
-        if (v != .object) return .{ .bool = false };
+        if (v != .object) return NativeResult.scalar(.{ .bool = false });
         const valid = try ctx.vm.callMethod(v.object, "valid", &.{});
-        if (valid.isTruthy()) return .{ .bool = true };
+        if (valid.isTruthy()) return NativeResult.scalar(.{ .bool = true });
         try obj.set(ctx.allocator, "__app_idx", .{ .int = idx + 1 });
         if (idx + 1 < iters.length()) {
             const nxt = iters.get(.{ .int = idx + 1 });
@@ -1532,90 +1516,90 @@ fn appValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     }
 }
 
-fn appCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iter = appCurrentIter(obj) orelse return .null;
-    return ctx.vm.callMethod(iter, "current", &.{});
+fn appCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iter = appCurrentIter(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(iter, "current", &.{}));
 }
 
-fn appKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iter = appCurrentIter(obj) orelse return .null;
-    return ctx.vm.callMethod(iter, "key", &.{});
+fn appKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iter = appCurrentIter(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.vm.callMethod(iter, "key", &.{}));
 }
 
-fn appNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iter = appCurrentIter(obj) orelse return .null;
+fn appNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iter = appCurrentIter(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(iter, "next", &.{});
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn appGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iter = appCurrentIter(obj) orelse return .null;
-    return .{ .object = iter };
+fn appGetInner(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iter = appCurrentIter(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .object = iter });
 }
 
-fn appGetIndex(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__app_idx") };
+fn appGetIndex(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__app_idx") });
 }
 
-fn appGetArrayIterator(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const iters = appGetIters(obj) orelse return .null;
-    return .{ .array = iters };
+fn appGetArrayIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const iters = appGetIters(obj) orelse return NativeResult.scalar(.null);
+    return NativeResult.borrowed(.{ .array = iters });
 }
 
 // ==========================================
 // CallbackFilterIterator
 // ==========================================
 
-fn cbfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn cbfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const inner = try wrapAsIterator(ctx, args[0]);
-    if (inner != .object) return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__fi_inner", inner);
     if (args.len >= 2) try obj.set(ctx.allocator, "__cb_fn", args[1]);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn cbfAccept(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn cbfAccept(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const cb = obj.get("__cb_fn");
-    if (cb == .null) return .{ .bool = false };
+    if (cb == .null) return NativeResult.scalar(.{ .bool = false });
     const inner_v = obj.get("__fi_inner");
-    if (inner_v != .object) return .{ .bool = false };
+    if (inner_v != .object) return NativeResult.scalar(.{ .bool = false });
     const cur = try ctx.vm.callMethod(inner_v.object, "current", &.{});
     const key = try ctx.vm.callMethod(inner_v.object, "key", &.{});
     const result = try ctx.invokeCallable(cb, &.{ cur, key, inner_v });
-    return .{ .bool = result.isTruthy() };
+    return NativeResult.scalar(.{ .bool = result.isTruthy() });
 }
 
 // ==========================================
 // RegexIterator
 // ==========================================
 
-fn rxConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn rxConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const inner = try wrapAsIterator(ctx, args[0]);
-    if (inner != .object) return .null;
-    if (args.len < 2 or args[1] != .string) return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__fi_inner", inner);
-    try obj.set(ctx.allocator, "__rx_regex", .{ .string = Value.String.borrowed(try createString(ctx, args[1].string.bytes())) });
+    try obj.set(ctx.allocator, "__rx_regex", args[1]);
     const mode: i64 = if (args.len >= 3) Value.toInt(args[2]) else 0;
     const flags: i64 = if (args.len >= 4) Value.toInt(args[3]) else 0;
     const preg_flags: i64 = if (args.len >= 5) Value.toInt(args[4]) else 0;
     try obj.set(ctx.allocator, "__rx_mode", .{ .int = mode });
     try obj.set(ctx.allocator, "__rx_flags", .{ .int = flags });
     try obj.set(ctx.allocator, "__rx_preg_flags", .{ .int = preg_flags });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rxSubjectFromInner(ctx: *NativeContext, obj: *PhpObject) RuntimeError!?[]const u8 {
+fn rxSubjectFromInner(ctx: *NativeContext, obj: *PhpObject) RuntimeError!?Value.String {
     const inner_v = obj.get("__fi_inner");
     if (inner_v != .object) return null;
     const flags = objGetInt(obj, "__rx_flags");
@@ -1623,131 +1607,128 @@ fn rxSubjectFromInner(ctx: *NativeContext, obj: *PhpObject) RuntimeError!?[]cons
         try ctx.vm.callMethod(inner_v.object, "key", &.{})
     else
         try ctx.vm.callMethod(inner_v.object, "current", &.{});
-    if (subject_val == .string) return subject_val.string.bytes();
+    if (subject_val == .string) {
+        subject_val.string.retain();
+        return subject_val.string;
+    }
     if (subject_val == .int or subject_val == .float or subject_val == .bool) {
         var buf: std.ArrayListUnmanaged(u8) = .{};
+        defer buf.deinit(ctx.allocator);
         try subject_val.format(&buf, ctx.allocator);
-        const s = try ctx.allocator.dupe(u8, buf.items);
-        buf.deinit(ctx.allocator);
-        try ctx.vm.strings.append(ctx.allocator, s);
-        return s;
+        return try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator));
     }
     return null;
 }
 
-fn rxAccept(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn rxAccept(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const regex = objGetStr(obj, "__rx_regex");
-    if (regex.len == 0) return .{ .bool = false };
+    if (regex.len == 0) return NativeResult.scalar(.{ .bool = false });
     // arrays pass through so recursive variants can descend into them
     const inner_v = obj.get("__fi_inner");
     if (inner_v == .object) {
         const flags_check = objGetInt(obj, "__rx_flags");
         if ((flags_check & 1) == 0) {
             const cur_check = try ctx.vm.callMethod(inner_v.object, "current", &.{});
-            if (cur_check == .array) return .{ .bool = true };
+            if (cur_check == .array) return NativeResult.scalar(.{ .bool = true });
         }
     }
-    const subject = (try rxSubjectFromInner(ctx, obj)) orelse return .{ .bool = false };
+    const subject = (try rxSubjectFromInner(ctx, obj)) orelse return NativeResult.scalar(.{ .bool = false });
+    defer subject.release();
     const flags = objGetInt(obj, "__rx_flags");
     const invert = (flags & 2) != 0;
 
-    const matches_arr = try ctx.allocator.create(PhpArray);
-    matches_arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, matches_arr);
-    const result = try ctx.vm.callByName("preg_match", &.{ .{ .string = Value.String.borrowed(regex) }, .{ .string = Value.String.borrowed(subject) }, .{ .array = matches_arr } });
+    const matches_arr = try ctx.createArray();
+    const result = try ctx.vm.callByName("preg_match", &.{ .{ .string = Value.String.borrowed(regex) }, .{ .string = subject }, .{ .array = matches_arr } });
     const matched = result == .int and result.int == 1;
     try obj.set(ctx.allocator, "__rx_match", .{ .array = matches_arr });
-    return .{ .bool = if (invert) !matched else matched };
+    return NativeResult.scalar(.{ .bool = if (invert) !matched else matched });
 }
 
-fn rxCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn rxCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const inner_v = obj.get("__fi_inner");
-    if (inner_v != .object) return .null;
+    if (inner_v != .object) return NativeResult.scalar(.null);
     const mode = objGetInt(obj, "__rx_mode");
     if (mode == 0) {
-        return ctx.vm.callMethod(inner_v.object, "current", &.{});
+        return NativeResult.share(try ctx.vm.callMethod(inner_v.object, "current", &.{}));
     }
     if (mode == 1) {
         const m = obj.get("__rx_match");
-        if (m == .array) return m;
-        return .null;
+        if (m == .array) return NativeResult.borrowed(m);
+        return NativeResult.scalar(.null);
     }
     if (mode == 2 or mode == 3) {
-        const subject = (try rxSubjectFromInner(ctx, obj)) orelse return .null;
+        const subject = (try rxSubjectFromInner(ctx, obj)) orelse return NativeResult.scalar(.null);
+        defer subject.release();
         const regex = objGetStr(obj, "__rx_regex");
         if (mode == 3) {
-            return ctx.vm.callByName("preg_split", &.{ .{ .string = Value.String.borrowed(regex) }, .{ .string = Value.String.borrowed(subject) } });
+            return NativeResult.share(try ctx.vm.callByName("preg_split", &.{ .{ .string = Value.String.borrowed(regex) }, .{ .string = subject } }));
         } else {
-            const out_arr = try ctx.allocator.create(PhpArray);
-            out_arr.* = .{};
-            try ctx.vm.arrays.append(ctx.allocator, out_arr);
-            _ = try ctx.vm.callByName("preg_match_all", &.{ .{ .string = Value.String.borrowed(regex) }, .{ .string = Value.String.borrowed(subject) }, .{ .array = out_arr } });
-            return .{ .array = out_arr };
+            const out_arr = try ctx.createArray();
+            _ = try ctx.vm.callByName("preg_match_all", &.{ .{ .string = Value.String.borrowed(regex) }, .{ .string = subject }, .{ .array = out_arr } });
+            return NativeResult.borrowed(.{ .array = out_arr });
         }
     }
-    return ctx.vm.callMethod(inner_v.object, "current", &.{});
+    return NativeResult.share(try ctx.vm.callMethod(inner_v.object, "current", &.{}));
 }
 
-fn rxGetRegex(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(objGetStr(obj, "__rx_regex")) };
+fn rxGetRegex(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
+    return NativeResult.share(obj.get("__rx_regex"));
 }
 
-fn rxGetMode(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__rx_mode") };
+fn rxGetMode(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__rx_mode") });
 }
 
-fn rxSetMode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn rxSetMode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__rx_mode", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rxGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__rx_flags") };
+fn rxGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__rx_flags") });
 }
 
-fn rxSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn rxSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__rx_flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn rxGetPregFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__rx_preg_flags") };
+fn rxGetPregFlags(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__rx_preg_flags") });
 }
 
-fn rxSetPregFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn rxSetPregFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__rx_preg_flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ==========================================
 // CachingIterator
 // ==========================================
 
-fn ciConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn ciConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     const inner = try wrapAsIterator(ctx, args[0]);
-    if (inner != .object) return .null;
+    if (inner != .object) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__ii_inner", inner);
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 1;
     try obj.set(ctx.allocator, "__ci_flags", .{ .int = flags });
-    const cache = try ctx.allocator.create(PhpArray);
-    cache.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, cache);
+    const cache = try ctx.createArray();
     try obj.set(ctx.allocator, "__ci_cache", .{ .array = cache });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 fn ciCacheCurrent(ctx: *NativeContext, obj: *PhpObject, inner: *PhpObject) !void {
@@ -1769,146 +1750,140 @@ fn ciCacheCurrent(ctx: *NativeContext, obj: *PhpObject, inner: *PhpObject) !void
     }
 }
 
-fn ciRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+fn ciRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     _ = try ctx.vm.callMethod(inner, "rewind", &.{});
     try ciCacheCurrent(ctx, obj, inner);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn ciValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn ciValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const v = obj.get("__ci_valid");
-    if (v == .bool) return v;
-    return .{ .bool = false };
+    if (v == .bool) return NativeResult.scalar(v);
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn ciCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__ci_current");
+fn ciCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__ci_current"));
 }
 
-fn ciKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__ci_key");
+fn ciKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__ci_key"));
 }
 
-fn ciNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const inner = iiGetInnerObj(obj) orelse return .null;
+fn ciNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.null);
     try ciCacheCurrent(ctx, obj, inner);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn ciHasNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const inner = iiGetInnerObj(obj) orelse return .{ .bool = false };
-    return ctx.vm.callMethod(inner, "valid", &.{});
+fn ciHasNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const inner = iiGetInnerObj(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callMethod(inner, "valid", &.{}));
 }
 
-fn ciToString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
+fn ciToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
     const flags = objGetInt(obj, "__ci_flags");
     const target = if ((flags & 4) != 0) obj.get("__ci_key") else if ((flags & 16) != 0) blk: {
         const inner = iiGetInnerObj(obj) orelse break :blk obj.get("__ci_current");
         break :blk try ctx.vm.callMethod(inner, "current", &.{});
     } else obj.get("__ci_current");
-    if (target == .string) return .{ .string = target.string };
+    if (target == .string) return NativeResult.shareString(target.string);
     var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(ctx.allocator);
     try target.format(&buf, ctx.allocator);
-    const s = try ctx.allocator.dupe(u8, buf.items);
-    buf.deinit(ctx.allocator);
-    try ctx.vm.strings.append(ctx.allocator, s);
-    return .{ .string = Value.String.borrowed(s) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator)));
 }
 
-fn ciGetCache(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    return obj.get("__ci_cache");
+fn ciGetCache(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(obj.get("__ci_cache"));
 }
 
-fn ciGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__ci_flags") };
+fn ciGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__ci_flags") });
 }
 
-fn ciSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn ciSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__ci_flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ==========================================
 // MultipleIterator
 // ==========================================
 
-fn miConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn miConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const flags: i64 = if (args.len >= 1) Value.toInt(args[0]) else 1;
     try obj.set(ctx.allocator, "__mi_flags", .{ .int = flags });
-    const iters = try ctx.allocator.create(PhpArray);
-    iters.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, iters);
-    const keys = try ctx.allocator.create(PhpArray);
-    keys.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, keys);
+    const iters = try ctx.createArray();
+    const keys = try ctx.createArray();
     try obj.set(ctx.allocator, "__mi_iters", .{ .array = iters });
     try obj.set(ctx.allocator, "__mi_keys", .{ .array = keys });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn miAttach(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
-    if (args[0] != .object and args[0] != .generator) return .null;
+fn miAttach(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    if (args[0] != .object and args[0] != .generator) return NativeResult.scalar(.null);
     const iters_v = obj.get("__mi_iters");
     const keys_v = obj.get("__mi_keys");
-    if (iters_v != .array or keys_v != .array) return .null;
+    if (iters_v != .array or keys_v != .array) return NativeResult.scalar(.null);
     try iters_v.array.append(ctx.allocator, args[0]);
     if (args.len >= 2 and (args[1] == .string or args[1] == .int)) {
         try keys_v.array.append(ctx.allocator, args[1]);
     } else {
         try keys_v.array.append(ctx.allocator, .null);
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn miDetach(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .object) return .null;
+fn miDetach(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
     const iters_v = obj.get("__mi_iters");
     const keys_v = obj.get("__mi_keys");
-    if (iters_v != .array or keys_v != .array) return .null;
+    if (iters_v != .array or keys_v != .array) return NativeResult.scalar(.null);
     var i: usize = 0;
     while (i < iters_v.array.entries.items.len) : (i += 1) {
         const e = iters_v.array.entries.items[i];
         if (e.value == .object and e.value.object == args[0].object) {
             _ = iters_v.array.entries.orderedRemove(i);
             if (i < keys_v.array.entries.items.len) _ = keys_v.array.entries.orderedRemove(i);
-            return .null;
+            return NativeResult.scalar(.null);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn miContains(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
+fn miContains(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
     const iters_v = obj.get("__mi_iters");
-    if (iters_v != .array) return .{ .bool = false };
+    if (iters_v != .array) return NativeResult.scalar(.{ .bool = false });
     for (iters_v.array.entries.items) |e| {
-        if (e.value == .object and e.value.object == args[0].object) return .{ .bool = true };
+        if (e.value == .object and e.value.object == args[0].object) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn miCountIterators(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
+fn miCountIterators(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const iters_v = obj.get("__mi_iters");
-    if (iters_v != .array) return .{ .int = 0 };
-    return .{ .int = iters_v.array.length() };
+    if (iters_v != .array) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = iters_v.array.length() });
 }
 
 fn miCallValid(ctx: *NativeContext, v: Value) !bool {
@@ -1951,18 +1926,18 @@ fn miCallRewind(ctx: *NativeContext, v: Value) !void {
     }
 }
 
-fn miRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn miRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const iters_v = obj.get("__mi_iters");
-    if (iters_v != .array) return .null;
+    if (iters_v != .array) return NativeResult.scalar(.null);
     for (iters_v.array.entries.items) |e| try miCallRewind(ctx, e.value);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn miValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn miValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const iters_v = obj.get("__mi_iters");
-    if (iters_v != .array or iters_v.array.length() == 0) return .{ .bool = false };
+    if (iters_v != .array or iters_v.array.length() == 0) return NativeResult.scalar(.{ .bool = false });
     const flags = objGetInt(obj, "__mi_flags");
     const need_all = (flags & 1) != 0;
     var any: bool = false;
@@ -1970,19 +1945,17 @@ fn miValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     for (iters_v.array.entries.items) |e| {
         if (try miCallValid(ctx, e.value)) any = true else all = false;
     }
-    return .{ .bool = if (need_all) all else any };
+    return NativeResult.scalar(.{ .bool = if (need_all) all else any });
 }
 
-fn miCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn miCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const iters_v = obj.get("__mi_iters");
     const keys_v = obj.get("__mi_keys");
-    if (iters_v != .array) return .null;
+    if (iters_v != .array) return NativeResult.scalar(.null);
     const flags = objGetInt(obj, "__mi_flags");
     const assoc = (flags & 2) != 0;
-    const result = try ctx.allocator.create(PhpArray);
-    result.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, result);
+    const result = try ctx.createArray();
     var idx: i64 = 0;
     for (iters_v.array.entries.items, 0..) |e, i| {
         var v: Value = .null;
@@ -1995,19 +1968,17 @@ fn miCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             idx += 1;
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn miKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn miKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const iters_v = obj.get("__mi_iters");
     const keys_v = obj.get("__mi_keys");
-    if (iters_v != .array) return .null;
+    if (iters_v != .array) return NativeResult.scalar(.null);
     const flags = objGetInt(obj, "__mi_flags");
     const assoc = (flags & 2) != 0;
-    const result = try ctx.allocator.create(PhpArray);
-    result.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, result);
+    const result = try ctx.createArray();
     var idx: i64 = 0;
     for (iters_v.array.entries.items, 0..) |e, i| {
         var v: Value = .null;
@@ -2020,75 +1991,75 @@ fn miKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             idx += 1;
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn miNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn miNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const iters_v = obj.get("__mi_iters");
-    if (iters_v != .array) return .null;
+    if (iters_v != .array) return NativeResult.scalar(.null);
     for (iters_v.array.entries.items) |e| try miCallNext(ctx, e.value);
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn miGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    return .{ .int = objGetInt(obj, "__mi_flags") };
+fn miGetFlags(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = objGetInt(obj, "__mi_flags") });
 }
 
-fn miSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1) return .null;
+fn miSetFlags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__mi_flags", .{ .int = Value.toInt(args[0]) });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ==========================================
 // RecursiveFilterIterator / RecursiveCallbackFilterIterator / RecursiveRegexIterator
 // ==========================================
 
-fn rfiHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn rfiHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const inner_v = obj.get("__fi_inner");
-    if (inner_v != .object) return .{ .bool = false };
-    return ctx.vm.callMethod(inner_v.object, "hasChildren", &.{});
+    if (inner_v != .object) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.vm.callMethod(inner_v.object, "hasChildren", &.{}));
 }
 
-fn rfiGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn rfiGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const inner_v = obj.get("__fi_inner");
-    if (inner_v != .object) return .null;
+    if (inner_v != .object) return NativeResult.scalar(.null);
     const child_inner = try ctx.vm.callMethod(inner_v.object, "getChildren", &.{});
-    if (child_inner != .object) return .null;
+    if (child_inner != .object) return NativeResult.scalar(.null);
     const new_obj = try ctx.allocator.create(PhpObject);
     new_obj.* = .{ .class_name = obj.class_name };
     try ctx.vm.objects.append(ctx.allocator, new_obj);
     ctx.vm.initObjectProperties(new_obj, obj.class_name) catch {};
     try new_obj.set(ctx.allocator, "__fi_inner", child_inner);
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
-fn rcbfGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn rcbfGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const inner_v = obj.get("__fi_inner");
-    if (inner_v != .object) return .null;
+    if (inner_v != .object) return NativeResult.scalar(.null);
     const child_inner = try ctx.vm.callMethod(inner_v.object, "getChildren", &.{});
-    if (child_inner != .object) return .null;
+    if (child_inner != .object) return NativeResult.scalar(.null);
     const new_obj = try ctx.allocator.create(PhpObject);
     new_obj.* = .{ .class_name = obj.class_name };
     try ctx.vm.objects.append(ctx.allocator, new_obj);
     ctx.vm.initObjectProperties(new_obj, obj.class_name) catch {};
     try new_obj.set(ctx.allocator, "__fi_inner", child_inner);
     try new_obj.set(ctx.allocator, "__cb_fn", obj.get("__cb_fn"));
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
-fn rrxGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn rrxGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const inner_v = obj.get("__fi_inner");
-    if (inner_v != .object) return .null;
+    if (inner_v != .object) return NativeResult.scalar(.null);
     const child_inner = try ctx.vm.callMethod(inner_v.object, "getChildren", &.{});
-    if (child_inner != .object) return .null;
+    if (child_inner != .object) return NativeResult.scalar(.null);
     const new_obj = try ctx.allocator.create(PhpObject);
     new_obj.* = .{ .class_name = obj.class_name };
     try ctx.vm.objects.append(ctx.allocator, new_obj);
@@ -2098,99 +2069,99 @@ fn rrxGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try new_obj.set(ctx.allocator, "__rx_mode", obj.get("__rx_mode"));
     try new_obj.set(ctx.allocator, "__rx_flags", obj.get("__rx_flags"));
     try new_obj.set(ctx.allocator, "__rx_preg_flags", obj.get("__rx_preg_flags"));
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
 // ==========================================
 // RecursiveArrayIterator
 // ==========================================
 
-fn raiHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn raiHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const cur = try ctx.vm.callMethod(obj, "current", &.{});
-    return .{ .bool = cur == .array };
+    return NativeResult.scalar(.{ .bool = cur == .array });
 }
 
-fn raiGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn raiGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const cur = try ctx.vm.callMethod(obj, "current", &.{});
-    if (cur != .array) return .null;
+    if (cur != .array) return NativeResult.scalar(.null);
     const new_obj = try ctx.allocator.create(PhpObject);
     new_obj.* = .{ .class_name = "RecursiveArrayIterator" };
     try ctx.vm.objects.append(ctx.allocator, new_obj);
     ctx.vm.initObjectProperties(new_obj, "RecursiveArrayIterator") catch {};
     _ = try ctx.vm.callMethod(new_obj, "__construct", &.{cur});
-    return .{ .object = new_obj };
+    return NativeResult.borrowed(.{ .object = new_obj });
 }
 
 // ==========================================
 // RecursiveTreeIterator
 // ==========================================
 
-fn rtiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .null;
+fn rtiConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.null);
     // RecursiveTreeIterator default mode is SELF_FIRST; we only forward iterator + mode
     return riiConstruct(ctx, &.{ args[0], .{ .int = 1 } });
 }
 
-fn rtiCurrent(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    const prefix = try rtiGetPrefix(ctx, args);
-    const entry = try rtiGetEntry(ctx, args);
-    const postfix = try rtiGetPostfix(ctx, args);
+fn rtiCurrent(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const prefix = (try rtiGetPrefix(ctx, args)).value;
+    defer if (prefix == .string) prefix.string.release();
+    const entry = (try rtiGetEntry(ctx, args)).value;
+    defer if (entry == .string) entry.string.release();
+    const postfix = (try rtiGetPostfix(ctx, args)).value;
+    defer if (postfix == .string) postfix.string.release();
     var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(ctx.allocator);
     if (prefix == .string) try buf.appendSlice(ctx.allocator, prefix.string.bytes());
     if (entry == .string) try buf.appendSlice(ctx.allocator, entry.string.bytes());
     if (postfix == .string) try buf.appendSlice(ctx.allocator, postfix.string.bytes());
-    const s = try ctx.allocator.dupe(u8, buf.items);
-    buf.deinit(ctx.allocator);
-    try ctx.vm.strings.append(ctx.allocator, s);
+    const s = try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator));
     _ = obj;
-    return .{ .string = Value.String.borrowed(s) };
+    return NativeResult.takeString(s);
 }
 
-fn rtiGetPrefix(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
+fn rtiGetPrefix(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
     const depth_v = try ctx.vm.callMethod(obj, "getDepth", &.{});
     const depth: i64 = if (depth_v == .int) depth_v.int else 0;
     var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(ctx.allocator);
     var i: i64 = 0;
     while (i < depth) : (i += 1) {
         try buf.appendSlice(ctx.allocator, "| ");
     }
     try buf.appendSlice(ctx.allocator, "|-");
-    const s = try ctx.allocator.dupe(u8, buf.items);
-    buf.deinit(ctx.allocator);
-    try ctx.vm.strings.append(ctx.allocator, s);
-    return .{ .string = Value.String.borrowed(s) };
+    const s = try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator));
+    return NativeResult.takeString(s);
 }
 
-fn rtiGetEntry(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = Value.String.borrowed("") };
+fn rtiGetEntry(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.literal("");
     // delegate to inner current
-    const inner = riiCurrentIterator(obj) orelse return .{ .string = Value.String.borrowed("") };
+    const inner = riiCurrentIterator(obj) orelse return NativeResult.literal("");
     const cur = try ctx.vm.callMethod(inner, "current", &.{});
-    if (cur == .string) return cur;
+    if (cur == .string) return NativeResult.share(cur);
     var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(ctx.allocator);
     try cur.format(&buf, ctx.allocator);
-    const s = try ctx.allocator.dupe(u8, buf.items);
-    buf.deinit(ctx.allocator);
-    try ctx.vm.strings.append(ctx.allocator, s);
-    return .{ .string = Value.String.borrowed(s) };
+    const s = try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator));
+    return NativeResult.takeString(s);
 }
 
-fn rtiGetPostfix(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed("") };
+fn rtiGetPostfix(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal("");
 }
 
 // ==========================================
 // GlobIterator
 // ==========================================
 
-fn giConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
-    try obj.set(ctx.allocator, "__gi_pattern", .{ .string = Value.String.borrowed(try createString(ctx, args[0].string.bytes())) });
+fn giConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    try obj.set(ctx.allocator, "__gi_pattern", args[0]);
     const result = try ctx.vm.callByName("glob", &.{args[0]});
     if (result == .array) {
         try obj.set(ctx.allocator, "__gi_results", result);
@@ -2201,11 +2172,11 @@ fn giConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try obj.set(ctx.allocator, "__gi_results", .{ .array = empty });
     }
     try obj.set(ctx.allocator, "__gi_pos", .{ .int = 0 });
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn giRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn giRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     try obj.set(ctx.allocator, "__gi_pos", .{ .int = 0 });
     const results = obj.get("__gi_results");
     if (results == .array and results.array.length() > 0) {
@@ -2214,43 +2185,43 @@ fn giRewind(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             try obj.set(ctx.allocator, "__pathname", path);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn giValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn giValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     const results = obj.get("__gi_results");
-    if (results != .array) return .{ .bool = false };
+    if (results != .array) return NativeResult.scalar(.{ .bool = false });
     const pos = objGetInt(obj, "__gi_pos");
-    return .{ .bool = pos < results.array.length() };
+    return NativeResult.scalar(.{ .bool = pos < results.array.length() });
 }
 
-fn giCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn giCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const results = obj.get("__gi_results");
-    if (results != .array) return .null;
+    if (results != .array) return NativeResult.scalar(.null);
     const pos = objGetInt(obj, "__gi_pos");
-    if (pos < 0 or pos >= results.array.length()) return .null;
+    if (pos < 0 or pos >= results.array.length()) return NativeResult.scalar(.null);
     const path = results.array.get(.{ .int = pos });
-    if (path != .string) return .null;
+    if (path != .string) return NativeResult.scalar(.null);
     const fi = try createFileInfoObj(ctx, path.string.bytes());
     fi.class_name = "GlobIterator";
-    return .{ .object = fi };
+    return NativeResult.borrowed(.{ .object = fi });
 }
 
-fn giKey(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
+fn giKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const results = obj.get("__gi_results");
-    if (results != .array) return .{ .int = 0 };
+    if (results != .array) return NativeResult.scalar(.{ .int = 0 });
     const pos = objGetInt(obj, "__gi_pos");
-    if (pos < 0 or pos >= results.array.length()) return .{ .int = 0 };
+    if (pos < 0 or pos >= results.array.length()) return NativeResult.scalar(.{ .int = 0 });
     const path = results.array.get(.{ .int = pos });
-    if (path == .string) return path;
-    return .{ .int = pos };
+    if (path == .string) return NativeResult.share(path);
+    return NativeResult.scalar(.{ .int = pos });
 }
 
-fn giNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn giNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const pos = objGetInt(obj, "__gi_pos");
     try obj.set(ctx.allocator, "__gi_pos", .{ .int = pos + 1 });
     const results = obj.get("__gi_results");
@@ -2260,12 +2231,12 @@ fn giNext(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
             try obj.set(ctx.allocator, "__pathname", path);
         }
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn giCount(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
+fn giCount(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
     const results = obj.get("__gi_results");
-    if (results != .array) return .{ .int = 0 };
-    return .{ .int = results.array.length() };
+    if (results != .array) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = results.array.length() });
 }

--- a/src/stdlib/strings.zig
+++ b/src/stdlib/strings.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 
 extern "c" fn snprintf(buf: [*c]u8, size: usize, fmt: [*c]const u8, ...) c_int;
@@ -161,14 +162,14 @@ pub const entries = .{
     .{ "strpbrk", native_strpbrk },
 };
 
-fn substr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .string = Value.String.borrowed("") };
+fn substr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.literal("");
     if (try rejectArrayParam(ctx, args[0], "substr")) return error.RuntimeError;
     const s = try coerceToString(ctx, args[0]);
     const slen: i64 = @intCast(s.len);
     var start = Value.toInt(args[1]);
     if (start < 0) start = @max(0, slen + start);
-    if (start >= slen) return .{ .string = Value.String.borrowed("") };
+    if (start >= slen) return NativeResult.literal("");
     const ustart: usize = @intCast(start);
 
     if (args.len >= 3 and args[2] != .null) {
@@ -177,15 +178,15 @@ fn substr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             length = @max(0, slen - @as(i64, @intCast(ustart)) + length);
         }
         const end: usize = @min(s.len, ustart + @as(usize, @intCast(@max(0, length))));
-        if (args[0] == .string) return .{ .string = args[0].string.borrowedSlice(ustart, end) };
-        return .{ .string = Value.String.borrowed(s[ustart..end]) };
+        if (args[0] == .string) return NativeResult.shareString(args[0].string.borrowedSlice(ustart, end));
+        return NativeResult.copyString(ctx.allocator, s[ustart..end]);
     }
-    if (args[0] == .string) return .{ .string = args[0].string.borrowedSlice(ustart, s.len) };
-    return .{ .string = Value.String.borrowed(s[ustart..]) };
+    if (args[0] == .string) return NativeResult.shareString(args[0].string.borrowedSlice(ustart, s.len));
+    return NativeResult.copyString(ctx.allocator, s[ustart..]);
 }
 
-fn strpos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn strpos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const haystack = try coerceToString(ctx, args[0]);
     const needle = try coerceToString(ctx, args[1]);
     const hlen: i64 = @intCast(haystack.len);
@@ -195,12 +196,12 @@ fn strpos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         return error.RuntimeError;
     }
     const off_i: i64 = if (raw_off < 0) @max(0, hlen + raw_off) else raw_off;
-    if (off_i > hlen) return .{ .bool = false };
+    if (off_i > hlen) return NativeResult.scalar(.{ .bool = false });
     const offset: usize = @intCast(off_i);
     if (std.mem.indexOf(u8, haystack[offset..], needle)) |pos| {
-        return .{ .int = @intCast(pos + offset) };
+        return NativeResult.scalar(.{ .int = @intCast(pos + offset) });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 const ReplaceResult = struct { str: Value.String, count: i64 };
@@ -225,8 +226,8 @@ fn replaceOne(ctx: *NativeContext, subject: []const u8, search: []const u8, repl
     return .{ .str = try Value.String.adopt(ctx.allocator, s), .count = cnt };
 }
 
-fn str_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return if (args.len >= 3) args[2] else Value{ .string = Value.String.borrowed("") };
+fn str_replace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.literal("");
     if (args[0] != .array and args[1] == .array) {
         try ctx.vm.setPendingException("TypeError", "str_replace(): Argument #2 ($replace) must be of type string when argument #1 ($search) is a string");
         return error.RuntimeError;
@@ -245,13 +246,13 @@ fn str_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try out.set(ctx.allocator, se.key, .{ .string = replaced });
         }
         if (args.len >= 4) ctx.setCallerVar(3, args.len, .{ .int = total_count });
-        return .{ .array = out };
+        return NativeResult.borrowed(.{ .array = out });
     }
 
-    const subject = if (args[2] == .object) try coerceToString(ctx, args[2]) else if (args[2] == .string) args[2].string.bytes() else return args[2];
+    const subject = if (args[2] == .object) try coerceToString(ctx, args[2]) else if (args[2] == .string) args[2].string.bytes() else return NativeResult.share(args[2]);
     const replaced = try strReplaceOnSingle(ctx, args[0], args[1], subject, &total_count);
     if (args.len >= 4) ctx.setCallerVar(3, args.len, .{ .int = total_count });
-    return .{ .string = replaced };
+    return NativeResult.takeString(replaced);
 }
 
 fn strReplaceOnSingle(ctx: *NativeContext, search: Value, replace: Value, subject: []const u8, total_count: *i64) !Value.String {
@@ -280,8 +281,8 @@ fn strReplaceOnSingle(ctx: *NativeContext, search: Value, replace: Value, subjec
     return r.str;
 }
 
-fn explode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
+fn explode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
     const delim = try coerceToString(ctx, args[0]);
     const s = try coerceToString(ctx, args[1]);
     if (delim.len == 0) {
@@ -325,11 +326,11 @@ fn explode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
 
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn implode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn implode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     var glue: []const u8 = "";
     var arr_val: Value = .null;
     var arr_pos: u8 = 2;
@@ -349,9 +350,10 @@ fn implode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         return error.RuntimeError;
     }
     const arr = arr_val.array;
-    if (arr.entries.items.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (arr.entries.items.len == 0) return NativeResult.literal("");
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     for (arr.entries.items, 0..) |entry, i| {
         if (i > 0) try buf.appendSlice(ctx.allocator, glue);
         if (entry.value == .object and ctx.vm.hasMethod(entry.value.object.class_name, "__toString")) {
@@ -363,7 +365,7 @@ fn implode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
     const s = try buf.toOwnedSlice(ctx.allocator);
-    return .{ .string = try Value.String.adopt(ctx.allocator, s) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
 }
 
 const default_trim_chars = " \t\n\r\x0b\x00";
@@ -397,40 +399,40 @@ fn trimWithSet(s: []const u8, set: [256]bool, left: bool, right: bool) []const u
     return s[lo..hi];
 }
 
-fn trim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn trim(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const chars = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else default_trim_chars;
     const set = buildTrimSet(chars);
-    return .{ .string = try Value.String.create(ctx.allocator, trimWithSet(s, set, true, true)) };
+    return NativeResult.takeString(try Value.String.create(ctx.allocator, trimWithSet(s, set, true, true)));
 }
 
-fn ltrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn ltrim(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const chars = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else default_trim_chars;
     const set = buildTrimSet(chars);
-    return .{ .string = try Value.String.create(ctx.allocator, trimWithSet(s, set, true, false)) };
+    return NativeResult.takeString(try Value.String.create(ctx.allocator, trimWithSet(s, set, true, false)));
 }
 
-fn rtrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn rtrim(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const chars = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else default_trim_chars;
     const set = buildTrimSet(chars);
-    return .{ .string = try Value.String.create(ctx.allocator, trimWithSet(s, set, false, true)) };
+    return NativeResult.takeString(try Value.String.create(ctx.allocator, trimWithSet(s, set, false, true)));
 }
 
-fn strtolower(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn strtolower(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     if (try rejectArrayParam(ctx, args[0], "strtolower")) return error.RuntimeError;
     const s = try coerceToString(ctx, args[0]);
     const buf = try ctx.allocator.alloc(u8, s.len);
     for (s, 0..) |c, i| buf[i] = std.ascii.toLower(c);
-    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len != 1) {
         const msg = try std.fmt.allocPrint(ctx.allocator, "strtoupper() expects exactly 1 argument, {d} given", .{args.len});
         try ctx.strings.append(ctx.allocator, msg);
@@ -441,35 +443,35 @@ fn strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const s = try coerceToString(ctx, args[0]);
     const buf = try ctx.allocator.alloc(u8, s.len);
     for (s, 0..) |c, i| buf[i] = std.ascii.toUpper(c);
-    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn str_contains(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn str_contains(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const haystack = try coerceToString(ctx, args[0]);
     const needle = try coerceToString(ctx, args[1]);
-    if (needle.len == 0) return .{ .bool = true };
-    return .{ .bool = std.mem.indexOf(u8, haystack, needle) != null };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = std.mem.indexOf(u8, haystack, needle) != null });
 }
 
-fn str_starts_with(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn str_starts_with(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const haystack = try coerceToString(ctx, args[0]);
     const needle = try coerceToString(ctx, args[1]);
-    return .{ .bool = std.mem.startsWith(u8, haystack, needle) };
+    return NativeResult.scalar(.{ .bool = std.mem.startsWith(u8, haystack, needle) });
 }
 
-fn str_ends_with(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn str_ends_with(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const haystack = try coerceToString(ctx, args[0]);
     const needle = try coerceToString(ctx, args[1]);
-    return .{ .bool = std.mem.endsWith(u8, haystack, needle) };
+    return NativeResult.scalar(.{ .bool = std.mem.endsWith(u8, haystack, needle) });
 }
 
-fn str_shuffle(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn str_shuffle(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
-    if (s.len <= 1) return if (args[0] == .string) args[0] else .{ .string = Value.String.borrowed(s) };
+    if (s.len <= 1) return if (args[0] == .string) NativeResult.share(args[0]) else NativeResult.copyString(ctx.allocator, s);
     const buf = try ctx.allocator.alloc(u8, s.len);
     @memcpy(buf, s);
     // Fisher-Yates with the default PRNG
@@ -481,11 +483,11 @@ fn str_shuffle(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         buf[i] = buf[j];
         buf[j] = tmp;
     }
-    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn str_repeat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .string = Value.String.borrowed("") };
+fn str_repeat(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const raw_times = Value.toInt(args[1]);
     if (raw_times < 0) {
@@ -493,38 +495,38 @@ fn str_repeat(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         return error.RuntimeError;
     }
     const times: usize = std.math.cast(usize, raw_times) orelse return error.OutOfMemory;
-    if (times == 0 or s.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (times == 0 or s.len == 0) return NativeResult.literal("");
     const length = std.math.mul(usize, s.len, times) catch return error.OutOfMemory;
     const result = try ctx.allocator.alloc(u8, length);
     for (0..times) |i| @memcpy(result[i * s.len ..][0..s.len], s);
-    return .{ .string = try Value.String.adopt(ctx.allocator, result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn ucfirst(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn ucfirst(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (s.len == 0) return NativeResult.literal("");
     const buf = try ctx.allocator.alloc(u8, s.len);
     @memcpy(buf, s);
     buf[0] = std.ascii.toUpper(buf[0]);
-    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn lcfirst(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn lcfirst(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (s.len == 0) return NativeResult.literal("");
     const buf = try ctx.allocator.alloc(u8, s.len);
     @memcpy(buf, s);
     buf[0] = std.ascii.toLower(buf[0]);
-    return .{ .string = try Value.String.adopt(ctx.allocator, buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return if (args.len > 0) args[0] else Value{ .string = Value.String.borrowed("") };
+fn str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return if (args.len > 0) NativeResult.share(args[0]) else NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const target_len: usize = @intCast(@max(0, Value.toInt(args[1])));
-    if (s.len >= target_len) return if (args[0] == .string) args[0] else .{ .string = Value.String.borrowed(s) };
+    if (s.len >= target_len) return if (args[0] == .string) NativeResult.share(args[0]) else NativeResult.copyString(ctx.allocator, s);
     const pad_str = if (args.len >= 3 and args[2] != .null) try coerceToString(ctx, args[2]) else " ";
     if (pad_str.len == 0) {
         try ctx.vm.setPendingException("ValueError", "str_pad(): Argument #3 ($pad_string) must not be empty");
@@ -538,6 +540,7 @@ fn str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const diff = target_len - s.len;
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     if (pad_type == 0) {
         var i: usize = 0;
         while (i < diff) : (i += 1) try buf.append(ctx.allocator, pad_str[i % pad_str.len]);
@@ -556,33 +559,33 @@ fn str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         while (i < diff) : (i += 1) try buf.append(ctx.allocator, pad_str[i % pad_str.len]);
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    return .{ .string = try Value.String.adopt(ctx.allocator, result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_strcmp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
+fn native_strcmp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
     const a = try coerceToString(ctx, args[0]);
     const b = try coerceToString(ctx, args[1]);
     const min_len = @min(a.len, b.len);
     for (0..min_len) |i| {
-        if (a[i] != b[i]) return .{ .int = @as(i64, a[i]) - @as(i64, b[i]) };
+        if (a[i] != b[i]) return NativeResult.scalar(.{ .int = @as(i64, a[i]) - @as(i64, b[i]) });
     }
-    if (a.len != b.len) return .{ .int = @as(i64, @intCast(a.len)) - @as(i64, @intCast(b.len)) };
-    return .{ .int = 0 };
+    if (a.len != b.len) return NativeResult.scalar(.{ .int = @as(i64, @intCast(a.len)) - @as(i64, @intCast(b.len)) });
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_strcasecmp(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
+fn native_strcasecmp(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
     const a = if (args[0] == .string) args[0].string.bytes() else "";
     const b = if (args[1] == .string) args[1].string.bytes() else "";
     const min_len = @min(a.len, b.len);
     for (0..min_len) |i| {
         const ca = std.ascii.toLower(a[i]);
         const cb = std.ascii.toLower(b[i]);
-        if (ca != cb) return .{ .int = @as(i64, ca) - @as(i64, cb) };
+        if (ca != cb) return NativeResult.scalar(.{ .int = @as(i64, ca) - @as(i64, cb) });
     }
-    if (a.len != b.len) return .{ .int = @as(i64, @intCast(a.len)) - @as(i64, @intCast(b.len)) };
-    return .{ .int = 0 };
+    if (a.len != b.len) return NativeResult.scalar(.{ .int = @as(i64, @intCast(a.len)) - @as(i64, @intCast(b.len)) });
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
 fn natCompare(a: []const u8, b: []const u8, fold_case: bool) i64 {
@@ -622,22 +625,22 @@ fn natCompare(a: []const u8, b: []const u8, fold_case: bool) i64 {
     return 0;
 }
 
-fn native_strnatcmp(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
+fn native_strnatcmp(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
     const a = if (args[0] == .string) args[0].string.bytes() else "";
     const b = if (args[1] == .string) args[1].string.bytes() else "";
-    return .{ .int = natCompare(a, b, false) };
+    return NativeResult.scalar(.{ .int = natCompare(a, b, false) });
 }
 
-fn native_strnatcasecmp(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
+fn native_strnatcasecmp(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
     const a = if (args[0] == .string) args[0].string.bytes() else "";
     const b = if (args[1] == .string) args[1].string.bytes() else "";
-    return .{ .int = natCompare(a, b, true) };
+    return NativeResult.scalar(.{ .int = natCompare(a, b, true) });
 }
 
-fn native_strncasecmp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .{ .int = 0 };
+fn native_strncasecmp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.{ .int = 0 });
     const a = if (args[0] == .string) args[0].string.bytes() else "";
     const b = if (args[1] == .string) args[1].string.bytes() else "";
     const n_raw = Value.toInt(args[2]);
@@ -652,14 +655,14 @@ fn native_strncasecmp(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     for (0..min_len) |i| {
         const ca = std.ascii.toLower(sa[i]);
         const cb = std.ascii.toLower(sb[i]);
-        if (ca != cb) return .{ .int = @as(i64, ca) - @as(i64, cb) };
+        if (ca != cb) return NativeResult.scalar(.{ .int = @as(i64, ca) - @as(i64, cb) });
     }
-    if (sa.len != sb.len) return .{ .int = @as(i64, @intCast(sa.len)) - @as(i64, @intCast(sb.len)) };
-    return .{ .int = 0 };
+    if (sa.len != sb.len) return NativeResult.scalar(.{ .int = @as(i64, @intCast(sa.len)) - @as(i64, @intCast(sb.len)) });
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_strncmp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .{ .int = 0 };
+fn native_strncmp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.{ .int = 0 });
     const a = if (args[0] == .string) args[0].string.bytes() else "";
     const b = if (args[1] == .string) args[1].string.bytes() else "";
     const n_raw = Value.toInt(args[2]);
@@ -674,31 +677,30 @@ fn native_strncmp(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // just the sign), matching strcmp
     const min_len = @min(sa.len, sb.len);
     for (0..min_len) |i| {
-        if (sa[i] != sb[i]) return .{ .int = @as(i64, sa[i]) - @as(i64, sb[i]) };
+        if (sa[i] != sb[i]) return NativeResult.scalar(.{ .int = @as(i64, sa[i]) - @as(i64, sb[i]) });
     }
-    if (sa.len != sb.len) return .{ .int = @as(i64, @intCast(sa.len)) - @as(i64, @intCast(sb.len)) };
-    return .{ .int = 0 };
+    if (sa.len != sb.len) return NativeResult.scalar(.{ .int = @as(i64, @intCast(sa.len)) - @as(i64, @intCast(sb.len)) });
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_ord(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
-    if (s.len == 0) return .{ .int = 0 };
-    return .{ .int = s[0] };
+fn native_ord(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
+    if (s.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.scalar(.{ .int = s[0] });
 }
 
-fn native_chr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("\x00") };
+fn native_chr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("\x00");
     const code: u8 = @truncate(@as(u64, @bitCast(Value.toInt(args[0]))));
     const buf = try ctx.allocator.alloc(u8, 1);
     buf[0] = code;
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn native_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value.null;
+fn native_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(.null);
     if (args.len >= 2) {
         const len = Value.toInt(args[1]);
         if (len <= 0) {
@@ -717,13 +719,13 @@ fn native_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         try arr.append(ctx.allocator, .{ .string = part });
         i = end;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_substr_count(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
-    const haystack = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
-    const needle = if (args[1] == .string) args[1].string.bytes() else return Value{ .int = 0 };
+fn native_substr_count(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
+    const haystack = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
+    const needle = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
     if (needle.len == 0) {
         try ctx.vm.setPendingException("ValueError", "substr_count(): Argument #2 ($needle) must not be empty");
         return error.RuntimeError;
@@ -759,11 +761,11 @@ fn native_substr_count(ctx: *NativeContext, args: []const Value) RuntimeError!Va
             i += 1;
         }
     }
-    return .{ .int = count };
+    return NativeResult.scalar(.{ .int = count });
 }
 
-fn native_substr_replace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return if (args.len > 0) args[0] else Value{ .string = Value.String.borrowed("") };
+fn native_substr_replace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return if (args.len > 0) NativeResult.share(args[0]) else NativeResult.literal("");
 
     if (args[0] == .array) {
         const src_arr = args[0].array;
@@ -798,20 +800,21 @@ fn native_substr_replace(ctx: *NativeContext, args: []const Value) RuntimeError!
             } else null;
 
             const replaced = try substrReplaceOne(ctx, elem_str, repl_str, start_val, len_val);
-            try out.append(ctx.allocator, .{ .string = Value.String.borrowed(replaced) });
+            defer replaced.release();
+            try out.append(ctx.allocator, .{ .string = replaced });
         }
-        return .{ .array = out };
+        return NativeResult.borrowed(.{ .array = out });
     }
 
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const replacement = if (args[1] == .string) args[1].string.bytes() else "";
     const start_val = Value.toInt(args[2]);
     const len_val: ?i64 = if (args.len >= 4) Value.toInt(args[3]) else null;
     const result = try substrReplaceOne(ctx, s, replacement, start_val, len_val);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(result);
 }
 
-fn substrReplaceOne(ctx: *NativeContext, s: []const u8, replacement: []const u8, start_in: i64, len_opt: ?i64) ![]const u8 {
+fn substrReplaceOne(ctx: *NativeContext, s: []const u8, replacement: []const u8, start_in: i64, len_opt: ?i64) !Value.String {
     const slen: i64 = @intCast(s.len);
     var start = start_in;
     if (start < 0) start = @max(0, slen + start);
@@ -829,17 +832,17 @@ fn substrReplaceOne(ctx: *NativeContext, s: []const u8, replacement: []const u8,
     }
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     try buf.appendSlice(ctx.allocator, s[0..ustart]);
     try buf.appendSlice(ctx.allocator, replacement);
     if (end < s.len) try buf.appendSlice(ctx.allocator, s[end..]);
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return result;
+    return Value.String.adopt(ctx.allocator, result);
 }
 
-fn native_str_word_count(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
+fn native_str_word_count(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
     const format: i64 = if (args.len > 1) Value.toInt(args[1]) else 0;
     if (format != 0 and format != 1 and format != 2) {
         try ctx.vm.setPendingException("ValueError", "str_word_count(): Argument #2 ($format) must be a valid format value");
@@ -867,7 +870,7 @@ fn native_str_word_count(ctx: *NativeContext, args: []const Value) RuntimeError!
                 in_word = false;
             }
         }
-        return .{ .int = count };
+        return NativeResult.scalar(.{ .int = count });
     }
 
     var arr = try ctx.createArray();
@@ -897,15 +900,16 @@ fn native_str_word_count(ctx: *NativeContext, args: []const Value) RuntimeError!
             try arr.append(ctx.allocator, .{ .string = args[0].string.borrowedSlice(word_start, s.len) });
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_nl2br(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_nl2br(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const use_xhtml = if (args.len >= 2) args[1].isTruthy() else true;
     const br = if (use_xhtml) "<br />" else "<br>";
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         const c = s[i];
@@ -923,18 +927,18 @@ fn native_nl2br(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_wordwrap(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_wordwrap(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const width: usize = if (args.len >= 2) @intCast(@max(1, Value.toInt(args[1]))) else 75;
     const brk = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else "\n";
     const cut = args.len >= 4 and args[3].isTruthy();
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var line_start: usize = 0;
     var last_space: ?usize = null;
     var i: usize = 0;
@@ -966,13 +970,12 @@ fn native_wordwrap(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     }
     if (line_start < s.len) try buf.appendSlice(ctx.allocator, s[line_start..]);
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_chunk_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_chunk_split(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     if (args.len >= 2 and Value.toInt(args[1]) <= 0) {
         try ctx.vm.setPendingException("ValueError", "chunk_split(): Argument #2 ($length) must be greater than 0");
         return error.RuntimeError;
@@ -981,6 +984,7 @@ fn native_chunk_split(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     const end = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else "\r\n";
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     if (s.len == 0) {
         try buf.appendSlice(ctx.allocator, end);
     } else {
@@ -993,17 +997,16 @@ fn native_chunk_split(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_number_format(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("0") };
+fn native_number_format(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("0");
     // PHP returns the literal "nan" / "inf" / "-inf" for non-finite floats
     if (args[0] == .float) {
         const f = args[0].float;
-        if (std.math.isNan(f)) return Value{ .string = Value.String.borrowed("nan") };
-        if (std.math.isInf(f)) return Value{ .string = Value.String.borrowed(if (f < 0) "-inf" else "inf") };
+        if (std.math.isNan(f)) return NativeResult.literal("nan");
+        if (std.math.isInf(f)) return if (f < 0) NativeResult.literal("-inf") else NativeResult.literal("inf");
     }
     const decimals_signed: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     const decimals: usize = if (decimals_signed > 0) @intCast(decimals_signed) else 0;
@@ -1046,7 +1049,7 @@ fn native_number_format(ctx: *NativeContext, args: []const Value) RuntimeError!V
         } else {
             abs_u = @intCast(if (i < 0) -i else i);
         }
-        const ip_str = std.fmt.bufPrint(&int_part_buf, "{d}", .{abs_u}) catch return Value{ .string = Value.String.borrowed("0") };
+        const ip_str = std.fmt.bufPrint(&int_part_buf, "{d}", .{abs_u}) catch return NativeResult.literal("0");
         var fp_len: usize = 0;
         while (fp_len < decimals and fp_len < frac_part_buf.len) : (fp_len += 1) frac_part_buf[fp_len] = '0';
         formatted = .{
@@ -1060,6 +1063,7 @@ fn native_number_format(ctx: *NativeContext, args: []const Value) RuntimeError!V
     }
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     if (formatted.is_negative) try buf.append(ctx.allocator, '-');
 
     const int_str = formatted.int_part;
@@ -1082,8 +1086,7 @@ fn native_number_format(ctx: *NativeContext, args: []const Value) RuntimeError!V
     }
 
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 const RoundedFloat = struct { is_negative: bool, int_part: []const u8, frac_part: []const u8 };
@@ -1279,43 +1282,47 @@ fn expandScientific(src: []const u8, out: []u8) ![]const u8 {
     return out[0..ol];
 }
 
-fn native_sprintf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_sprintf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const result = try sprintfImpl(ctx, fmt_str, args[1..]);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(result);
 }
 
-fn native_printf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
+fn native_printf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
     const result = try sprintfImpl(ctx, fmt_str, args[1..]);
-    try ctx.vm.output.appendSlice(ctx.allocator, result);
-    return .{ .int = @intCast(result.len) };
+    defer result.release();
+    try ctx.vm.output.appendSlice(ctx.allocator, result.bytes());
+    return NativeResult.scalar(.{ .int = @intCast(result.bytes().len) });
 }
 
-fn native_fprintf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
-    const fmt_str = if (args[1] == .string) args[1].string.bytes() else return Value{ .int = 0 };
+fn native_fprintf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
+    const fmt_str = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
     const result = try sprintfImpl(ctx, fmt_str, args[2..]);
-    const written = try ctx.vm.callByName("fwrite", &.{ args[0], .{ .string = Value.String.borrowed(result) } });
-    return written;
+    defer result.release();
+    const written = try ctx.vm.callByName("fwrite", &.{ args[0], .{ .string = result } });
+    return NativeResult.share(written);
 }
 
-fn native_vfprintf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .{ .int = 0 };
-    const fmt_str = if (args[1] == .string) args[1].string.bytes() else return Value{ .int = 0 };
-    if (args[2] != .array) return .{ .int = 0 };
+fn native_vfprintf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.{ .int = 0 });
+    const fmt_str = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
+    if (args[2] != .array) return NativeResult.scalar(.{ .int = 0 });
     const arr = args[2].array;
     var vals = try ctx.allocator.alloc(Value, arr.entries.items.len);
     defer ctx.allocator.free(vals);
     for (arr.entries.items, 0..) |entry, i| vals[i] = entry.value;
     const result = try sprintfImpl(ctx, fmt_str, vals);
-    return try ctx.vm.callByName("fwrite", &.{ args[0], .{ .string = Value.String.borrowed(result) } });
+    defer result.release();
+    return NativeResult.share(try ctx.vm.callByName("fwrite", &.{ args[0], .{ .string = result } }));
 }
 
-fn sprintfImpl(ctx: *NativeContext, fmt_str: []const u8, args: []const Value) ![]const u8 {
+fn sprintfImpl(ctx: *NativeContext, fmt_str: []const u8, args: []const Value) !Value.String {
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     var arg_idx: usize = 0;
     while (i < fmt_str.len) {
@@ -1413,6 +1420,7 @@ fn sprintfImpl(ctx: *NativeContext, fmt_str: []const u8, args: []const Value) ![
             };
 
             var tmp_buf = std.ArrayListUnmanaged(u8){};
+            defer tmp_buf.deinit(ctx.allocator);
             switch (spec) {
                 's' => {
                     if (arg == .array) ctx.vm.emitWarning("Array to string conversion");
@@ -1508,8 +1516,6 @@ fn sprintfImpl(ctx: *NativeContext, fmt_str: []const u8, args: []const Value) ![
                     try formatGeneral(&tmp_buf, ctx.allocator, v, prec, spec);
                 },
                 else => {
-                    buf.deinit(ctx.allocator);
-                    tmp_buf.deinit(ctx.allocator);
                     var msg_buf: [64]u8 = undefined;
                     const msg = std.fmt.bufPrint(&msg_buf, "Unknown format specifier \"{c}\"", .{spec}) catch "Unknown format specifier";
                     const msg_dup = try ctx.allocator.dupe(u8, msg);
@@ -1539,15 +1545,13 @@ fn sprintfImpl(ctx: *NativeContext, fmt_str: []const u8, args: []const Value) ![
             } else {
                 try buf.appendSlice(ctx.allocator, formatted);
             }
-            tmp_buf.deinit(ctx.allocator);
         } else {
             try buf.append(ctx.allocator, fmt_str[i]);
             i += 1;
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return result;
+    return Value.String.adopt(ctx.allocator, result);
 }
 
 fn formatFixedFloat(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, val: f64, prec: usize) !void {
@@ -1830,10 +1834,11 @@ fn stripTrailingZeros(buf: *std.ArrayListUnmanaged(u8)) void {
     }
 }
 
-fn native_addslashes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_addslashes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     for (s) |c| {
         if (c == 0) {
             // PHP encodes NUL as the literal sequence "\0" (backslash + zero digit)
@@ -1847,14 +1852,14 @@ fn native_addslashes(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         try buf.append(ctx.allocator, c);
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_stripslashes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_stripslashes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var j: usize = 0;
     while (j < s.len) {
         if (s[j] == '\\' and j + 1 < s.len) {
@@ -1864,8 +1869,7 @@ fn native_stripslashes(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         j += 1;
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 fn latin1NamedEntity(cp: u21) ?[]const u8 {
@@ -2041,7 +2045,7 @@ fn latin1NamedEntity(cp: u21) ?[]const u8 {
     };
 }
 
-fn native_get_html_translation_table(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_get_html_translation_table(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const table_kind: i64 = if (args.len >= 1) Value.toInt(args[0]) else 0;
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 3;
     const escape_double = (flags & 2) != 0;
@@ -2062,24 +2066,27 @@ fn native_get_html_translation_table(ctx: *NativeContext, args: []const Value) R
             if (latin1NamedEntity(cp)) |ent| {
                 var enc: [4]u8 = undefined;
                 const elen = std.unicode.utf8Encode(cp, &enc) catch continue;
-                const key = try ctx.allocator.dupe(u8, enc[0..elen]);
-                try ctx.vm.strings.append(ctx.allocator, key);
-                try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(key) }, .{ .string = Value.String.borrowed(ent) });
+                const key = try Value.String.create(ctx.allocator, enc[0..elen]);
+                defer key.release();
+                try arr.set(ctx.allocator, .{ .string = key }, .{ .string = Value.String.borrowed(ent) });
             }
         }
     }
 
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_htmlentities(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    if (args[0] == .null) return .{ .string = Value.String.borrowed("") };
+fn native_htmlentities(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    if (args[0] == .null) return NativeResult.literal("");
+    var temporary: ?[]u8 = null;
+    defer if (temporary) |bytes| ctx.allocator.free(bytes);
     const s = if (args[0] == .string) args[0].string.bytes() else blk: {
         var buf = std.ArrayListUnmanaged(u8){};
+        defer buf.deinit(ctx.allocator);
         try args[0].format(&buf, ctx.allocator);
         const c = try buf.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, c);
+        temporary = c;
         break :blk c;
     };
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 3;
@@ -2087,6 +2094,7 @@ fn native_htmlentities(ctx: *NativeContext, args: []const Value) RuntimeError!Va
     const escape_single = (flags & 1) != 0;
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         const b = s[i];
@@ -2125,13 +2133,12 @@ fn native_htmlentities(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         i += len;
     }
     const out = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_htmlspecialchars(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    if (args[0] == .null) return .{ .string = Value.String.borrowed("") };
+fn native_htmlspecialchars(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    if (args[0] == .null) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 3;
     const escape_double = (flags & 2) != 0;
@@ -2140,6 +2147,7 @@ fn native_htmlspecialchars(ctx: *NativeContext, args: []const Value) RuntimeErro
     const html5_mode = (flags & 48) != 0;
     const double_encode: bool = if (args.len >= 4) args[3].isTruthy() else true;
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) : (i += 1) {
         const c = s[i];
@@ -2163,8 +2171,7 @@ fn native_htmlspecialchars(ctx: *NativeContext, args: []const Value) RuntimeErro
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 // returns total entity length (including '&' and ';') if s[i..] starts with a
@@ -2285,13 +2292,14 @@ fn latin1EntityToCodepoint(name: []const u8) ?u21 {
     return null;
 }
 
-fn native_html_entity_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_html_entity_decode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 11;
     // HTML5/XHTML/XML1 modes (bits 4-5) recognize &apos;; HTML401 default does not
     const html5_mode = (flags & 48) != 0;
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var j: usize = 0;
     while (j < s.len) {
         if (s[j] == '&') {
@@ -2331,17 +2339,17 @@ fn native_html_entity_decode(ctx: *NativeContext, args: []const Value) RuntimeEr
         j += 1;
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_htmlspecialchars_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_htmlspecialchars_decode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const flags: i64 = if (args.len >= 2) Value.toInt(args[1]) else 3; // default ENT_QUOTES | ENT_HTML401
     const decode_double = (flags & 2) != 0;
     const decode_single = (flags & 1) != 0;
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var j: usize = 0;
     while (j < s.len) {
         if (s[j] == '&') {
@@ -2366,8 +2374,7 @@ fn native_htmlspecialchars_decode(ctx: *NativeContext, args: []const Value) Runt
         j += 1;
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 fn matchNumericEntity(s: []const u8) ?struct { code: u32, len: usize } {
@@ -2425,12 +2432,12 @@ fn matchEntity(s: []const u8) ?EntityMatch {
     return null;
 }
 
-fn native_hex2bin(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .bool = false };
+fn native_hex2bin(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
     if (s.len % 2 != 0) {
         ctx.vm.emitWarning("hex2bin(): Input string must be hexadecimal string");
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const out_len = s.len / 2;
     const buf = try ctx.allocator.alloc(u8, out_len);
@@ -2438,17 +2445,16 @@ fn native_hex2bin(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const hi = hexVal(s[j * 2]) orelse {
             ctx.allocator.free(buf);
             ctx.vm.emitWarning("hex2bin(): Input string must be hexadecimal string");
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         };
         const lo = hexVal(s[j * 2 + 1]) orelse {
             ctx.allocator.free(buf);
             ctx.vm.emitWarning("hex2bin(): Input string must be hexadecimal string");
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         };
         buf[j] = (hi << 4) | lo;
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
 fn hexVal(c: u8) ?u8 {
@@ -2458,22 +2464,21 @@ fn hexVal(c: u8) ?u8 {
     return null;
 }
 
-fn native_bin2hex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_bin2hex(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const hex_chars = "0123456789abcdef";
     const buf = try ctx.allocator.alloc(u8, s.len * 2);
     for (s, 0..) |c, j| {
         buf[j * 2] = hex_chars[c >> 4];
         buf[j * 2 + 1] = hex_chars[c & 0x0f];
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
-fn native_mb_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value.null;
+fn native_mb_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(.null);
     const raw_len: i64 = if (args.len >= 2) Value.toInt(args[1]) else 1;
     if (raw_len < 1) {
         try ctx.vm.setPendingException("ValueError", "mb_str_split(): Argument #2 ($length) must be greater than 0");
@@ -2481,7 +2486,7 @@ fn native_mb_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!Va
     }
     const chunk_len: usize = @intCast(raw_len);
     var arr = try ctx.createArray();
-    if (s.len == 0) return .{ .array = arr };
+    if (s.len == 0) return NativeResult.borrowed(.{ .array = arr });
     var i: usize = 0;
     while (i < s.len) {
         const start = i;
@@ -2492,18 +2497,20 @@ fn native_mb_str_split(ctx: *NativeContext, args: []const Value) RuntimeError!Va
             if (i > s.len) i = s.len;
             taken += 1;
         }
-        try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(try ctx.createString(s[start..i])) });
+        const part = try Value.String.create(ctx.allocator, s[start..i]);
+        defer part.release();
+        try arr.append(ctx.allocator, .{ .string = part });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_mb_strlen(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
+fn native_mb_strlen(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
     if (args.len >= 2 and args[1] == .string) {
         const enc = args[1].string.bytes();
         if (std.ascii.eqlIgnoreCase(enc, "8bit") or std.ascii.eqlIgnoreCase(enc, "binary")) {
-            return .{ .int = @intCast(s.len) };
+            return NativeResult.scalar(.{ .int = @intCast(s.len) });
         }
     }
     var count: i64 = 0;
@@ -2521,35 +2528,36 @@ fn native_mb_strlen(_: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         count += 1;
     }
-    return .{ .int = count };
+    return NativeResult.scalar(.{ .int = count });
 }
 
-fn native_mb_strtolower(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try utfCaseConvert(ctx, s, false)) };
+fn native_mb_strtolower(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    return NativeResult.takeString(try utfCaseConvert(ctx, s, false));
 }
 
-fn native_mb_strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try utfCaseConvert(ctx, s, true)) };
+fn native_mb_strtoupper(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    return NativeResult.takeString(try utfCaseConvert(ctx, s, true));
 }
 
-fn native_mb_convert_case(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_mb_convert_case(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     const mode = Value.toInt(args[1]);
     return switch (mode) {
-        0 => .{ .string = Value.String.borrowed(try utfCaseConvert(ctx, s, true)) },
-        1 => .{ .string = Value.String.borrowed(try utfCaseConvert(ctx, s, false)) },
-        2 => .{ .string = Value.String.borrowed(try utfTitleCase(ctx, s)) },
-        else => .{ .string = Value.String.borrowed(try ctx.createString(s)) },
+        0 => NativeResult.takeString(try utfCaseConvert(ctx, s, true)),
+        1 => NativeResult.takeString(try utfCaseConvert(ctx, s, false)),
+        2 => NativeResult.takeString(try utfTitleCase(ctx, s)),
+        else => NativeResult.share(args[0]),
     };
 }
 
-fn utfTitleCase(ctx: *NativeContext, s: []const u8) ![]u8 {
+fn utfTitleCase(ctx: *NativeContext, s: []const u8) !Value.String {
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     var at_word_start = true;
     while (i < s.len) {
@@ -2595,15 +2603,12 @@ fn utfTitleCase(ctx: *NativeContext, s: []const u8) ![]u8 {
             i += len;
         }
     }
-    const out = try ctx.allocator.dupe(u8, buf.items);
-    buf.deinit(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return out;
+    return Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator));
 }
 
-fn native_mb_check_encoding(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = true };
-    if (args[0] != .string) return .{ .bool = false };
+fn native_mb_check_encoding(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = true });
+    if (args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     // encoding arg defaults to mb_internal_encoding (UTF-8)
     var is_ascii = false;
@@ -2619,8 +2624,8 @@ fn native_mb_check_encoding(_: *NativeContext, args: []const Value) RuntimeError
         }
     }
     if (is_ascii) {
-        for (s) |b| if (b >= 0x80) return .{ .bool = false };
-        return .{ .bool = true };
+        for (s) |b| if (b >= 0x80) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .bool = true });
     }
     var i: usize = 0;
     while (i < s.len) {
@@ -2629,16 +2634,17 @@ fn native_mb_check_encoding(_: *NativeContext, args: []const Value) RuntimeError
             i += 1;
             continue;
         }
-        const len = std.unicode.utf8ByteSequenceLength(byte) catch return .{ .bool = false };
-        if (i + len > s.len) return .{ .bool = false };
-        _ = std.unicode.utf8Decode(s[i..][0..len]) catch return .{ .bool = false };
+        const len = std.unicode.utf8ByteSequenceLength(byte) catch return NativeResult.scalar(.{ .bool = false });
+        if (i + len > s.len) return NativeResult.scalar(.{ .bool = false });
+        _ = std.unicode.utf8Decode(s[i..][0..len]) catch return NativeResult.scalar(.{ .bool = false });
         i += len;
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn utfCaseConvert(ctx: *NativeContext, s: []const u8, to_upper: bool) ![]u8 {
+fn utfCaseConvert(ctx: *NativeContext, s: []const u8, to_upper: bool) !Value.String {
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         const byte = s[i];
@@ -2681,8 +2687,7 @@ fn utfCaseConvert(ctx: *NativeContext, s: []const u8, to_upper: bool) ![]u8 {
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return result;
+    return Value.String.adopt(ctx.allocator, result);
 }
 
 fn caseExpansionUpper(cp: u21) ?[]const u8 {
@@ -2782,8 +2787,8 @@ pub fn unicodeToLower(cp: u21) u21 {
     return cp;
 }
 
-fn native_mb_detect_encoding(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_mb_detect_encoding(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     // walk the candidate list in order and return the first encoding the
     // input is valid for. matches PHP behavior - ASCII before UTF-8 in the
@@ -2824,18 +2829,18 @@ fn native_mb_detect_encoding(_: *NativeContext, args: []const Value) RuntimeErro
     if (args.len >= 2 and args[1] == .array) {
         for (args[1].array.entries.items) |entry| {
             if (entry.value == .string) {
-                if (Probe.match(s, entry.value.string.bytes())) |hit| return .{ .string = Value.String.borrowed(hit) };
+                if (Probe.match(s, entry.value.string.bytes())) |hit| return NativeResult.copyString(ctx.allocator, hit);
             }
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     if (args.len >= 2 and args[1] == .string) {
-        if (Probe.match(s, args[1].string.bytes())) |hit| return .{ .string = Value.String.borrowed(hit) };
-        return .{ .bool = false };
+        if (Probe.match(s, args[1].string.bytes())) |hit| return NativeResult.copyString(ctx.allocator, hit);
+        return NativeResult.scalar(.{ .bool = false });
     }
-    if (Probe.isAscii(s)) return .{ .string = Value.String.borrowed("ASCII") };
-    if (Probe.isUtf8(s)) return .{ .string = Value.String.borrowed("UTF-8") };
-    return .{ .bool = false };
+    if (Probe.isAscii(s)) return NativeResult.literal("ASCII");
+    if (Probe.isUtf8(s)) return NativeResult.literal("UTF-8");
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 fn encodingMatches(name: []const u8, options: anytype) bool {
@@ -3052,31 +3057,31 @@ fn convertLatin1ToUtf8(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
     return try out.toOwnedSlice(allocator);
 }
 
-fn native_utf8_encode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const out = convertLatin1ToUtf8(ctx.allocator, args[0].string.bytes()) catch return .{ .bool = false };
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_utf8_encode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = convertLatin1ToUtf8(ctx.allocator, args[0].string.bytes()) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_utf8_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const out = convertUtf8ToLatin1(ctx.allocator, args[0].string.bytes()) catch return .{ .bool = false };
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+fn native_utf8_decode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const out = convertUtf8ToLatin1(ctx.allocator, args[0].string.bytes()) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn convertVarEncoding(ctx: *NativeContext, val: Value, to: []const u8, from: []const u8) RuntimeError!Value {
+fn convertVarEncoding(ctx: *NativeContext, val: Value, to: []const u8, from: []const u8) RuntimeError!NativeResult {
     return switch (val) {
         .string => try native_mb_convert_encoding(ctx, &.{ val, .{ .string = Value.String.borrowed(to) }, .{ .string = Value.String.borrowed(from) } }),
         .array => blk: {
             const arr = try ctx.createArray();
             for (val.array.entries.items) |e| {
-                try arr.set(ctx.allocator, e.key, try convertVarEncoding(ctx, e.value, to, from));
+                const converted = try convertVarEncoding(ctx, e.value, to, from);
+                defer if (converted.value == .string) converted.value.string.release();
+                try arr.set(ctx.allocator, e.key, converted.value);
             }
-            break :blk .{ .array = arr };
+            break :blk NativeResult.borrowed(.{ .array = arr });
         },
-        else => val,
+        else => NativeResult.borrowed(val),
     };
 }
 
@@ -3084,8 +3089,8 @@ fn convertVarEncoding(ctx: *NativeContext, val: Value, to: []const u8, from: []c
 // converts the encoding of each var IN PLACE (by reference, recursing into
 // arrays) and returns the source encoding. Symfony Console's splitStringByWidth
 // calls this on its line array - without it, error rendering throws and cascades
-fn native_mb_convert_variables(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string) return .{ .bool = false };
+fn native_mb_convert_variables(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const to = args[0].string.bytes();
     // $from may be a comma-separated candidate list or an array of candidates;
     // take the first (detection among ASCII/UTF-8/Latin1 is near-identity anyway)
@@ -3104,13 +3109,14 @@ fn native_mb_convert_variables(ctx: *NativeContext, args: []const Value) Runtime
     var i: usize = 2;
     while (i < args.len) : (i += 1) {
         const converted = try convertVarEncoding(ctx, args[i], to, from);
-        ctx.setCallerVar(i, args.len, converted);
+        defer if (converted.value == .string) converted.value.string.release();
+        ctx.setCallerVar(i, args.len, converted.value);
     }
-    return .{ .string = Value.String.borrowed(try ctx.createString(from)) };
+    return NativeResult.copyString(ctx.allocator, from);
 }
 
-fn native_mb_convert_encoding(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_convert_encoding(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const input = args[0].string.bytes();
     const to = args[1].string.bytes();
     const from: []const u8 = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else "UTF-8";
@@ -3119,20 +3125,18 @@ fn native_mb_convert_encoding(ctx: *NativeContext, args: []const Value) RuntimeE
         (isLatin1Encoding(from) and isLatin1Encoding(to)) or
         (isAsciiEncoding(from) and isAsciiEncoding(to)))
     {
-        return args[0];
+        return NativeResult.share(args[0]);
     }
     if (isUtf8Encoding(from) and isLatin1Encoding(to)) {
-        const out = convertUtf8ToLatin1(ctx.allocator, input) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertUtf8ToLatin1(ctx.allocator, input) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     if (isLatin1Encoding(from) and isUtf8Encoding(to)) {
-        const out = convertLatin1ToUtf8(ctx.allocator, input) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertLatin1ToUtf8(ctx.allocator, input) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     if (isAsciiEncoding(from) and (isUtf8Encoding(to) or isLatin1Encoding(to))) {
-        return args[0]; // ascii is a subset of both
+        return NativeResult.share(args[0]); // ascii is a subset of both
     }
     if ((isUtf8Encoding(from) or isLatin1Encoding(from)) and isAsciiEncoding(to)) {
         // strip non-ascii bytes
@@ -3153,50 +3157,43 @@ fn native_mb_convert_encoding(ctx: *NativeContext, args: []const Value) RuntimeE
             }
         }
         const owned = try out.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, owned);
-        return .{ .string = Value.String.borrowed(owned) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
     }
     // UTF-8/Latin1/ASCII <-> UTF-16{,BE,LE}. "UTF-16" without suffix is BE
     if (isUtf8Encoding(from) and isUtf16Encoding(to)) {
-        const out = convertUtf8ToUtf16(ctx.allocator, input, isUtf16LE(to)) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertUtf8ToUtf16(ctx.allocator, input, isUtf16LE(to)) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     if (isUtf16Encoding(from) and isUtf8Encoding(to)) {
-        const out = convertUtf16ToUtf8(ctx.allocator, input, isUtf16LE(from)) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertUtf16ToUtf8(ctx.allocator, input, isUtf16LE(from)) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     if (isUtf8Encoding(from) and isUtf32Encoding(to)) {
-        const out = convertUtf8ToUtf32(ctx.allocator, input, isUtf32LE(to)) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertUtf8ToUtf32(ctx.allocator, input, isUtf32LE(to)) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     if (isUtf32Encoding(from) and isUtf8Encoding(to)) {
-        const out = convertUtf32ToUtf8(ctx.allocator, input, isUtf32LE(from)) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertUtf32ToUtf8(ctx.allocator, input, isUtf32LE(from)) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     if (isLatin1Encoding(from) and isUtf16Encoding(to)) {
-        const tmp = convertLatin1ToUtf8(ctx.allocator, input) catch return .{ .bool = false };
+        const tmp = convertLatin1ToUtf8(ctx.allocator, input) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(tmp);
-        const out = convertUtf8ToUtf16(ctx.allocator, tmp, isUtf16LE(to)) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertUtf8ToUtf16(ctx.allocator, tmp, isUtf16LE(to)) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     if (isUtf16Encoding(from) and isLatin1Encoding(to)) {
-        const tmp = convertUtf16ToUtf8(ctx.allocator, input, isUtf16LE(from)) catch return .{ .bool = false };
+        const tmp = convertUtf16ToUtf8(ctx.allocator, input, isUtf16LE(from)) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(tmp);
-        const out = convertUtf8ToLatin1(ctx.allocator, tmp) catch return .{ .bool = false };
-        try ctx.strings.append(ctx.allocator, out);
-        return .{ .string = Value.String.borrowed(out) };
+        const out = convertUtf8ToLatin1(ctx.allocator, tmp) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
     }
     // unknown encoding pair - pass through
-    return args[0];
+    return NativeResult.share(args[0]);
 }
 
-fn native_iconv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return .{ .bool = false };
+fn native_iconv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string or args[1] != .string or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
     const from = args[0].string.bytes();
     const to_raw = args[1].string.bytes();
     // iconv supports "//IGNORE" and "//TRANSLIT" suffixes after the target
@@ -3232,16 +3229,15 @@ fn native_iconv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
         }
         const owned = try out.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, owned);
-        return .{ .string = Value.String.borrowed(owned) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
     }
 
     const args2 = [_]Value{ args[2], .{ .string = Value.String.borrowed(to) }, .{ .string = Value.String.borrowed(from) } };
     return try native_mb_convert_encoding(ctx, &args2);
 }
 
-fn native_mb_strpos(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_strpos(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
     const byte_offset: usize = if (args.len >= 3) blk: {
@@ -3255,7 +3251,7 @@ fn native_mb_strpos(_: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         break :blk bo;
     } else 0;
-    if (byte_offset >= haystack.len) return .{ .bool = false };
+    if (byte_offset >= haystack.len) return NativeResult.scalar(.{ .bool = false });
     if (std.mem.indexOf(u8, haystack[byte_offset..], needle)) |pos| {
         var char_pos: i64 = 0;
         var j: usize = 0;
@@ -3263,13 +3259,13 @@ fn native_mb_strpos(_: *NativeContext, args: []const Value) RuntimeError!Value {
             j += utf8CharLen(haystack[j]);
             char_pos += 1;
         }
-        return .{ .int = char_pos };
+        return NativeResult.scalar(.{ .int = char_pos });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_mb_strrpos(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_strrpos(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
     if (std.mem.lastIndexOf(u8, haystack, needle)) |pos| {
@@ -3279,13 +3275,13 @@ fn native_mb_strrpos(_: *NativeContext, args: []const Value) RuntimeError!Value 
             j += utf8CharLen(haystack[j]);
             char_pos += 1;
         }
-        return .{ .int = char_pos };
+        return NativeResult.scalar(.{ .int = char_pos });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_mb_substr_count(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .int = 0 };
+fn native_mb_substr_count(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .int = 0 });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
     if (needle.len == 0) {
@@ -3302,15 +3298,15 @@ fn native_mb_substr_count(ctx: *NativeContext, args: []const Value) RuntimeError
             i += 1;
         }
     }
-    return .{ .int = count };
+    return NativeResult.scalar(.{ .int = count });
 }
 
-fn native_mb_internal_encoding(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed("UTF-8") };
+fn native_mb_internal_encoding(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal("UTF-8");
 }
 
-fn native_mb_substitute_character(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_mb_substitute_character(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn cjkWidth(cp: u21) usize {
@@ -3331,8 +3327,8 @@ fn cjkWidth(cp: u21) usize {
     return 1;
 }
 
-fn native_mb_strwidth(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .int = 0 };
+fn native_mb_strwidth(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .int = 0 });
     const s = args[0].string.bytes();
     var width: i64 = 0;
     var i: usize = 0;
@@ -3351,7 +3347,7 @@ fn native_mb_strwidth(_: *NativeContext, args: []const Value) RuntimeError!Value
         width += @intCast(cjkWidth(cp));
         i += len;
     }
-    return .{ .int = width };
+    return NativeResult.scalar(.{ .int = width });
 }
 
 fn parseEntityMap(arr: *PhpArray) ?[4]i64 {
@@ -3361,13 +3357,14 @@ fn parseEntityMap(arr: *PhpArray) ?[4]i64 {
     return out;
 }
 
-fn native_mb_encode_numericentity(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .array) return if (args.len > 0) args[0] else .{ .string = Value.String.borrowed("") };
+fn native_mb_encode_numericentity(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .array) return if (args.len > 0) NativeResult.share(args[0]) else NativeResult.literal("");
     const s = args[0].string.bytes();
-    const map = parseEntityMap(args[1].array) orelse return args[0];
+    const map = parseEntityMap(args[1].array) orelse return NativeResult.share(args[0]);
     const hex = args.len >= 4 and args[3].isTruthy();
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         const len = std.unicode.utf8ByteSequenceLength(s[i]) catch 1;
@@ -3402,16 +3399,16 @@ fn native_mb_encode_numericentity(ctx: *NativeContext, args: []const Value) Runt
         i += len;
     }
     const out = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_mb_decode_numericentity(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .array) return if (args.len > 0) args[0] else .{ .string = Value.String.borrowed("") };
+fn native_mb_decode_numericentity(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .array) return if (args.len > 0) NativeResult.share(args[0]) else NativeResult.literal("");
     const s = args[0].string.bytes();
-    const map = parseEntityMap(args[1].array) orelse return args[0];
+    const map = parseEntityMap(args[1].array) orelse return NativeResult.share(args[0]);
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '&' and i + 1 < s.len and s[i + 1] == '#') {
@@ -3447,33 +3444,31 @@ fn native_mb_decode_numericentity(ctx: *NativeContext, args: []const Value) Runt
         i += 1;
     }
     const out = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_mb_chr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_mb_chr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const cp_int = Value.toInt(args[0]);
-    if (cp_int < 0 or cp_int > 0x10FFFF) return .{ .bool = false };
+    if (cp_int < 0 or cp_int > 0x10FFFF) return NativeResult.scalar(.{ .bool = false });
     const cp: u21 = @intCast(cp_int);
     var buf: [4]u8 = undefined;
-    const n = std.unicode.utf8Encode(cp, &buf) catch return .{ .bool = false };
+    const n = std.unicode.utf8Encode(cp, &buf) catch return NativeResult.scalar(.{ .bool = false });
     const out = try ctx.allocator.dupe(u8, buf[0..n]);
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_mb_ord(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_mb_ord(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     if (s.len == 0) {
         try ctx.vm.setPendingException("ValueError", "mb_ord(): Argument #1 ($string) must not be empty");
         return error.RuntimeError;
     }
-    const len = std.unicode.utf8ByteSequenceLength(s[0]) catch return .{ .bool = false };
-    if (len > s.len) return .{ .bool = false };
-    const cp = std.unicode.utf8Decode(s[0..len]) catch return .{ .bool = false };
-    return .{ .int = @intCast(cp) };
+    const len = std.unicode.utf8ByteSequenceLength(s[0]) catch return NativeResult.scalar(.{ .bool = false });
+    if (len > s.len) return NativeResult.scalar(.{ .bool = false });
+    const cp = std.unicode.utf8Decode(s[0..len]) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(cp) });
 }
 
 fn lowerCpUtf8(s: []const u8, i: usize) struct { cp: u21, len: usize } {
@@ -3509,11 +3504,11 @@ fn byteToCharPos(s: []const u8, byte_pos: usize) i64 {
     return c;
 }
 
-fn native_mb_stripos(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_stripos(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
-    if (needle.len == 0) return .{ .bool = false };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = false });
     const start_char: i64 = if (args.len >= 3) Value.toInt(args[2]) else 0;
     var byte_offset: usize = 0;
     var c: i64 = 0;
@@ -3523,17 +3518,17 @@ fn native_mb_stripos(_: *NativeContext, args: []const Value) RuntimeError!Value 
     }
     var i = byte_offset;
     while (i < haystack.len) {
-        if (matchAtCi(haystack, i, needle)) return .{ .int = byteToCharPos(haystack, i) };
+        if (matchAtCi(haystack, i, needle)) return NativeResult.scalar(.{ .int = byteToCharPos(haystack, i) });
         i += utf8CharLen(haystack[i]);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_mb_strripos(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_strripos(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
-    if (needle.len == 0) return .{ .bool = false };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = false });
     // walk to the end recording the last case-insensitive match position
     var last: ?usize = null;
     var i: usize = 0;
@@ -3541,50 +3536,50 @@ fn native_mb_strripos(_: *NativeContext, args: []const Value) RuntimeError!Value
         if (matchAtCi(haystack, i, needle)) last = i;
         i += utf8CharLen(haystack[i]);
     }
-    if (last) |bi| return .{ .int = byteToCharPos(haystack, bi) };
-    return .{ .bool = false };
+    if (last) |bi| return NativeResult.scalar(.{ .int = byteToCharPos(haystack, bi) });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_mb_strstr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_strstr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
-    if (needle.len == 0) return .{ .bool = false };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = false });
     const before: bool = if (args.len >= 3) Value.isTruthy(args[2]) else false;
     if (std.mem.indexOf(u8, haystack, needle)) |pos| {
         const slice = if (before) haystack[0..pos] else haystack[pos..];
-        return .{ .string = Value.String.borrowed(try ctx.createString(slice)) };
+        return NativeResult.copyString(ctx.allocator, slice);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_mb_stristr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_stristr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
-    if (needle.len == 0) return .{ .bool = false };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = false });
     const before: bool = if (args.len >= 3) Value.isTruthy(args[2]) else false;
     var i: usize = 0;
     while (i < haystack.len) : (i += utf8CharLen(haystack[i])) {
         if (matchAtCi(haystack, i, needle)) {
             const slice = if (before) haystack[0..i] else haystack[i..];
-            return .{ .string = Value.String.borrowed(try ctx.createString(slice)) };
+            return NativeResult.copyString(ctx.allocator, slice);
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 // last-occurrence variant of mb_strstr. PHP: mb_strrchr(haystack, needle, before=false)
 // returns the slice starting at the LAST occurrence of needle (or the part
 // before it when $before_needle=true). only the first character of $needle
 // is used in PHP. case-sensitive
-fn native_mb_strrchr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_strrchr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
-    if (needle.len == 0) return .{ .bool = false };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = false });
     const nch_len = utf8CharLen(needle[0]);
-    if (nch_len > needle.len) return .{ .bool = false };
+    if (nch_len > needle.len) return NativeResult.scalar(.{ .bool = false });
     const before: bool = if (args.len >= 3) Value.isTruthy(args[2]) else false;
     var last: ?usize = null;
     var i: usize = 0;
@@ -3597,9 +3592,9 @@ fn native_mb_strrchr(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     }
     if (last) |pos| {
         const slice = if (before) haystack[0..pos] else haystack[pos..];
-        return .{ .string = Value.String.borrowed(try ctx.createString(slice)) };
+        return NativeResult.copyString(ctx.allocator, slice);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 // trim string to a maximum display width and optionally append a marker.
@@ -3642,12 +3637,12 @@ fn decodeUtf8(s: []const u8, i: usize) struct { cp: u32, len: usize } {
     return .{ .cp = (@as(u32, b0 & 0x07) << 18) | (@as(u32, s[i + 1] & 0x3F) << 12) | (@as(u32, s[i + 2] & 0x3F) << 6) | (s[i + 3] & 0x3F), .len = 4 };
 }
 
-fn native_mb_strimwidth(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string) return .{ .bool = false };
+fn native_mb_strimwidth(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     const start: i64 = Value.toInt(args[1]);
     const max_width: i64 = Value.toInt(args[2]);
-    if (max_width <= 0) return .{ .string = Value.String.borrowed(try ctx.createString("")) };
+    if (max_width <= 0) return NativeResult.literal("");
     const marker = if (args.len >= 4 and args[3] == .string) args[3].string.bytes() else "";
 
     // marker width
@@ -3674,6 +3669,7 @@ fn native_mb_strimwidth(ctx: *NativeContext, args: []const Value) RuntimeError!V
     }
 
     var out = std.ArrayListUnmanaged(u8){};
+    defer out.deinit(ctx.allocator);
     const target = max_width - marker_w;
     // first try to fit without the marker
     var probe = bi;
@@ -3700,12 +3696,11 @@ fn native_mb_strimwidth(ctx: *NativeContext, args: []const Value) RuntimeError!V
         try out.appendSlice(ctx.allocator, marker);
     }
     const owned = try out.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
-fn native_mb_strcut(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_mb_strcut(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     var start: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     if (start < 0) start = @max(0, @as(i64, @intCast(s.len)) + start);
@@ -3725,15 +3720,15 @@ fn native_mb_strcut(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         // align end to leading byte (don't split a multibyte char)
         while (end > ustart and end < s.len and (s[end] & 0xC0) == 0x80) end -= 1;
     }
-    if (end <= ustart) return .{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try ctx.createString(s[ustart..end])) };
+    if (end <= ustart) return NativeResult.literal("");
+    return NativeResult.copyString(ctx.allocator, s[ustart..end]);
 }
 
-fn native_mb_encoding_aliases(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_mb_encoding_aliases(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const enc = args[0].string.bytes();
     var lower_buf: [32]u8 = undefined;
-    if (enc.len > lower_buf.len) return .{ .bool = false };
+    if (enc.len > lower_buf.len) return NativeResult.scalar(.{ .bool = false });
     for (enc, 0..) |c, i| lower_buf[i] = std.ascii.toLower(c);
     const e = lower_buf[0..enc.len];
     const arr = try ctx.createArray();
@@ -3747,10 +3742,10 @@ fn native_mb_encoding_aliases(ctx: *NativeContext, args: []const Value) RuntimeE
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("ISO_8859-1") });
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("latin1") });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_mb_list_encodings(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_mb_list_encodings(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     // mirrors PHP 8.4's mb_list_encodings() output, in the same order.
     // zphp doesn't actually transcode most of these - it lists them so feature
@@ -3772,27 +3767,28 @@ fn native_mb_list_encodings(ctx: *NativeContext, _: []const Value) RuntimeError!
         "CP50222",
     };
     for (list) |n| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(n) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_mb_str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return args[0];
+fn native_mb_str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    if (args.len < 2 or args[0] != .string) return NativeResult.share(args[0]);
     const s = args[0].string.bytes();
     const target_chars: i64 = Value.toInt(args[1]);
     const pad_str: []const u8 = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else " ";
     const pad_type: i64 = if (args.len >= 4) Value.toInt(args[3]) else 1; // STR_PAD_RIGHT
-    if (pad_str.len == 0 or target_chars <= 0) return args[0];
+    if (pad_str.len == 0 or target_chars <= 0) return NativeResult.share(args[0]);
 
     var s_chars: i64 = 0;
     var i: usize = 0;
     while (i < s.len) : (i += utf8CharLen(s[i])) s_chars += 1;
-    if (s_chars >= target_chars) return args[0];
+    if (s_chars >= target_chars) return NativeResult.share(args[0]);
     const pad_needed: i64 = target_chars - s_chars;
 
     var pad_chars: i64 = 0;
     var pi: usize = 0;
     while (pi < pad_str.len) : (pi += utf8CharLen(pad_str[pi])) pad_chars += 1;
-    if (pad_chars == 0) return args[0];
+    if (pad_chars == 0) return NativeResult.share(args[0]);
 
     const left_chars: i64 = switch (pad_type) {
         0 => pad_needed, // STR_PAD_LEFT
@@ -3808,7 +3804,7 @@ fn native_mb_str_pad(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     try buf.appendSlice(ctx.allocator, s);
     try appendPadChars(ctx, &buf, pad_str, right_chars);
 
-    return .{ .string = Value.String.borrowed(try ctx.createString(buf.items)) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator)));
 }
 
 fn appendPadChars(ctx: *NativeContext, buf: *std.ArrayListUnmanaged(u8), pad_str: []const u8, count: i64) !void {
@@ -3831,9 +3827,9 @@ fn utf8CharLen(byte: u8) usize {
     return 4;
 }
 
-fn native_str_getcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value.null;
+fn native_str_getcsv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(.null);
     const sep: u8 = if (args.len >= 2 and args[1] == .string and args[1].string.bytes().len > 0) args[1].string.bytes()[0] else ',';
     const enc: u8 = if (args.len >= 3 and args[2] == .string and args[2].string.bytes().len > 0) args[2].string.bytes()[0] else '"';
 
@@ -3841,10 +3837,11 @@ fn native_str_getcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
 
     if (s.len == 0) {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("") });
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
     var field = std.ArrayListUnmanaged(u8){};
+    defer field.deinit(ctx.allocator);
     var in_quotes = false;
     var at_field_start = true;
     var i: usize = 0;
@@ -3866,9 +3863,9 @@ fn native_str_getcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
                 in_quotes = true;
                 at_field_start = false;
             } else if (c == sep) {
-                const f = try field.toOwnedSlice(ctx.allocator);
-                try ctx.strings.append(ctx.allocator, f);
-                try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(f) });
+                const f = try Value.String.adopt(ctx.allocator, try field.toOwnedSlice(ctx.allocator));
+                defer f.release();
+                try arr.append(ctx.allocator, .{ .string = f });
                 at_field_start = true;
             } else {
                 try field.append(ctx.allocator, c);
@@ -3876,19 +3873,19 @@ fn native_str_getcsv(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
             }
         }
     }
-    const f = try field.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, f);
-    try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(f) });
+    const f = try Value.String.adopt(ctx.allocator, try field.toOwnedSlice(ctx.allocator));
+    defer f.release();
+    try arr.append(ctx.allocator, .{ .string = f });
 
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 const base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-fn native_base64_encode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_base64_encode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    if (s.len == 0) return NativeResult.literal("");
 
     const out_len = ((s.len + 2) / 3) * 4;
     const buf = try ctx.allocator.alloc(u8, out_len);
@@ -3917,8 +3914,7 @@ fn native_base64_encode(ctx: *NativeContext, args: []const Value) RuntimeError!V
         buf[di + 2] = base64_chars[@intCast((n >> 6) & 0x3f)];
         buf[di + 3] = '=';
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
 fn base64Decode(c: u8) ?u6 {
@@ -3930,14 +3926,15 @@ fn base64Decode(c: u8) ?u6 {
     return null;
 }
 
-fn native_base64_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .bool = false };
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_base64_decode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
+    if (s.len == 0) return NativeResult.literal("");
 
     const strict = args.len >= 2 and args[1] == .bool and args[1].bool;
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var accum: u24 = 0;
     var bits: u5 = 0;
     var pad_count: usize = 0;
@@ -3947,8 +3944,7 @@ fn native_base64_decode(ctx: *NativeContext, args: []const Value) RuntimeError!V
             continue;
         }
         if (pad_count > 0 and strict) {
-            buf.deinit(ctx.allocator);
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         }
         if (c == ' ' or c == '\n' or c == '\r' or c == '\t') {
             // PHP allows whitespace in both strict and non-strict modes
@@ -3956,8 +3952,7 @@ fn native_base64_decode(ctx: *NativeContext, args: []const Value) RuntimeError!V
         }
         const val = base64Decode(c) orelse {
             if (strict) {
-                buf.deinit(ctx.allocator);
-                return .{ .bool = false };
+                return NativeResult.scalar(.{ .bool = false });
             }
             continue;
         };
@@ -3969,15 +3964,15 @@ fn native_base64_decode(ctx: *NativeContext, args: []const Value) RuntimeError!V
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_convert_uuencode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_convert_uuencode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
-    if (s.len == 0) return .{ .bool = false };
+    if (s.len == 0) return NativeResult.scalar(.{ .bool = false });
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         const line_len = @min(@as(usize, 45), s.len - i);
@@ -4005,15 +4000,15 @@ fn native_convert_uuencode(ctx: *NativeContext, args: []const Value) RuntimeErro
     try buf.append(ctx.allocator, 0x60);
     try buf.append(ctx.allocator, '\n');
     const out = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_convert_uudecode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_convert_uudecode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
-    if (s.len == 0) return .{ .bool = false };
+    if (s.len == 0) return NativeResult.scalar(.{ .bool = false });
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var p: usize = 0;
     while (p < s.len) {
         // read length byte
@@ -4055,8 +4050,7 @@ fn native_convert_uudecode(ctx: *NativeContext, args: []const Value) RuntimeErro
         if (p < s.len and s[p] == '\n') p += 1;
     }
     const out = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
 fn decodeUuChar(c: u8) u8 {
@@ -4065,10 +4059,11 @@ fn decodeUuChar(c: u8) u8 {
     return (c - 0x20) & 0x3f;
 }
 
-fn native_urlencode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_urlencode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     const hex = "0123456789ABCDEF";
     for (s) |c| {
         if (std.ascii.isAlphanumeric(c) or c == '-' or c == '_' or c == '.') {
@@ -4082,14 +4077,14 @@ fn native_urlencode(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_urldecode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_urldecode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '%' and i + 2 < s.len) {
@@ -4114,14 +4109,14 @@ fn native_urldecode(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_rawurlencode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_rawurlencode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     const hex = "0123456789ABCDEF";
     for (s) |c| {
         if (std.ascii.isAlphanumeric(c) or c == '-' or c == '_' or c == '.' or c == '~') {
@@ -4133,14 +4128,14 @@ fn native_rawurlencode(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_rawurldecode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_rawurldecode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '%' and i + 2 < s.len) {
@@ -4162,8 +4157,7 @@ fn native_rawurldecode(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 /// PHP's `string` parameter type rejects arrays with a TypeError. Most native
@@ -4219,49 +4213,49 @@ pub fn coerceToString(ctx: *NativeContext, v: Value) ![]const u8 {
     };
 }
 
-fn native_md5(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_md5(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
     const raw_output = args.len >= 2 and args[1].isTruthy();
     var hash: [16]u8 = undefined;
     std.crypto.hash.Md5.hash(s, &hash, .{});
-    if (raw_output) return .{ .string = Value.String.borrowed(try ctx.createString(&hash)) };
+    if (raw_output) return NativeResult.copyString(ctx.allocator, &hash);
     const hex = "0123456789abcdef";
     var buf: [32]u8 = undefined;
     for (hash, 0..) |byte, i| {
         buf[i * 2] = hex[byte >> 4];
         buf[i * 2 + 1] = hex[byte & 0x0f];
     }
-    return .{ .string = Value.String.borrowed(try ctx.createString(&buf)) };
+    return NativeResult.copyString(ctx.allocator, &buf);
 }
 
-fn native_sha1(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_sha1(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const raw_output = args.len >= 2 and args[1].isTruthy();
     var hash: [20]u8 = undefined;
     std.crypto.hash.Sha1.hash(s, &hash, .{});
-    if (raw_output) return .{ .string = Value.String.borrowed(try ctx.createString(&hash)) };
+    if (raw_output) return NativeResult.copyString(ctx.allocator, &hash);
     const hex = "0123456789abcdef";
     var buf: [40]u8 = undefined;
     for (hash, 0..) |byte, i| {
         buf[i * 2] = hex[byte >> 4];
         buf[i * 2 + 1] = hex[byte & 0x0f];
     }
-    return .{ .string = Value.String.borrowed(try ctx.createString(&buf)) };
+    return NativeResult.copyString(ctx.allocator, &buf);
 }
 
-fn native_mb_substr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_mb_substr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const char_count = mbCharCount(s);
     var start = Value.toInt(args[1]);
     if (start < 0) start = @max(0, char_count + start);
-    if (start >= char_count) return .{ .string = Value.String.borrowed("") };
+    if (start >= char_count) return NativeResult.literal("");
 
     var length = if (args.len >= 3 and args[2] != .null) Value.toInt(args[2]) else char_count - start;
     if (length < 0) length = @max(0, char_count - start + length);
-    if (length <= 0) return .{ .string = Value.String.borrowed("") };
+    if (length <= 0) return NativeResult.literal("");
 
     var byte_start: usize = 0;
     var ci: i64 = 0;
@@ -4278,7 +4272,7 @@ fn native_mb_substr(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         chars_remaining -= 1;
     }
 
-    return .{ .string = Value.String.borrowed(try ctx.createString(s[byte_start..bi])) };
+    return NativeResult.copyString(ctx.allocator, s[byte_start..bi]);
 }
 
 fn mbCharCount(s: []const u8) i64 {
@@ -4298,14 +4292,13 @@ fn mbCharLen(byte: u8) usize {
     return 4;
 }
 
-fn native_strrev(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_strrev(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (s.len == 0) return NativeResult.literal("");
     const buf = try ctx.allocator.alloc(u8, s.len);
     for (s, 0..) |c, i| buf[s.len - 1 - i] = c;
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
 fn toLowerBuf(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
@@ -4314,34 +4307,34 @@ fn toLowerBuf(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
     return buf;
 }
 
-fn native_stripos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn native_stripos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const haystack = try coerceToString(ctx, args[0]);
     const needle = try coerceToString(ctx, args[1]);
     const hlen: i64 = @intCast(haystack.len);
     const raw_off: i64 = if (args.len >= 3) Value.toInt(args[2]) else 0;
     const off_i: i64 = if (raw_off < 0) @max(0, hlen + raw_off) else raw_off;
-    if (off_i > hlen) return .{ .bool = false };
+    if (off_i > hlen) return NativeResult.scalar(.{ .bool = false });
     const offset: usize = @intCast(off_i);
     // PHP 8+: stripos/strpos with empty needle returns the offset (0 default)
-    if (needle.len == 0) return .{ .int = @intCast(offset) };
+    if (needle.len == 0) return NativeResult.scalar(.{ .int = @intCast(offset) });
     const h_lower = try toLowerBuf(ctx.allocator, haystack[offset..]);
     defer ctx.allocator.free(h_lower);
     const n_lower = try toLowerBuf(ctx.allocator, needle);
     defer ctx.allocator.free(n_lower);
     if (std.mem.indexOf(u8, h_lower, n_lower)) |pos| {
-        return .{ .int = @intCast(pos + offset) };
+        return NativeResult.scalar(.{ .int = @intCast(pos + offset) });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_strrpos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn native_strrpos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const haystack = try coerceToString(ctx, args[0]);
     const needle = try coerceToString(ctx, args[1]);
-    if (needle.len == 0) return .{ .int = @intCast(haystack.len) };
-    if (haystack.len == 0) return .{ .bool = false };
-    return strrposImpl(haystack, needle, args);
+    if (needle.len == 0) return NativeResult.scalar(.{ .int = @intCast(haystack.len) });
+    if (haystack.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(strrposImpl(haystack, needle, args));
 }
 
 fn strrposImpl(haystack: []const u8, needle: []const u8, args: []const Value) Value {
@@ -4370,21 +4363,21 @@ fn strrposImpl(haystack: []const u8, needle: []const u8, args: []const Value) Va
     return .{ .bool = false };
 }
 
-fn native_strripos(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
-    const haystack = if (args[0] == .string) args[0].string.bytes() else return Value{ .bool = false };
-    const needle = if (args[1] == .string) args[1].string.bytes() else return Value{ .bool = false };
-    if (needle.len == 0) return .{ .int = @intCast(haystack.len) };
-    if (haystack.len == 0) return .{ .bool = false };
+fn native_strripos(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
+    const haystack = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
+    const needle = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
+    if (needle.len == 0) return NativeResult.scalar(.{ .int = @intCast(haystack.len) });
+    if (haystack.len == 0) return NativeResult.scalar(.{ .bool = false });
     const h_lower = try toLowerBuf(ctx.allocator, haystack);
     defer ctx.allocator.free(h_lower);
     const n_lower = try toLowerBuf(ctx.allocator, needle);
     defer ctx.allocator.free(n_lower);
-    return strrposImpl(h_lower, n_lower, args);
+    return NativeResult.scalar(strrposImpl(h_lower, n_lower, args));
 }
 
-fn native_str_ireplace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return if (args.len >= 3) args[2] else Value{ .string = Value.String.borrowed("") };
+fn native_str_ireplace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.literal("");
     var total_count: i64 = 0;
 
     if (args[2] == .array) {
@@ -4393,26 +4386,28 @@ fn native_str_ireplace(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         for (subject_arr.entries.items) |se| {
             const elem_str: []const u8 = if (se.value == .string) se.value.string.bytes() else "";
             const replaced = try strIreplaceOnSingle(ctx, args[0], args[1], elem_str, &total_count);
-            try out.set(ctx.allocator, se.key, .{ .string = Value.String.borrowed(replaced) });
+            defer replaced.release();
+            try out.set(ctx.allocator, se.key, .{ .string = replaced });
         }
         if (args.len >= 4) ctx.setCallerVar(3, args.len, .{ .int = total_count });
-        return .{ .array = out };
+        return NativeResult.borrowed(.{ .array = out });
     }
 
-    const subject = if (args[2] == .string) args[2].string.bytes() else return args[2];
+    const subject = if (args[2] == .string) args[2].string.bytes() else return NativeResult.share(args[2]);
     const replaced = try strIreplaceOnSingle(ctx, args[0], args[1], subject, &total_count);
     if (args.len >= 4) ctx.setCallerVar(3, args.len, .{ .int = total_count });
-    return .{ .string = Value.String.borrowed(replaced) };
+    return NativeResult.takeString(replaced);
 }
 
-fn strIreplaceOne(ctx: *NativeContext, subject: []const u8, search: []const u8, replace: []const u8, count: *i64) ![]const u8 {
-    if (search.len == 0) return subject;
+fn strIreplaceOne(ctx: *NativeContext, subject: []const u8, search: []const u8, replace: []const u8, count: *i64) !Value.String {
+    if (search.len == 0) return Value.String.create(ctx.allocator, subject);
     const s_lower = try toLowerBuf(ctx.allocator, subject);
     defer ctx.allocator.free(s_lower);
     const n_lower = try toLowerBuf(ctx.allocator, search);
     defer ctx.allocator.free(n_lower);
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < subject.len) {
         if (i + search.len <= subject.len and std.mem.eql(u8, s_lower[i .. i + search.len], n_lower)) {
@@ -4425,13 +4420,13 @@ fn strIreplaceOne(ctx: *NativeContext, subject: []const u8, search: []const u8, 
         }
     }
     const out = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return out;
+    return Value.String.adopt(ctx.allocator, out);
 }
 
-fn strIreplaceOnSingle(ctx: *NativeContext, search: Value, replace: Value, subject: []const u8, total_count: *i64) ![]const u8 {
+fn strIreplaceOnSingle(ctx: *NativeContext, search: Value, replace: Value, subject: []const u8, total_count: *i64) !Value.String {
     if (search == .array) {
-        var result = subject;
+        var result = try Value.String.create(ctx.allocator, subject);
+        errdefer result.release();
         for (search.array.entries.items, 0..) |entry, idx| {
             const needle = if (entry.value == .string) entry.value.string.bytes() else continue;
             const replacement = if (replace == .array) blk: {
@@ -4440,19 +4435,21 @@ fn strIreplaceOnSingle(ctx: *NativeContext, search: Value, replace: Value, subje
                 }
                 break :blk "";
             } else if (replace == .string) replace.string.bytes() else "";
-            result = try strIreplaceOne(ctx, result, needle, replacement, total_count);
+            const next = try strIreplaceOne(ctx, result.bytes(), needle, replacement, total_count);
+            result.release();
+            result = next;
         }
         return result;
     }
-    const s = if (search == .string) search.string.bytes() else return subject;
+    const s = if (search == .string) search.string.bytes() else return Value.String.create(ctx.allocator, subject);
     const rep = if (replace == .string) replace.string.bytes() else "";
     return strIreplaceOne(ctx, subject, s, rep, total_count);
 }
 
-fn native_ucwords(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_ucwords(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const s = try coerceToString(ctx, args[0]);
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (s.len == 0) return NativeResult.literal("");
     const delimiters = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else " \t\r\n\x0b";
     const buf = try ctx.allocator.alloc(u8, s.len);
     var capitalize_next = true;
@@ -4467,8 +4464,7 @@ fn native_ucwords(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             buf[i] = c;
         }
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
 fn isDelimiter(c: u8, delimiters: []const u8) bool {
@@ -4478,18 +4474,18 @@ fn isDelimiter(c: u8, delimiters: []const u8) bool {
     return false;
 }
 
-fn native_crc32(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
+fn native_crc32(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
     const result = std.hash.crc.Crc32IsoHdlc.hash(s);
     // PHP returns the unsigned 32-bit value (zero-extended into signed 64-bit)
-    return .{ .int = @as(i64, result) };
+    return NativeResult.scalar(.{ .int = @as(i64, result) });
 }
 
-fn native_str_rot13(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_str_rot13(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    if (s.len == 0) return NativeResult.literal("");
     const buf = try ctx.allocator.alloc(u8, s.len);
     for (s, 0..) |c, i| {
         buf[i] = if (c >= 'a' and c <= 'z')
@@ -4499,8 +4495,7 @@ fn native_str_rot13(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         else
             c;
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return .{ .string = Value.String.borrowed(buf) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
 }
 
 // PHP's default Unicode-whitespace set for mb_trim family. matches what PHP
@@ -4558,7 +4553,7 @@ fn cpInSet(set: []const u21, cp: u21) bool {
     return false;
 }
 
-fn mbTrimImpl(ctx: *NativeContext, s: []const u8, set: []const u21, left: bool, right: bool) ![]const u8 {
+fn mbTrimImpl(ctx: *NativeContext, s: []const u8, set: []const u21, left: bool, right: bool) !Value.String {
     var start: usize = 0;
     if (left) {
         while (start < s.len) {
@@ -4577,41 +4572,42 @@ fn mbTrimImpl(ctx: *NativeContext, s: []const u8, set: []const u21, left: bool, 
             end -= pl;
         }
     }
-    return try ctx.createString(s[start..end]);
+    return Value.String.create(ctx.allocator, s[start..end]);
 }
 
-fn native_mb_trim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_mb_trim(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const arg_chars: ?[]const u8 = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else null;
     const set = try buildMbTrimSet(ctx.allocator, arg_chars);
     defer ctx.allocator.free(set);
-    return .{ .string = Value.String.borrowed(try mbTrimImpl(ctx, s, set, true, true)) };
+    return NativeResult.takeString(try mbTrimImpl(ctx, s, set, true, true));
 }
 
-fn native_mb_ltrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_mb_ltrim(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const arg_chars: ?[]const u8 = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else null;
     const set = try buildMbTrimSet(ctx.allocator, arg_chars);
     defer ctx.allocator.free(set);
-    return .{ .string = Value.String.borrowed(try mbTrimImpl(ctx, s, set, true, false)) };
+    return NativeResult.takeString(try mbTrimImpl(ctx, s, set, true, false));
 }
 
-fn native_mb_rtrim(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
+fn native_mb_rtrim(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
     const arg_chars: ?[]const u8 = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else null;
     const set = try buildMbTrimSet(ctx.allocator, arg_chars);
     defer ctx.allocator.free(set);
-    return .{ .string = Value.String.borrowed(try mbTrimImpl(ctx, s, set, false, true)) };
+    return NativeResult.takeString(try mbTrimImpl(ctx, s, set, false, true));
 }
 
-fn native_quotemeta(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    if (s.len == 0) return .{ .string = Value.String.borrowed("") };
+fn native_quotemeta(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    if (s.len == 0) return NativeResult.literal("");
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     for (s) |c| {
         if (c == '.' or c == '\\' or c == '+' or c == '*' or c == '?' or
             c == '[' or c == '^' or c == ']' or c == '(' or c == ')' or
@@ -4622,43 +4618,39 @@ fn native_quotemeta(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         try buf.append(ctx.allocator, c);
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_mb_ucfirst(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try mbCaseFirst(ctx, s, true)) };
+fn native_mb_ucfirst(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    return NativeResult.takeString(try mbCaseFirst(ctx, s, true));
 }
 
-fn native_mb_lcfirst(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    const s = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try mbCaseFirst(ctx, s, false)) };
+fn native_mb_lcfirst(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    const s = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    return NativeResult.takeString(try mbCaseFirst(ctx, s, false));
 }
 
-fn mbCaseFirst(ctx: *NativeContext, s: []const u8, to_upper: bool) ![]const u8 {
-    if (s.len == 0) return "";
+fn mbCaseFirst(ctx: *NativeContext, s: []const u8, to_upper: bool) !Value.String {
+    if (s.len == 0) return Value.String.create(ctx.allocator, "");
     const first_len = std.unicode.utf8ByteSequenceLength(s[0]) catch 1;
     if (first_len > s.len) {
         const buf = try ctx.allocator.alloc(u8, s.len);
         @memcpy(buf, s);
-        try ctx.strings.append(ctx.allocator, buf);
-        return buf;
+        return Value.String.adopt(ctx.allocator, buf);
     }
     if (first_len == 1) {
         const buf = try ctx.allocator.alloc(u8, s.len);
         @memcpy(buf, s);
         buf[0] = if (to_upper) std.ascii.toUpper(s[0]) else std.ascii.toLower(s[0]);
-        try ctx.strings.append(ctx.allocator, buf);
-        return buf;
+        return Value.String.adopt(ctx.allocator, buf);
     }
     const cp = std.unicode.utf8Decode(s[0..first_len]) catch {
         const buf = try ctx.allocator.alloc(u8, s.len);
         @memcpy(buf, s);
-        try ctx.strings.append(ctx.allocator, buf);
-        return buf;
+        return Value.String.adopt(ctx.allocator, buf);
     };
     const new_cp = if (to_upper) unicodeToUpper(cp) else unicodeToLower(cp);
     var enc: [4]u8 = undefined;
@@ -4667,12 +4659,11 @@ fn mbCaseFirst(ctx: *NativeContext, s: []const u8, to_upper: bool) ![]const u8 {
     const buf = try ctx.allocator.alloc(u8, total);
     @memcpy(buf[0..enc_len], enc[0..enc_len]);
     @memcpy(buf[enc_len..], s[first_len..]);
-    try ctx.strings.append(ctx.allocator, buf);
-    return buf;
+    return Value.String.adopt(ctx.allocator, buf);
 }
 
-fn native_strip_tags(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_strip_tags(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
 
     var allowed_tags_buf: [64][64]u8 = undefined;
@@ -4717,6 +4708,7 @@ fn native_strip_tags(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     }
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '<') {
@@ -4752,16 +4744,15 @@ fn native_strip_tags(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 fn toLowerAscii(c: u8) u8 {
     return if (c >= 'A' and c <= 'Z') c + 32 else c;
 }
 
-fn native_http_build_query(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .array) return .{ .string = Value.String.borrowed("") };
+fn native_http_build_query(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .array) return NativeResult.literal("");
     const arr = args[0].array;
     const prefix_str: []const u8 = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "";
     // arg_separator default "&"
@@ -4771,6 +4762,7 @@ fn native_http_build_query(ctx: *NativeContext, args: []const Value) RuntimeErro
     const rfc3986 = enc_type == 2;
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var first = true;
     for (arr.entries.items) |entry| {
         var key_buf: [32]u8 = undefined;
@@ -4788,8 +4780,7 @@ fn native_http_build_query(ctx: *NativeContext, args: []const Value) RuntimeErro
         try buildQueryPairs(&buf, ctx.allocator, key_str, entry.value, &first, arg_sep, rfc3986);
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
 fn buildQueryPairs(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, prefix: []const u8, value: Value, first: *bool, sep: []const u8, rfc3986: bool) !void {
@@ -4875,10 +4866,11 @@ fn appendUrlEncodedMode(buf: *std.ArrayListUnmanaged(u8), a: std.mem.Allocator, 
     }
 }
 
-fn native_qp_encode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_qp_encode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     const hex = "0123456789ABCDEF";
     var line_len: usize = 0;
     var i: usize = 0;
@@ -4906,14 +4898,14 @@ fn native_qp_encode(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         i += 1;
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_qp_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_qp_decode(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '=' and i + 2 < s.len) {
@@ -4940,12 +4932,11 @@ fn native_qp_decode(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_parse_url(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return Value{ .bool = false };
+fn native_parse_url(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const url = args[0].string.bytes();
 
     const component: ?i64 = if (args.len >= 2 and args[1] == .int) args[1].int else null;
@@ -4968,9 +4959,9 @@ fn native_parse_url(ctx: *NativeContext, args: []const Value) RuntimeError!Value
             }
         }
         if (!scheme_ok) {
-            var arr = try ctx.createArray();
-            try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("path") }, .{ .string = Value.String.borrowed(try ctx.createString(url)) });
-            return .{ .array = arr };
+            const arr = try ctx.createArray();
+            try setUrlComponent(ctx, arr, "path", url);
+            return NativeResult.borrowed(.{ .array = arr });
         }
         scheme = url[0..pos];
         scheme_end = pos + 3;
@@ -5044,8 +5035,8 @@ fn native_parse_url(ctx: *NativeContext, args: []const Value) RuntimeError!Value
                 host = authority[0 .. bracket + 1];
                 if (bracket + 1 < authority.len and authority[bracket + 1] == ':') {
                     const port_str = authority[bracket + 2 ..];
-                    port = std.fmt.parseInt(i64, port_str, 10) catch return Value{ .bool = false };
-                    if (port.? < 0 or port.? > 65535) return Value{ .bool = false };
+                    port = std.fmt.parseInt(i64, port_str, 10) catch return NativeResult.scalar(.{ .bool = false });
+                    if (port.? < 0 or port.? > 65535) return NativeResult.scalar(.{ .bool = false });
                 }
             } else {
                 host = authority;
@@ -5054,8 +5045,8 @@ fn native_parse_url(ctx: *NativeContext, args: []const Value) RuntimeError!Value
             host = authority[0..pos];
             const port_str = authority[pos + 1 ..];
             // PHP rejects URLs with non-numeric or out-of-range ports
-            port = std.fmt.parseInt(i64, port_str, 10) catch return Value{ .bool = false };
-            if (port.? < 0 or port.? > 65535) return Value{ .bool = false };
+            port = std.fmt.parseInt(i64, port_str, 10) catch return NativeResult.scalar(.{ .bool = false });
+            if (port.? < 0 or port.? > 65535) return NativeResult.scalar(.{ .bool = false });
         } else if (authority.len > 0) {
             host = authority;
         }
@@ -5071,40 +5062,41 @@ fn native_parse_url(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     if (has_authority) {
         const host_empty = if (host) |h| h.len == 0 else true;
         if (host_empty) {
-            if (port != null or user != null or pass != null) return Value{ .bool = false };
+            if (port != null or user != null or pass != null) return NativeResult.scalar(.{ .bool = false });
             const is_file_scheme = if (scheme) |s| std.ascii.eqlIgnoreCase(s, "file") else false;
-            if (scheme != null and !is_file_scheme) return Value{ .bool = false };
+            if (scheme != null and !is_file_scheme) return NativeResult.scalar(.{ .bool = false });
         }
     }
 
     if (component) |c| {
         return switch (c) {
-            0 => if (scheme) |s| Value{ .string = Value.String.borrowed(try ctx.createString(s)) } else .null,
-            1 => if (host) |h| Value{ .string = Value.String.borrowed(try ctx.createString(h)) } else .null,
-            2 => if (port) |p| Value{ .int = p } else .null,
-            3 => if (user) |u| Value{ .string = Value.String.borrowed(try ctx.createString(u)) } else .null,
-            4 => if (pass) |p| Value{ .string = Value.String.borrowed(try ctx.createString(p)) } else .null,
-            5 => if (path) |p| Value{ .string = Value.String.borrowed(try ctx.createString(p)) } else .null,
-            6 => if (query) |q| Value{ .string = Value.String.borrowed(try ctx.createString(q)) } else .null,
-            7 => if (fragment) |f| Value{ .string = Value.String.borrowed(try ctx.createString(f)) } else .null,
-            else => Value{ .bool = false },
+            0 => if (scheme) |s| try NativeResult.copyString(ctx.allocator, s) else NativeResult.scalar(.null),
+            1 => if (host) |h| try NativeResult.copyString(ctx.allocator, h) else NativeResult.scalar(.null),
+            2 => if (port) |p| NativeResult.scalar(.{ .int = p }) else NativeResult.scalar(.null),
+            3 => if (user) |u| try NativeResult.copyString(ctx.allocator, u) else NativeResult.scalar(.null),
+            4 => if (pass) |p| try NativeResult.copyString(ctx.allocator, p) else NativeResult.scalar(.null),
+            5 => if (path) |p| try NativeResult.copyString(ctx.allocator, p) else NativeResult.scalar(.null),
+            6 => if (query) |q| try NativeResult.copyString(ctx.allocator, q) else NativeResult.scalar(.null),
+            7 => if (fragment) |f| try NativeResult.copyString(ctx.allocator, f) else NativeResult.scalar(.null),
+            else => NativeResult.scalar(.{ .bool = false }),
         };
     }
 
     var arr = try ctx.createArray();
-    if (scheme) |s| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("scheme") }, .{ .string = Value.String.borrowed(try ctx.createString(s)) });
-    if (host) |h| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("host") }, .{ .string = Value.String.borrowed(try ctx.createString(h)) });
+    if (scheme) |s| try setUrlComponent(ctx, arr, "scheme", s);
+    if (host) |h| try setUrlComponent(ctx, arr, "host", h);
     if (port) |p| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("port") }, .{ .int = p });
-    if (user) |u| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("user") }, .{ .string = Value.String.borrowed(try ctx.createString(u)) });
-    if (pass) |p| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("pass") }, .{ .string = Value.String.borrowed(try ctx.createString(p)) });
-    if (path) |p| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("path") }, .{ .string = Value.String.borrowed(try ctx.createString(p)) });
-    if (query) |q| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("query") }, .{ .string = Value.String.borrowed(try ctx.createString(q)) });
-    if (fragment) |f| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("fragment") }, .{ .string = Value.String.borrowed(try ctx.createString(f)) });
-    return .{ .array = arr };
+    if (user) |u| try setUrlComponent(ctx, arr, "user", u);
+    if (pass) |p| try setUrlComponent(ctx, arr, "pass", p);
+    if (path) |p| try setUrlComponent(ctx, arr, "path", p);
+    if (query) |q| try setUrlComponent(ctx, arr, "query", q);
+    if (fragment) |f| try setUrlComponent(ctx, arr, "fragment", f);
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn urlDecodeSlice(ctx: *NativeContext, s: []const u8) ![]const u8 {
+fn urlDecodeSlice(ctx: *NativeContext, s: []const u8) !Value.String {
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '%' and i + 2 < s.len) {
@@ -5129,12 +5121,11 @@ fn urlDecodeSlice(ctx: *NativeContext, s: []const u8) ![]const u8 {
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return result;
+    return Value.String.adopt(ctx.allocator, result);
 }
 
-fn native_parse_str(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .null;
+fn native_parse_str(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.null);
     const s = args[0].string.bytes();
 
     const arr = try ctx.createArray();
@@ -5160,19 +5151,21 @@ fn native_parse_str(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         }
 
         const decoded_key = try urlDecodeSlice(ctx, key);
+        defer decoded_key.release();
         const decoded_val = try urlDecodeSlice(ctx, val);
-        try insertParsedKey(ctx, arr, decoded_key, .{ .string = Value.String.borrowed(decoded_val) });
+        defer decoded_val.release();
+        try insertParsedKey(ctx, arr, decoded_key.bytes(), .{ .string = decoded_val });
     }
     if (args.len >= 2) {
         ctx.setCallerVar(1, args.len, .{ .array = arr });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // PHP coerces invalid PHP-variable chars in the base part of parse_str keys
 // (the bit before the first '[') to underscores: space, '.', '['. The chars
 // inside brackets are kept as-is.
-fn sanitizeParseStrKey(ctx: *NativeContext, name: []const u8) ![]const u8 {
+fn sanitizeParseStrKey(ctx: *NativeContext, name: []const u8) !Value.String {
     var needs_fix = false;
     for (name) |c| {
         if (c == ' ' or c == '.' or c == '[') {
@@ -5180,13 +5173,12 @@ fn sanitizeParseStrKey(ctx: *NativeContext, name: []const u8) ![]const u8 {
             break;
         }
     }
-    if (!needs_fix) return name;
+    if (!needs_fix) return Value.String.create(ctx.allocator, name);
     const buf = try ctx.allocator.alloc(u8, name.len);
     for (name, 0..) |c, i| {
         buf[i] = if (c == ' ' or c == '.' or c == '[') '_' else c;
     }
-    try ctx.strings.append(ctx.allocator, buf);
-    return buf;
+    return Value.String.adopt(ctx.allocator, buf);
 }
 
 fn insertParsedKey(ctx: *NativeContext, root: *PhpArray, key: []const u8, value: Value) !void {
@@ -5196,8 +5188,9 @@ fn insertParsedKey(ctx: *NativeContext, root: *PhpArray, key: []const u8, value:
     // PHP drops keys with empty base name when bracket segments follow (e.g. "[a]=1")
     if (raw_base.len == 0 and open != null) return;
     const base_name = try sanitizeParseStrKey(ctx, raw_base);
+    defer base_name.release();
     if (open == null) {
-        try root.set(ctx.allocator, .{ .string = Value.String.borrowed(base_name) }, value);
+        try setParsedEntry(ctx, root, .{ .string = base_name }, value);
         return;
     }
     var segments: [16][]const u8 = undefined;
@@ -5211,7 +5204,7 @@ fn insertParsedKey(ctx: *NativeContext, root: *PhpArray, key: []const u8, value:
         pos = close + 1;
     }
 
-    const base_key: PhpArray.Key = .{ .string = Value.String.borrowed(base_name) };
+    const base_key: PhpArray.Key = .{ .string = base_name };
     var current_arr: *PhpArray = root;
     var current_key: PhpArray.Key = base_key;
     var i: usize = 0;
@@ -5219,10 +5212,8 @@ fn insertParsedKey(ctx: *NativeContext, root: *PhpArray, key: []const u8, value:
         const cur_v = current_arr.get(current_key);
         const next_arr: *PhpArray = blk: {
             if (cur_v == .array) break :blk cur_v.array;
-            const new_a = try ctx.allocator.create(PhpArray);
-            new_a.* = .{};
-            try ctx.vm.arrays.append(ctx.allocator, new_a);
-            try current_arr.set(ctx.allocator, current_key, .{ .array = new_a });
+            const new_a = try ctx.createArray();
+            try setParsedEntry(ctx, current_arr, current_key, .{ .array = new_a });
             break :blk new_a;
         };
         const seg = segments[i];
@@ -5244,11 +5235,11 @@ fn insertParsedKey(ctx: *NativeContext, root: *PhpArray, key: []const u8, value:
             }
         }
     }
-    try current_arr.set(ctx.allocator, current_key, value);
+    try setParsedEntry(ctx, current_arr, current_key, value);
 }
 
-fn native_addcslashes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return if (args.len >= 1) args[0] else Value.null;
+fn native_addcslashes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return if (args.len >= 1) NativeResult.share(args[0]) else NativeResult.scalar(.null);
     const s = args[0].string.bytes();
     const charset = args[1].string.bytes();
     // expand "a..z" ranges
@@ -5298,12 +5289,11 @@ fn native_addcslashes(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_stripcslashes(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn native_stripcslashes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const s = args[0].string.bytes();
     var buf = std.ArrayListUnmanaged(u8){};
     errdefer buf.deinit(ctx.allocator);
@@ -5355,47 +5345,46 @@ fn native_stripcslashes(ctx: *NativeContext, args: []const Value) RuntimeError!V
         }
     }
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_strrchr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_strrchr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
-    if (needle.len == 0) return .{ .bool = false };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = false });
     const c = needle[0];
     if (std.mem.lastIndexOfScalar(u8, haystack, c)) |pos| {
         const before = args.len >= 3 and args[2].isTruthy();
-        if (before) return .{ .string = Value.String.borrowed(try ctx.createString(haystack[0..pos])) };
-        return .{ .string = Value.String.borrowed(try ctx.createString(haystack[pos..])) };
+        if (before) return NativeResult.copyString(ctx.allocator, haystack[0..pos]);
+        return NativeResult.copyString(ctx.allocator, haystack[pos..]);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_strstr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return Value{ .bool = false };
-    const haystack = if (args[0] == .string) args[0].string.bytes() else return Value{ .bool = false };
-    const needle = if (args[1] == .string) args[1].string.bytes() else return Value{ .bool = false };
-    if (needle.len == 0) return Value{ .bool = false };
+fn native_strstr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(Value{ .bool = false });
+    const haystack = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
+    const needle = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
+    if (needle.len == 0) return NativeResult.scalar(Value{ .bool = false });
 
     const before_needle: bool = args.len >= 3 and args[2].isTruthy();
 
     if (std.mem.indexOf(u8, haystack, needle)) |pos| {
         if (before_needle) {
-            return .{ .string = Value.String.borrowed(try ctx.createString(haystack[0..pos])) };
+            return NativeResult.copyString(ctx.allocator, haystack[0..pos]);
         }
-        return .{ .string = Value.String.borrowed(try ctx.createString(haystack[pos..])) };
+        return NativeResult.copyString(ctx.allocator, haystack[pos..]);
     }
-    return Value{ .bool = false };
+    return NativeResult.scalar(Value{ .bool = false });
 }
 
-fn native_strtok(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_strtok(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const tokens: []const u8 = blk: {
         if (args.len >= 2) {
             // strtok(str, tokens) - reset state with a new string
-            if (args[0] != .string or args[1] != .string) return Value{ .bool = false };
+            if (args[0] != .string or args[1] != .string) return NativeResult.scalar(Value{ .bool = false });
             const owned = try ctx.allocator.dupe(u8, args[0].string.bytes());
             try ctx.strings.append(ctx.allocator, owned);
             ctx.vm.strtok_state = owned;
@@ -5403,29 +5392,29 @@ fn native_strtok(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             break :blk args[1].string.bytes();
         }
         // strtok(tokens) - continue with prior string
-        if (args[0] != .string) return Value{ .bool = false };
+        if (args[0] != .string) return NativeResult.scalar(Value{ .bool = false });
         break :blk args[0].string.bytes();
     };
-    const s = ctx.vm.strtok_state orelse return .{ .bool = false };
+    const s = ctx.vm.strtok_state orelse return NativeResult.scalar(.{ .bool = false });
     var p = ctx.vm.strtok_pos;
     // skip leading delimiters
     while (p < s.len and std.mem.indexOfScalar(u8, tokens, s[p]) != null) : (p += 1) {}
     if (p >= s.len) {
         ctx.vm.strtok_pos = s.len;
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     const start = p;
     while (p < s.len and std.mem.indexOfScalar(u8, tokens, s[p]) == null) : (p += 1) {}
     // advance past the delimiter so the next call doesn't re-consider it
     ctx.vm.strtok_pos = if (p < s.len) p + 1 else p;
-    return .{ .string = Value.String.borrowed(try ctx.createString(s[start..p])) };
+    return NativeResult.copyString(ctx.allocator, s[start..p]);
 }
 
-fn native_stristr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return Value{ .bool = false };
-    const haystack = if (args[0] == .string) args[0].string.bytes() else return Value{ .bool = false };
-    const needle = if (args[1] == .string) args[1].string.bytes() else return Value{ .bool = false };
-    if (needle.len == 0) return Value{ .bool = false };
+fn native_stristr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(Value{ .bool = false });
+    const haystack = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
+    const needle = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(Value{ .bool = false });
+    if (needle.len == 0) return NativeResult.scalar(Value{ .bool = false });
     const before_needle: bool = args.len >= 3 and args[2].isTruthy();
 
     const lower_h = try toLowerBuf(ctx.allocator, haystack);
@@ -5434,14 +5423,14 @@ fn native_stristr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     defer ctx.allocator.free(lower_n);
     if (std.mem.indexOf(u8, lower_h, lower_n)) |pos| {
         // return the original-case substring
-        if (before_needle) return .{ .string = Value.String.borrowed(try ctx.createString(haystack[0..pos])) };
-        return .{ .string = Value.String.borrowed(try ctx.createString(haystack[pos..])) };
+        if (before_needle) return NativeResult.copyString(ctx.allocator, haystack[0..pos]);
+        return NativeResult.copyString(ctx.allocator, haystack[pos..]);
     }
-    return Value{ .bool = false };
+    return NativeResult.scalar(Value{ .bool = false });
 }
 
-fn native_strtr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .null;
+fn native_strtr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.null);
     const str = args[0].string.bytes();
 
     if (args.len >= 3 and args[1] == .string and args[2] == .string) {
@@ -5449,7 +5438,6 @@ fn native_strtr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const to = args[2].string.bytes();
         const len = @min(from.len, to.len);
         const buf = try ctx.allocator.alloc(u8, str.len);
-        try ctx.strings.append(ctx.allocator, buf);
         for (str, 0..) |c, i| {
             var replaced = false;
             for (0..len) |j| {
@@ -5461,27 +5449,29 @@ fn native_strtr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             }
             if (!replaced) buf[i] = c;
         }
-        return .{ .string = Value.String.borrowed(buf) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf));
     }
 
     if (args[1] == .array) {
         const replacements = args[1].array;
-        // result is grown via realloc below; registering it for cleanup here
-        // would leave a stale (realloc-freed) pointer in ctx.strings and
-        // double-free at request end. register the final pointer after the loop
         var result = try ctx.allocator.alloc(u8, str.len * 4);
+        defer ctx.allocator.free(result);
         var out_len: usize = 0;
         var i: usize = 0;
         while (i < str.len) {
             // pick the longest matching key at the current position
             var best_search: []const u8 = &.{};
             var best_repl: []const u8 = &.{};
+            var temporary: ?[]const u8 = null;
+            defer if (temporary) |bytes| ctx.allocator.free(bytes);
             for (replacements.entries.items) |entry| {
                 if (entry.key != .string) continue;
                 const search = entry.key.string.bytes();
                 if (search.len == 0) continue;
                 if (search.len <= best_search.len) continue;
                 if (i + search.len <= str.len and std.mem.eql(u8, str[i .. i + search.len], search)) {
+                    if (temporary) |bytes| ctx.allocator.free(bytes);
+                    temporary = null;
                     best_search = search;
                     // PHP coerces non-string replacement values to their string
                     // form, so int/float/bool entries substitute correctly
@@ -5494,7 +5484,7 @@ fn native_strtr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                         else => "",
                     };
                     if (entry.value == .int or entry.value == .float) {
-                        try ctx.strings.append(ctx.allocator, best_repl);
+                        temporary = best_repl;
                     }
                 }
             }
@@ -5516,17 +5506,16 @@ fn native_strtr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 i += 1;
             }
         }
-        try ctx.strings.append(ctx.allocator, result);
-        return .{ .string = Value.String.borrowed(result[0..out_len]) };
+        return NativeResult.copyString(ctx.allocator, result[0..out_len]);
     }
 
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_vsprintf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .string = Value.String.borrowed("") };
-    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return Value{ .string = Value.String.borrowed("") };
-    if (args[1] != .array) return .{ .string = Value.String.borrowed("") };
+fn native_vsprintf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.literal("");
+    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return NativeResult.literal("");
+    if (args[1] != .array) return NativeResult.literal("");
 
     // convert array values to a slice for sprintfImpl
     const arr = args[1].array;
@@ -5537,21 +5526,22 @@ fn native_vsprintf(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     }
     if (try vsprintfArgsTooFew(ctx, fmt_str, vals.len)) return error.RuntimeError;
     const result = try sprintfImpl(ctx, fmt_str, vals);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(result);
 }
 
-fn native_vprintf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
-    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return Value{ .int = 0 };
-    if (args[1] != .array) return .{ .int = 0 };
+fn native_vprintf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
+    const fmt_str = if (args[0] == .string) args[0].string.bytes() else return NativeResult.scalar(Value{ .int = 0 });
+    if (args[1] != .array) return NativeResult.scalar(.{ .int = 0 });
     const arr = args[1].array;
     var vals = try ctx.allocator.alloc(Value, arr.entries.items.len);
     defer ctx.allocator.free(vals);
     for (arr.entries.items, 0..) |entry, i| vals[i] = entry.value;
     if (try vsprintfArgsTooFew(ctx, fmt_str, vals.len)) return error.RuntimeError;
     const result = try sprintfImpl(ctx, fmt_str, vals);
-    try ctx.vm.output.appendSlice(ctx.allocator, result);
-    return .{ .int = @intCast(result.len) };
+    defer result.release();
+    try ctx.vm.output.appendSlice(ctx.allocator, result.bytes());
+    return NativeResult.scalar(.{ .int = @intCast(result.bytes().len) });
 }
 
 // PHP throws ValueError when vsprintf/vprintf is handed an args array
@@ -5598,12 +5588,14 @@ fn vsprintfArgsTooFew(ctx: *NativeContext, fmt: []const u8, argc: usize) Runtime
     return false;
 }
 
-fn native_fscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object) return .null;
+fn native_fscanf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.null);
     // read one line via fgets
     const line = try ctx.vm.callByName("fgets", &.{args[0]});
-    if (line == .bool and !line.bool) return .{ .bool = false };
-    if (line != .string) return .null;
+    if (line == .bool and !line.bool) return NativeResult.scalar(.{ .bool = false });
+    if (line != .string) return NativeResult.scalar(.null);
+    line.string.retain();
+    defer line.string.release();
     // delegate to sscanf with the line as input
     var sscanf_args = std.ArrayListUnmanaged(Value){};
     defer sscanf_args.deinit(ctx.allocator);
@@ -5612,13 +5604,16 @@ fn native_fscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return native_sscanf(ctx, sscanf_args.items);
 }
 
-fn native_sscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .null;
+fn native_sscanf(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
     const input = args[0].string.bytes();
     const fmt = args[1].string.bytes();
 
     var captures = std.ArrayListUnmanaged(Value){};
-    defer captures.deinit(ctx.allocator);
+    defer {
+        for (captures.items) |value| if (value == .string) value.string.release();
+        captures.deinit(ctx.allocator);
+    }
     var ip: usize = 0;
     var fp: usize = 0;
     while (fp < fmt.len) {
@@ -5688,16 +5683,18 @@ fn native_sscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     ip += 1;
                 }
                 const s = try ctx.allocator.dupe(u8, input[start..ip]);
-                try ctx.strings.append(ctx.allocator, s);
-                try captures.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+                const owned = try Value.String.adopt(ctx.allocator, s);
+                errdefer owned.release();
+                try captures.append(ctx.allocator, .{ .string = owned });
             },
             'c' => {
                 const want: usize = if (has_width) width else 1;
                 const end = @min(ip + want, input.len);
                 const s = try ctx.allocator.dupe(u8, input[ip..end]);
-                try ctx.strings.append(ctx.allocator, s);
+                const owned = try Value.String.adopt(ctx.allocator, s);
+                errdefer owned.release();
                 ip = end;
-                try captures.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+                try captures.append(ctx.allocator, .{ .string = owned });
             },
             'x', 'X' => {
                 // optional 0x / 0X prefix
@@ -5736,8 +5733,9 @@ fn native_sscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 } else {
                     const u_val: u64 = @bitCast(i_val);
                     const s = try std.fmt.allocPrint(ctx.allocator, "{d}", .{u_val});
-                    try ctx.vm.strings.append(ctx.allocator, s);
-                    try captures.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+                    const owned = try Value.String.adopt(ctx.allocator, s);
+                    errdefer owned.release();
+                    try captures.append(ctx.allocator, .{ .string = owned });
                 }
             },
             'n' => {
@@ -5786,8 +5784,9 @@ fn native_sscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                     continue;
                 }
                 const s = try ctx.allocator.dupe(u8, input[start..ip]);
-                try ctx.strings.append(ctx.allocator, s);
-                try captures.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+                const owned = try Value.String.adopt(ctx.allocator, s);
+                errdefer owned.release();
+                try captures.append(ctx.allocator, .{ .string = owned });
             },
             else => {
                 const msg = try std.fmt.allocPrint(ctx.allocator, "Bad scan conversion character \"{c}\"", .{spec});
@@ -5806,11 +5805,11 @@ fn native_sscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             if (2 + i >= args.len) break;
             ctx.setCallerVar(2 + i, args.len, v);
         }
-        return .{ .int = matched_count };
+        return NativeResult.scalar(.{ .int = matched_count });
     }
 
     // PHP returns null in array mode only when the input was empty
-    if (matched_count == 0 and input.len == 0) return .null;
+    if (matched_count == 0 and input.len == 0) return NativeResult.scalar(.null);
 
     // array-return mode: pad with null up to the total number of capturing specs
     var total_specs: usize = 0;
@@ -5844,17 +5843,17 @@ fn native_sscanf(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     var arr = try ctx.createArray();
     for (captures.items) |v| try arr.append(ctx.allocator, v);
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_levenshtein(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .int = -1 };
+fn native_levenshtein(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .int = -1 });
     const s1 = args[0].string.bytes();
     const s2 = args[1].string.bytes();
 
     // PHP 8 lifted the historical 255-char cap; computes regardless of length.
-    if (s1.len == 0) return .{ .int = @intCast(s2.len) };
-    if (s2.len == 0) return .{ .int = @intCast(s1.len) };
+    if (s1.len == 0) return NativeResult.scalar(.{ .int = @intCast(s2.len) });
+    if (s2.len == 0) return NativeResult.scalar(.{ .int = @intCast(s1.len) });
 
     const cost_ins: i64 = if (args.len >= 3) Value.toInt(args[2]) else 1;
     const cost_rep: i64 = if (args.len >= 4) Value.toInt(args[3]) else 1;
@@ -5887,7 +5886,7 @@ fn native_levenshtein(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     }
 
     _ = rows;
-    return .{ .int = prev[s2.len] };
+    return NativeResult.scalar(.{ .int = prev[s2.len] });
 }
 
 fn similarTextImpl(s1: []const u8, s2: []const u8, longest: *i64) void {
@@ -5920,8 +5919,8 @@ fn similarTextImpl(s1: []const u8, s2: []const u8, longest: *i64) void {
     }
 }
 
-fn native_similar_text(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .int = 0 };
+fn native_similar_text(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .int = 0 });
     const s1 = args[0].string.bytes();
     const s2 = args[1].string.bytes();
 
@@ -5934,13 +5933,13 @@ fn native_similar_text(ctx: *NativeContext, args: []const Value) RuntimeError!Va
         ctx.setCallerVar(2, args.len, .{ .float = pct });
     }
 
-    return .{ .int = matching };
+    return NativeResult.scalar(.{ .int = matching });
 }
 
-fn native_soundex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_soundex(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const input = args[0].string.bytes();
-    if (input.len == 0) return .{ .string = Value.String.borrowed("0000") };
+    if (input.len == 0) return NativeResult.literal("0000");
 
     const correct_table = [26]u8{
         '0', '1', '2', '3', '0', '1', '2', '0', '0', '2', '2', '4', '5',
@@ -5956,7 +5955,7 @@ fn native_soundex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             break;
         }
     }
-    if (first == 0) return .{ .string = Value.String.borrowed("") };
+    if (first == 0) return NativeResult.literal("");
 
     var result_buf: [4]u8 = .{ first, '0', '0', '0' };
     var pos: usize = 1;
@@ -5976,17 +5975,17 @@ fn native_soundex(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     const result = try ctx.allocator.alloc(u8, 4);
     @memcpy(result, &result_buf);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_metaphone(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_metaphone(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const input = args[0].string.bytes();
     const max_phonemes: usize = if (args.len >= 2) @intCast(@max(Value.toInt(args[1]), 0)) else 32;
-    if (input.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (input.len == 0) return NativeResult.literal("");
 
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     var upper = try ctx.allocator.alloc(u8, input.len);
     defer ctx.allocator.free(upper);
     for (input, 0..) |c, i| upper[i] = std.ascii.toUpper(c);
@@ -6196,12 +6195,11 @@ fn native_metaphone(ctx: *NativeContext, args: []const Value) RuntimeError!Value
     }
 
     const result = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, result);
-    return .{ .string = Value.String.borrowed(result) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
 }
 
-fn native_count_chars(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .null;
+fn native_count_chars(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.null);
     const s = args[0].string.bytes();
     const mode: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
 
@@ -6210,22 +6208,22 @@ fn native_count_chars(ctx: *NativeContext, args: []const Value) RuntimeError!Val
 
     if (mode == 3) {
         var buf2 = std.ArrayListUnmanaged(u8){};
+        defer buf2.deinit(ctx.allocator);
         for (0..256) |i| {
             if (freq[i] > 0) try buf2.append(ctx.allocator, @intCast(i));
         }
         const r = try buf2.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, r);
-        return .{ .string = Value.String.borrowed(r) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, r));
     }
 
     if (mode == 4) {
         var buf2 = std.ArrayListUnmanaged(u8){};
+        defer buf2.deinit(ctx.allocator);
         for (0..256) |i| {
             if (freq[i] == 0) try buf2.append(ctx.allocator, @intCast(i));
         }
         const r = try buf2.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, r);
-        return .{ .string = Value.String.borrowed(r) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, r));
     }
 
     var arr = try ctx.createArray();
@@ -6240,11 +6238,11 @@ fn native_count_chars(ctx: *NativeContext, args: []const Value) RuntimeError!Val
             try arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .int = freq[i] });
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_str_increment(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_str_increment(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     // PHP 8.3+ rejects empty strings and strings containing non-alphanumeric
     // bytes with ValueError
@@ -6303,17 +6301,16 @@ fn native_str_increment(ctx: *NativeContext, args: []const Value) RuntimeError!V
         } else {
             buf3[0] = '1';
         }
-        try ctx.strings.append(ctx.allocator, buf3);
-        return .{ .string = Value.String.borrowed(buf3) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, buf3));
     }
 
-    const r2 = buf3[1..];
-    try ctx.strings.append(ctx.allocator, buf3);
-    return .{ .string = Value.String.borrowed(r2) };
+    const owned = try Value.String.adopt(ctx.allocator, buf3);
+    defer owned.release();
+    return NativeResult.shareString(owned.borrowedSlice(1, buf3.len));
 }
 
-fn native_str_decrement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_str_decrement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     if (s.len == 0) {
         try ctx.vm.setPendingException("ValueError", "str_decrement(): Argument #1 ($string) cannot be empty");
@@ -6327,7 +6324,7 @@ fn native_str_decrement(ctx: *NativeContext, args: []const Value) RuntimeError!V
     }
 
     if (s.len == 1) {
-        if (s[0] == 'a' or s[0] == 'A' or s[0] == '0') return .{ .string = Value.String.borrowed(s) };
+        if (s[0] == 'a' or s[0] == 'A' or s[0] == '0') return NativeResult.share(args[0]);
     }
 
     var buf3 = try ctx.allocator.alloc(u8, s.len);
@@ -6368,13 +6365,13 @@ fn native_str_decrement(ctx: *NativeContext, args: []const Value) RuntimeError!V
     var start: usize = 0;
     if (borrow and buf3.len > 1) start = 1;
 
-    const r2 = buf3[start..];
-    try ctx.strings.append(ctx.allocator, buf3);
-    return .{ .string = Value.String.borrowed(r2) };
+    const owned = try Value.String.adopt(ctx.allocator, buf3);
+    defer owned.release();
+    return NativeResult.shareString(owned.borrowedSlice(start, buf3.len));
 }
 
-fn native_substr_compare(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_substr_compare(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
     var offset: i64 = Value.toInt(args[2]);
@@ -6389,7 +6386,7 @@ fn native_substr_compare(_: *NativeContext, args: []const Value) RuntimeError!Va
         if (offset < 0) offset = 0;
     }
     const off: usize = @intCast(offset);
-    if (off > haystack.len) return .{ .bool = false };
+    if (off > haystack.len) return NativeResult.scalar(.{ .bool = false });
 
     const hay_sub = haystack[off..];
     const hay_len = if (length) |l| @min(l, hay_sub.len) else hay_sub.len;
@@ -6404,13 +6401,13 @@ fn native_substr_compare(_: *NativeContext, args: []const Value) RuntimeError!Va
             a = std.ascii.toLower(a);
             b = std.ascii.toLower(b);
         }
-        if (a < b) return .{ .int = -1 };
-        if (a > b) return .{ .int = 1 };
+        if (a < b) return NativeResult.scalar(.{ .int = -1 });
+        if (a > b) return NativeResult.scalar(.{ .int = 1 });
     }
 
-    if (hay_len < ndl_len) return .{ .int = -1 };
-    if (hay_len > ndl_len) return .{ .int = 1 };
-    return .{ .int = 0 };
+    if (hay_len < ndl_len) return NativeResult.scalar(.{ .int = -1 });
+    if (hay_len > ndl_len) return NativeResult.scalar(.{ .int = 1 });
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
 fn spanResolveRange(slen: i64, args: []const Value) struct { start: usize, end: usize } {
@@ -6425,22 +6422,22 @@ fn spanResolveRange(slen: i64, args: []const Value) struct { start: usize, end: 
     return .{ .start = @intCast(s_off), .end = @intCast(end_i) };
 }
 
-fn native_strcspn(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .int = 0 };
+fn native_strcspn(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .int = 0 });
     const s = args[0].string.bytes();
     const chars = args[1].string.bytes();
     const r = spanResolveRange(@intCast(s.len), args);
 
     for (r.start..r.end) |i| {
         for (chars) |c| {
-            if (s[i] == c) return .{ .int = @intCast(i - r.start) };
+            if (s[i] == c) return NativeResult.scalar(.{ .int = @intCast(i - r.start) });
         }
     }
-    return .{ .int = @intCast(r.end - r.start) };
+    return NativeResult.scalar(.{ .int = @intCast(r.end - r.start) });
 }
 
-fn native_strspn(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .int = 0 };
+fn native_strspn(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .int = 0 });
     const s = args[0].string.bytes();
     const chars = args[1].string.bytes();
     const r = spanResolveRange(@intCast(s.len), args);
@@ -6453,34 +6450,33 @@ fn native_strspn(_: *NativeContext, args: []const Value) RuntimeError!Value {
                 break;
             }
         }
-        if (!found) return .{ .int = @intCast(i - r.start) };
+        if (!found) return NativeResult.scalar(.{ .int = @intCast(i - r.start) });
     }
-    return .{ .int = @intCast(r.end - r.start) };
+    return NativeResult.scalar(.{ .int = @intCast(r.end - r.start) });
 }
 
-fn native_strpbrk(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_strpbrk(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const s = args[0].string.bytes();
     const chars = args[1].string.bytes();
     for (s, 0..) |ch, i| {
         for (chars) |c| {
             if (ch == c) {
                 const result = try ctx.allocator.dupe(u8, s[i..]);
-                try ctx.vm.strings.append(ctx.allocator, result);
-                return .{ .string = Value.String.borrowed(result) };
+                return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result));
             }
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 // case-insensitive last-occurrence variant of mb_strstr - mirrors mb_strrchr
 // but folds case on both sides. only the first character of $needle is used
-fn native_mb_strrichr(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_mb_strrichr(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const haystack = args[0].string.bytes();
     const needle = args[1].string.bytes();
-    if (needle.len == 0) return .{ .bool = false };
+    if (needle.len == 0) return NativeResult.scalar(.{ .bool = false });
     const before: bool = if (args.len >= 3) Value.isTruthy(args[2]) else false;
     const n_first = lowerCpUtf8(needle, 0);
     var last: ?usize = null;
@@ -6492,16 +6488,16 @@ fn native_mb_strrichr(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     }
     if (last) |pos| {
         const slice = if (before) haystack[0..pos] else haystack[pos..];
-        return .{ .string = Value.String.borrowed(try ctx.createString(slice)) };
+        return NativeResult.copyString(ctx.allocator, slice);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 // replace invalid UTF-8 byte sequences with the substitute character. PHP's
 // default substitute is `?` (0x3F) - one `?` per invalid byte, not per
 // invalid sequence
-fn native_mb_scrub(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_mb_scrub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     var buf = std.ArrayListUnmanaged(u8){};
     defer buf.deinit(ctx.allocator);
@@ -6531,50 +6527,48 @@ fn native_mb_scrub(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         try buf.appendSlice(ctx.allocator, s[i .. i + len]);
         i += len;
     }
-    const out = try ctx.allocator.dupe(u8, buf.items);
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator)));
 }
 
 // CLI always returns false (no HTTP input encoding context). when called with
 // a setter arg, PHP returns true on success
-fn native_mb_http_input(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len >= 1) return .{ .bool = false };
-    return .{ .bool = false };
+fn native_mb_http_input(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len >= 1) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 // default HTTP output encoding. setter returns true; getter returns "UTF-8"
-fn native_mb_http_output(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len >= 1 and args[0] == .string) return .{ .bool = true };
-    return .{ .string = Value.String.borrowed("UTF-8") };
+fn native_mb_http_output(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len >= 1 and args[0] == .string) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.literal("UTF-8");
 }
 
 // default language. setter accepts neutral/uni/japanese/english/german/etc.
 // we don't differentiate behavior - getter always returns "neutral"
-fn native_mb_language(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len >= 1 and args[0] == .string) return .{ .bool = true };
-    return .{ .string = Value.String.borrowed("neutral") };
+fn native_mb_language(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len >= 1 and args[0] == .string) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.literal("neutral");
 }
 
 // map an internal encoding name to its MIME charset label
-fn native_mb_preferred_mime_name(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_mb_preferred_mime_name(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const enc = args[0].string.bytes();
     var lo: [32]u8 = undefined;
     const cap = @min(enc.len, lo.len);
     for (enc[0..cap], 0..) |c, i| lo[i] = std.ascii.toLower(c);
     const l = lo[0..cap];
-    if (std.mem.eql(u8, l, "utf-8") or std.mem.eql(u8, l, "utf8")) return .{ .string = Value.String.borrowed("UTF-8") };
-    if (std.mem.eql(u8, l, "ascii") or std.mem.eql(u8, l, "us-ascii")) return .{ .string = Value.String.borrowed("US-ASCII") };
-    if (std.mem.eql(u8, l, "iso-8859-1") or std.mem.eql(u8, l, "iso8859-1") or std.mem.eql(u8, l, "latin1")) return .{ .string = Value.String.borrowed("ISO-8859-1") };
-    if (std.mem.eql(u8, l, "iso-8859-15")) return .{ .string = Value.String.borrowed("ISO-8859-15") };
-    if (std.mem.eql(u8, l, "sjis") or std.mem.eql(u8, l, "shift_jis") or std.mem.eql(u8, l, "shift-jis")) return .{ .string = Value.String.borrowed("Shift_JIS") };
-    if (std.mem.eql(u8, l, "euc-jp") or std.mem.eql(u8, l, "eucjp")) return .{ .string = Value.String.borrowed("EUC-JP") };
-    if (std.mem.eql(u8, l, "iso-2022-jp")) return .{ .string = Value.String.borrowed("ISO-2022-JP") };
-    if (std.mem.eql(u8, l, "utf-16")) return .{ .string = Value.String.borrowed("UTF-16") };
-    if (std.mem.eql(u8, l, "utf-16be")) return .{ .string = Value.String.borrowed("UTF-16BE") };
-    if (std.mem.eql(u8, l, "utf-16le")) return .{ .string = Value.String.borrowed("UTF-16LE") };
-    if (std.mem.eql(u8, l, "utf-32")) return .{ .string = Value.String.borrowed("UTF-32") };
+    if (std.mem.eql(u8, l, "utf-8") or std.mem.eql(u8, l, "utf8")) return NativeResult.literal("UTF-8");
+    if (std.mem.eql(u8, l, "ascii") or std.mem.eql(u8, l, "us-ascii")) return NativeResult.literal("US-ASCII");
+    if (std.mem.eql(u8, l, "iso-8859-1") or std.mem.eql(u8, l, "iso8859-1") or std.mem.eql(u8, l, "latin1")) return NativeResult.literal("ISO-8859-1");
+    if (std.mem.eql(u8, l, "iso-8859-15")) return NativeResult.literal("ISO-8859-15");
+    if (std.mem.eql(u8, l, "sjis") or std.mem.eql(u8, l, "shift_jis") or std.mem.eql(u8, l, "shift-jis")) return NativeResult.literal("Shift_JIS");
+    if (std.mem.eql(u8, l, "euc-jp") or std.mem.eql(u8, l, "eucjp")) return NativeResult.literal("EUC-JP");
+    if (std.mem.eql(u8, l, "iso-2022-jp")) return NativeResult.literal("ISO-2022-JP");
+    if (std.mem.eql(u8, l, "utf-16")) return NativeResult.literal("UTF-16");
+    if (std.mem.eql(u8, l, "utf-16be")) return NativeResult.literal("UTF-16BE");
+    if (std.mem.eql(u8, l, "utf-16le")) return NativeResult.literal("UTF-16LE");
+    if (std.mem.eql(u8, l, "utf-32")) return NativeResult.literal("UTF-32");
     const msg = try std.fmt.allocPrint(ctx.allocator, "mb_preferred_mime_name(): Argument #1 ($encoding) must be a valid encoding, \"{s}\" given", .{enc});
     try ctx.vm.strings.append(ctx.allocator, msg);
     try ctx.vm.setPendingException("ValueError", msg);
@@ -6583,44 +6577,44 @@ fn native_mb_preferred_mime_name(ctx: *NativeContext, args: []const Value) Runti
 
 // detection order. getter returns ['ASCII', 'UTF-8']; setter (array or
 // comma-separated string) returns true
-fn native_mb_detect_order(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_mb_detect_order(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len >= 1) {
-        if (args[0] == .string or args[0] == .array) return .{ .bool = true };
-        return .{ .bool = false };
+        if (args[0] == .string or args[0] == .array) return NativeResult.scalar(.{ .bool = true });
+        return NativeResult.scalar(.{ .bool = false });
     }
     var arr = try ctx.createArray();
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("ASCII") });
     try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("UTF-8") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // PHP returns either the full info array, a specific key's value, or false
 // for an unknown key
-fn native_mb_get_info(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_mb_get_info(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const key: ?[]const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else null;
     if (key) |k| {
-        if (std.mem.eql(u8, k, "internal_encoding")) return .{ .string = Value.String.borrowed("UTF-8") };
-        if (std.mem.eql(u8, k, "http_input")) return .{ .string = Value.String.borrowed("UTF-8") };
-        if (std.mem.eql(u8, k, "http_output")) return .{ .string = Value.String.borrowed("UTF-8") };
-        if (std.mem.eql(u8, k, "http_output_conv_mimetypes")) return .{ .string = Value.String.borrowed("^(text/|application/xhtml\\+xml)") };
-        if (std.mem.eql(u8, k, "mail_charset")) return .{ .string = Value.String.borrowed("UTF-8") };
-        if (std.mem.eql(u8, k, "mail_header_encoding")) return .{ .string = Value.String.borrowed("BASE64") };
-        if (std.mem.eql(u8, k, "mail_body_encoding")) return .{ .string = Value.String.borrowed("BASE64") };
-        if (std.mem.eql(u8, k, "illegal_chars")) return .{ .int = 0 };
-        if (std.mem.eql(u8, k, "encoding_translation")) return .{ .string = Value.String.borrowed("Off") };
-        if (std.mem.eql(u8, k, "language")) return .{ .string = Value.String.borrowed("neutral") };
+        if (std.mem.eql(u8, k, "internal_encoding")) return NativeResult.literal("UTF-8");
+        if (std.mem.eql(u8, k, "http_input")) return NativeResult.literal("UTF-8");
+        if (std.mem.eql(u8, k, "http_output")) return NativeResult.literal("UTF-8");
+        if (std.mem.eql(u8, k, "http_output_conv_mimetypes")) return NativeResult.literal("^(text/|application/xhtml\\+xml)");
+        if (std.mem.eql(u8, k, "mail_charset")) return NativeResult.literal("UTF-8");
+        if (std.mem.eql(u8, k, "mail_header_encoding")) return NativeResult.literal("BASE64");
+        if (std.mem.eql(u8, k, "mail_body_encoding")) return NativeResult.literal("BASE64");
+        if (std.mem.eql(u8, k, "illegal_chars")) return NativeResult.scalar(.{ .int = 0 });
+        if (std.mem.eql(u8, k, "encoding_translation")) return NativeResult.literal("Off");
+        if (std.mem.eql(u8, k, "language")) return NativeResult.literal("neutral");
         if (std.mem.eql(u8, k, "detect_order")) {
             var arr = try ctx.createArray();
             try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("ASCII") });
             try arr.append(ctx.allocator, .{ .string = Value.String.borrowed("UTF-8") });
-            return .{ .array = arr };
+            return NativeResult.borrowed(.{ .array = arr });
         }
-        if (std.mem.eql(u8, k, "substitute_character")) return .{ .int = 63 };
-        if (std.mem.eql(u8, k, "strict_detection")) return .{ .string = Value.String.borrowed("Off") };
+        if (std.mem.eql(u8, k, "substitute_character")) return NativeResult.scalar(.{ .int = 63 });
+        if (std.mem.eql(u8, k, "strict_detection")) return NativeResult.literal("Off");
         if (std.mem.eql(u8, k, "all")) {} // fall through to full array
         else {
             ctx.vm.emitWarning("mb_get_info(): argument #1 ($type) must be a valid type");
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         }
     }
     var arr = try ctx.createArray();
@@ -6639,10 +6633,26 @@ fn native_mb_get_info(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("detect_order") }, .{ .array = order });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("substitute_character") }, .{ .int = 63 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("strict_detection") }, .{ .string = Value.String.borrowed("Off") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 // for UTF-8 input mb_parse_str is byte-identical to parse_str; delegate
-fn native_mb_parse_str(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_mb_parse_str(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return native_parse_str(ctx, args);
+}
+
+fn setParsedEntry(ctx: *NativeContext, array: *PhpArray, key: PhpArray.Key, value: Value) !void {
+    if (key == .string) {
+        const owned = try Value.String.create(ctx.allocator, key.string.bytes());
+        defer owned.release();
+        try ctx.vm.arraySetOwned(array, .{ .string = owned }, value);
+    } else {
+        try ctx.vm.arraySetOwned(array, key, value);
+    }
+}
+
+fn setUrlComponent(ctx: *NativeContext, array: *PhpArray, comptime name: []const u8, bytes: []const u8) !void {
+    const value = try Value.String.create(ctx.allocator, bytes);
+    defer value.release();
+    try array.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, .{ .string = value });
 }

--- a/src/stdlib/system.zig
+++ b/src/stdlib/system.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const VM = @import("../runtime/vm.zig").VM;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 
 pub const entries = .{
@@ -71,7 +72,7 @@ pub const entries = .{
     .{ "posix_strerror", native_posix_strerror },
 };
 
-fn native_getrusage(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_getrusage(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     // return zero-filled struct since std doesn't expose getrusage cleanly; matches "is_array" check
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("ru_utime.tv_sec") }, .{ .int = 0 });
@@ -85,35 +86,35 @@ fn native_getrusage(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("ru_oublock") }, .{ .int = 0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("ru_nvcsw") }, .{ .int = 0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("ru_nivcsw") }, .{ .int = 0 });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_getpid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(std.posix.system.getpid()) };
+fn native_posix_getpid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(std.posix.system.getpid()) });
 }
 
-fn native_posix_getlogin(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_posix_getlogin(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // try the LOGNAME / USER env vars first, then fall back to the passwd
     // entry for the effective uid via getpwuid. matches PHP's behavior of
     // returning false when neither path resolves
     if (std.posix.getenv("LOGNAME")) |s| {
-        if (s.len > 0) return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+        if (s.len > 0) return try NativeResult.copyString(ctx.allocator, s);
     }
     if (std.posix.getenv("USER")) |s| {
-        if (s.len > 0) return .{ .string = Value.String.borrowed(try ctx.createString(s)) };
+        if (s.len > 0) return try NativeResult.copyString(ctx.allocator, s);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 extern "c" fn getuid() std.c.uid_t;
 extern "c" fn getgid() std.c.gid_t;
 
-fn native_posix_getuid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(getuid()) };
+fn native_posix_getuid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(getuid()) });
 }
 
-fn native_posix_getgid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(getgid()) };
+fn native_posix_getgid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(getgid()) });
 }
 
 extern "c" fn getppid() std.c.pid_t;
@@ -150,38 +151,37 @@ extern "c" fn setrlimit(resource: c_int, rlim: *const Rlimit) c_int;
 // since most syscalls below don't reach back into thread-local errno
 var last_posix_errno: c_int = 0;
 
-fn native_posix_getppid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(getppid()) };
+fn native_posix_getppid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(getppid()) });
 }
 
-fn native_posix_kill(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int or args[1] != .int) return .{ .bool = false };
+fn native_posix_kill(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const rc = kill(@intCast(args[0].int), @intCast(args[1].int));
     if (rc != 0) {
         last_posix_errno = std.c._errno().*;
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_posix_isatty(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
+fn native_posix_isatty(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     const fd: c_int = switch (args[0]) {
         .int => |i| @intCast(i),
         .object => 1, // PHP also accepts a stream resource - treat as stdout best-effort
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
-    return .{ .bool = isatty(fd) != 0 };
+    return NativeResult.scalar(.{ .bool = isatty(fd) != 0 });
 }
 
-fn native_posix_ttyname(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const name = ttyname(@intCast(args[0].int)) orelse return .{ .bool = false };
+fn native_posix_ttyname(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const name = ttyname(@intCast(args[0].int)) orelse return NativeResult.scalar(.{ .bool = false });
     var i: usize = 0;
     while (name[i] != 0) : (i += 1) {}
     const owned = try ctx.allocator.dupe(u8, name[0..i]);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
 fn cstrToStr(ctx: *NativeContext, p: ?[*:0]const u8) ![]const u8 {
@@ -194,9 +194,9 @@ fn cstrToStr(ctx: *NativeContext, p: ?[*:0]const u8) ![]const u8 {
     return owned;
 }
 
-fn native_posix_getpwuid(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const pw = getpwuid(@intCast(args[0].int)) orelse return .{ .bool = false };
+fn native_posix_getpwuid(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const pw = getpwuid(@intCast(args[0].int)) orelse return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, pw.pw_name)) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("passwd") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, pw.pw_passwd)) });
@@ -205,28 +205,28 @@ fn native_posix_getpwuid(ctx: *NativeContext, args: []const Value) RuntimeError!
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("gecos") }, .{ .string = Value.String.borrowed("") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("dir") }, .{ .string = Value.String.borrowed("") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("shell") }, .{ .string = Value.String.borrowed("") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_getgrgid(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const g = getgrgid(@intCast(args[0].int)) orelse return .{ .bool = false };
+fn native_posix_getgrgid(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const g = getgrgid(@intCast(args[0].int)) orelse return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, g.gr_name)) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("passwd") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, g.gr_passwd)) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("gid") }, .{ .int = @intCast(g.gr_gid) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("members") }, .{ .array = try ctx.createArray() });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_getpwnam(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_posix_getpwnam(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name_buf = try ctx.allocator.alloc(u8, args[0].string.len + 1);
     @memcpy(name_buf[0..args[0].string.len], args[0].string.bytes());
     name_buf[args[0].string.len] = 0;
     try ctx.strings.append(ctx.allocator, name_buf);
     const name_z: [*:0]const u8 = @ptrCast(name_buf.ptr);
-    const pw = getpwnam(name_z) orelse return .{ .bool = false };
+    const pw = getpwnam(name_z) orelse return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, pw.pw_name)) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("passwd") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, pw.pw_passwd)) });
@@ -235,64 +235,64 @@ fn native_posix_getpwnam(ctx: *NativeContext, args: []const Value) RuntimeError!
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("gecos") }, .{ .string = Value.String.borrowed("") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("dir") }, .{ .string = Value.String.borrowed("") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("shell") }, .{ .string = Value.String.borrowed("") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_getgrnam(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_posix_getgrnam(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name_buf = try ctx.allocator.alloc(u8, args[0].string.len + 1);
     @memcpy(name_buf[0..args[0].string.len], args[0].string.bytes());
     name_buf[args[0].string.len] = 0;
     try ctx.strings.append(ctx.allocator, name_buf);
     const name_z: [*:0]const u8 = @ptrCast(name_buf.ptr);
-    const g = getgrnam(name_z) orelse return .{ .bool = false };
+    const g = getgrnam(name_z) orelse return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("name") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, g.gr_name)) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("passwd") }, .{ .string = Value.String.borrowed(try cstrToStr(ctx, g.gr_passwd)) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("gid") }, .{ .int = @intCast(g.gr_gid) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("members") }, .{ .array = try ctx.createArray() });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_getgroups(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_posix_getgroups(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var buf: [256]std.c.gid_t = undefined;
     const n = getgroups(@intCast(buf.len), &buf);
-    if (n < 0) return .{ .bool = false };
+    if (n < 0) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     var i: usize = 0;
     while (i < @as(usize, @intCast(n))) : (i += 1) {
         try arr.append(ctx.allocator, .{ .int = @intCast(buf[i]) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_setsid(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_posix_setsid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const r = setsid();
     if (r == -1) {
         last_posix_errno = std.c._errno().*;
-        return .{ .int = -1 };
+        return NativeResult.scalar(.{ .int = -1 });
     }
-    return .{ .int = @intCast(r) };
+    return NativeResult.scalar(.{ .int = @intCast(r) });
 }
 
-fn native_posix_setpgid(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .int or args[1] != .int) return .{ .bool = false };
+fn native_posix_setpgid(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .int or args[1] != .int) return NativeResult.scalar(.{ .bool = false });
     const rc = setpgid(@intCast(args[0].int), @intCast(args[1].int));
     if (rc != 0) {
         last_posix_errno = std.c._errno().*;
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_posix_getpgid(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
+fn native_posix_getpgid(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
     const r = getpgid(@intCast(args[0].int));
     if (r == -1) {
         last_posix_errno = std.c._errno().*;
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .int = @intCast(r) };
+    return NativeResult.scalar(.{ .int = @intCast(r) });
 }
 
 // PHP labels for posix_getrlimit. Index matches RLIMIT_* on Linux/macOS:
@@ -307,7 +307,7 @@ fn rlimitFromName(name: []const u8) ?c_int {
     return null;
 }
 
-fn native_posix_getrlimit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_posix_getrlimit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP returns an array of all rlimits by default, or just one when an int
     // resource id is passed
     const arr = try ctx.createArray();
@@ -325,22 +325,22 @@ fn native_posix_getrlimit(ctx: *NativeContext, args: []const Value) RuntimeError
         }
     }
     _ = args;
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_setrlimit(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3 or args[0] != .int) return .{ .bool = false };
+fn native_posix_setrlimit(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
     const soft: u64 = if (args[1] == .int) (if (args[1].int < 0) std.math.maxInt(u64) else @intCast(args[1].int)) else 0;
     const hard: u64 = if (args[2] == .int) (if (args[2].int < 0) std.math.maxInt(u64) else @intCast(args[2].int)) else 0;
     const rl = Rlimit{ .rlim_cur = soft, .rlim_max = hard };
     if (setrlimit(@intCast(args[0].int), &rl) != 0) {
         last_posix_errno = std.c._errno().*;
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_posix_uname(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_posix_uname(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // simple impl - php_uname-style fields. zphp doesn't link directly to
     // uname(2) but std.posix can produce host info
     const arr = try ctx.createArray();
@@ -349,27 +349,27 @@ fn native_posix_uname(ctx: *NativeContext, _: []const Value) RuntimeError!Value 
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("release") }, .{ .string = Value.String.borrowed("") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("version") }, .{ .string = Value.String.borrowed("") });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("machine") }, .{ .string = Value.String.borrowed("") });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_posix_get_last_error(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(last_posix_errno) };
+fn native_posix_get_last_error(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(last_posix_errno) });
 }
 
-fn native_posix_strerror(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .string = Value.String.borrowed("") };
-    const s = strerror(@intCast(args[0].int)) orelse return .{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try cstrToStr(ctx, s)) };
+fn native_posix_strerror(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.literal("");
+    const s = strerror(@intCast(args[0].int)) orelse return NativeResult.literal("");
+    return try NativeResult.copyString(ctx.allocator, std.mem.span(s));
 }
 
 // getopt(short, long?, &rest_index?) — PHP-style CLI option parser.
 // short is a string like "ab:c::" (a = no arg, b: = required, c:: = optional);
 // long is a list of strings with the same suffix convention. options stop at
 // the first non-option arg or at "--". returns assoc array of seen options.
-fn native_getopt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_getopt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const short: []const u8 = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else "";
-    const argv_val = ctx.vm.request_vars.get("$argv") orelse return .{ .array = try ctx.createArray() };
-    if (argv_val != .array) return .{ .array = try ctx.createArray() };
+    const argv_val = ctx.vm.request_vars.get("$argv") orelse return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    if (argv_val != .array) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const argv = argv_val.array;
 
     var shorts: std.StringHashMapUnmanaged(u8) = .{};
@@ -475,63 +475,63 @@ fn native_getopt(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
     }
     if (args.len >= 3) ctx.setCallerVar(2, args.len, .{ .int = @intCast(idx) });
-    return .{ .array = out };
+    return NativeResult.borrowed(.{ .array = out });
 }
 
-fn native_sleep(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn native_sleep(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
     const secs = Value.toInt(args[0]);
     if (secs > 0) std.Thread.sleep(@intCast(secs * 1_000_000_000));
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_usleep(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
+fn native_usleep(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     const usecs = Value.toInt(args[0]);
     if (usecs > 0) std.Thread.sleep(@intCast(usecs * 1_000));
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_time_nanosleep(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .bool = false };
+fn native_time_nanosleep(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const secs = Value.toInt(args[0]);
     const nsecs = Value.toInt(args[1]);
-    if (secs < 0 or nsecs < 0) return .{ .bool = false };
+    if (secs < 0 or nsecs < 0) return NativeResult.scalar(.{ .bool = false });
     const total_ns: u64 = @intCast(secs * 1_000_000_000 + nsecs);
     std.Thread.sleep(total_ns);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_time_sleep_until(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_time_sleep_until(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const target = Value.toFloat(args[0]);
     const now: f64 = @floatFromInt(std.time.timestamp());
-    if (target <= now) return .{ .bool = true };
+    if (target <= now) return NativeResult.scalar(.{ .bool = true });
     const delta_ns: u64 = @intFromFloat(@max(0, (target - now) * 1e9));
     std.Thread.sleep(delta_ns);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 extern fn getloadavg(loadavg: [*]f64, nelem: c_int) c_int;
 
-fn native_sys_getloadavg(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_sys_getloadavg(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var samples: [3]f64 = .{ 0, 0, 0 };
     const got = getloadavg(&samples, 3);
-    if (got < 0) return .{ .bool = false };
+    if (got < 0) return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
     var i: usize = 0;
     const count: usize = @intCast(got);
     while (i < count) : (i += 1) {
         try arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .float = samples[i] });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_getenv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_getenv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // no-arg form returns all environment vars as an associative array
     if (args.len == 0) {
         const arr = try ctx.createArray();
-        var em = std.process.getEnvMap(ctx.allocator) catch return .{ .array = arr };
+        var em = std.process.getEnvMap(ctx.allocator) catch return NativeResult.borrowed(.{ .array = arr });
         defer em.deinit();
         var it = em.iterator();
         while (it.next()) |e| {
@@ -541,38 +541,37 @@ fn native_getenv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try ctx.strings.append(ctx.allocator, v);
             try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(k) }, .{ .string = Value.String.borrowed(v) });
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
-    if (args[0] != .string) return .{ .bool = false };
-    const val = std.process.getEnvVarOwned(ctx.allocator, args[0].string.bytes()) catch return Value{ .bool = false };
-    try ctx.strings.append(ctx.allocator, val);
-    return .{ .string = Value.String.borrowed(val) };
+    if (args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const val = std.process.getEnvVarOwned(ctx.allocator, args[0].string.bytes()) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, val));
 }
 
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 
-fn native_putenv(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_putenv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const setting = args[0].string.bytes();
     if (std.mem.indexOfScalar(u8, setting, '=')) |eq| {
         const name = setting[0..eq];
         const val = setting[eq + 1 ..];
-        const name_z = ctx.allocator.dupeZ(u8, name) catch return Value{ .bool = false };
+        const name_z = ctx.allocator.dupeZ(u8, name) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(name_z);
-        const val_z = ctx.allocator.dupeZ(u8, val) catch return Value{ .bool = false };
+        const val_z = ctx.allocator.dupeZ(u8, val) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(val_z);
-        return .{ .bool = setenv(name_z.ptr, val_z.ptr, 1) == 0 };
+        return NativeResult.scalar(.{ .bool = setenv(name_z.ptr, val_z.ptr, 1) == 0 });
     } else {
-        const name_z = ctx.allocator.dupeZ(u8, setting) catch return Value{ .bool = false };
+        const name_z = ctx.allocator.dupeZ(u8, setting) catch return NativeResult.scalar(.{ .bool = false });
         defer ctx.allocator.free(name_z);
-        return .{ .bool = unsetenv(name_z.ptr) == 0 };
+        return NativeResult.scalar(.{ .bool = unsetenv(name_z.ptr) == 0 });
     }
 }
 
 threadlocal var previous_uniqid_microsecond: i128 = -1;
 
-fn native_uniqid(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_uniqid(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const prefix = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else "";
     const more_entropy = args.len >= 2 and args[1].isTruthy();
     var ns = std.time.nanoTimestamp();
@@ -583,115 +582,114 @@ fn native_uniqid(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const sec: u64 = @divTrunc(abs_ns, 1_000_000_000);
     var buf: [128]u8 = undefined;
     const hex = if (more_entropy)
-        std.fmt.bufPrint(&buf, "{s}{x:0>8}{x:0>5}.{d:0>8}", .{ prefix, sec, usec, std.crypto.random.intRangeAtMost(u32, 0, 99999999) }) catch return Value{ .string = Value.String.borrowed("") }
+        std.fmt.bufPrint(&buf, "{s}{x:0>8}{x:0>5}.{d:0>8}", .{ prefix, sec, usec, std.crypto.random.intRangeAtMost(u32, 0, 99999999) }) catch return NativeResult.literal("")
     else
-        std.fmt.bufPrint(&buf, "{s}{x:0>8}{x:0>5}", .{ prefix, sec, usec }) catch return Value{ .string = Value.String.borrowed("") };
-    return .{ .string = Value.String.borrowed(try ctx.createString(hex)) };
+        std.fmt.bufPrint(&buf, "{s}{x:0>8}{x:0>5}", .{ prefix, sec, usec }) catch return NativeResult.literal("");
+    return try NativeResult.copyString(ctx.allocator, hex);
 }
 
-fn native_getcwd(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_getcwd(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const cwd = std.fs.cwd().realpath(".", &buf) catch return Value{ .bool = false };
-    return .{ .string = Value.String.borrowed(try ctx.createString(cwd)) };
+    const cwd = std.fs.cwd().realpath(".", &buf) catch return NativeResult.scalar(.{ .bool = false });
+    return try NativeResult.copyString(ctx.allocator, cwd);
 }
 
-fn native_php_ini_loaded_file(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_php_ini_loaded_file(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // zphp doesn't read a php.ini file; report false to match PHP behavior
     // when no ini was loaded
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_php_ini_scanned_files(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_php_ini_scanned_files(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP returns false when no additional ini directory was scanned
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_dl(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_dl(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // dynamic loading: PHP's dl() is restricted in CGI/CLI in modern installs;
     // we don't support runtime extension loading, return false
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_phpinfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_phpinfo(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     _ = args;
     // minimal output: enough for callers to verify the function exists. real
     // PHP prints a giant HTML/text dump of the environment
     const out = try std.fmt.allocPrint(ctx.allocator, "PHP Version => 8.4.1\n", .{});
     try ctx.strings.append(ctx.allocator, out);
     try ctx.vm.output.appendSlice(ctx.allocator, out);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_phpcredits(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_phpcredits(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_getlastmod(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_getlastmod(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP returns the last modification time of the main script. zphp tracks
     // the running file path; stat it to produce a real mtime
     const path = ctx.vm.file_path;
-    if (path.len == 0) return .{ .bool = false };
-    const stat = std.fs.cwd().statFile(path) catch return .{ .bool = false };
-    return .{ .int = @intCast(@divTrunc(stat.mtime, std.time.ns_per_s)) };
+    if (path.len == 0) return NativeResult.scalar(.{ .bool = false });
+    const stat = std.fs.cwd().statFile(path) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .int = @intCast(@divTrunc(stat.mtime, std.time.ns_per_s)) });
 }
 
-fn native_cli_get_process_title(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_cli_get_process_title(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // not actually tracking the process title; PHP returns false when no title
     // was set explicitly via cli_set_process_title earlier in the run
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_cli_set_process_title(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_cli_set_process_title(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // best-effort no-op; the real prctl(PR_SET_NAME) syscall is linux-only and
     // the cosmetic effect rarely matters for scripts that defensively set it
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_php_strip_whitespace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_php_strip_whitespace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP's php_strip_whitespace runs the source through the tokenizer and
     // emits only the non-whitespace tokens; without a real tokenizer we return
     // the original source so callers that use the result still see valid PHP
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
-    const content = std.fs.cwd().readFileAlloc(ctx.allocator, args[0].string.bytes(), 1024 * 1024 * 64) catch return .{ .string = Value.String.borrowed("") };
-    try ctx.strings.append(ctx.allocator, content);
-    return .{ .string = Value.String.borrowed(content) };
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
+    const content = std.fs.cwd().readFileAlloc(ctx.allocator, args[0].string.bytes(), 1024 * 1024 * 64) catch return NativeResult.literal("");
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, content));
 }
 
-fn native_php_uname(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_php_uname(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const mode = if (args.len >= 1 and args[0] == .string and args[0].string.len > 0) args[0].string.bytes()[0] else 'a';
     const is_mac = @import("builtin").os.tag == .macos;
     const is_arm = @import("builtin").cpu.arch == .aarch64;
-    return .{ .string = Value.String.borrowed(switch (mode) {
+    return try NativeResult.copyString(ctx.allocator, switch (mode) {
         's' => if (is_mac) "Darwin" else "Linux",
         'n' => "localhost",
         'r' => "0.0.0",
         'm' => if (is_arm) "arm64" else "x86_64",
         else => if (is_mac) "Darwin localhost 0.0.0 arm64" else "Linux localhost 0.0.0 x86_64",
-    }) };
+    });
 }
 
-fn native_move_uploaded_file(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_move_uploaded_file(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const from = args[0].string.bytes();
     const to = args[1].string.bytes();
-    if (!std.mem.startsWith(u8, from, "/tmp/zphp_upload_")) return .{ .bool = false };
+    if (!std.mem.startsWith(u8, from, "/tmp/zphp_upload_")) return NativeResult.scalar(.{ .bool = false });
     std.fs.cwd().rename(from, to) catch {
-        const data = std.fs.cwd().readFileAlloc(std.heap.page_allocator, from, 1024 * 1024 * 64) catch return .{ .bool = false };
+        const data = std.fs.cwd().readFileAlloc(std.heap.page_allocator, from, 1024 * 1024 * 64) catch return NativeResult.scalar(.{ .bool = false });
         defer std.heap.page_allocator.free(data);
-        std.fs.cwd().writeFile(.{ .sub_path = to, .data = data }) catch return .{ .bool = false };
+        std.fs.cwd().writeFile(.{ .sub_path = to, .data = data }) catch return NativeResult.scalar(.{ .bool = false });
         std.fs.cwd().deleteFile(from) catch {};
     };
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_is_uploaded_file(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
-    if (!std.mem.startsWith(u8, args[0].string.bytes(), "/tmp/zphp_upload_")) return .{ .bool = false };
-    std.fs.cwd().access(args[0].string.bytes(), .{}) catch return .{ .bool = false };
-    return .{ .bool = true };
+fn native_is_uploaded_file(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    if (!std.mem.startsWith(u8, args[0].string.bytes(), "/tmp/zphp_upload_")) return NativeResult.scalar(.{ .bool = false });
+    std.fs.cwd().access(args[0].string.bytes(), .{}) catch return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_sys_get_temp_dir(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_sys_get_temp_dir(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // honor TMPDIR / TEMP / TMP env vars like PHP does, fall back to /tmp
     const env_keys = [_][]const u8{ "TMPDIR", "TEMP", "TMP" };
     for (env_keys) |k| {
@@ -699,14 +697,14 @@ fn native_sys_get_temp_dir(_: *NativeContext, _: []const Value) RuntimeError!Val
             if (v.len > 0) {
                 // strip a trailing slash to match PHP
                 const trimmed = if (v.len > 1 and v[v.len - 1] == '/') v[0 .. v.len - 1] else v;
-                return .{ .string = Value.String.borrowed(trimmed) };
+                return try NativeResult.copyString(ctx.allocator, trimmed);
             }
         }
     }
-    return .{ .string = Value.String.borrowed("/tmp") };
+    return NativeResult.literal("/tmp");
 }
 
-fn native_tempnam(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_tempnam(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const dir = if (args.len >= 1 and args[0] == .string) args[0].string.bytes() else "/tmp";
     const prefix = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "tmp";
     var seed_bytes: [8]u8 = undefined;
@@ -724,21 +722,18 @@ fn native_tempnam(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             file.close();
             var path_buf: [std.fs.max_path_bytes]u8 = undefined;
             const resolved = std.fs.cwd().realpath(candidate, &path_buf) catch {
-                try ctx.strings.append(ctx.allocator, candidate);
-                return .{ .string = Value.String.borrowed(candidate) };
+                return NativeResult.takeString(try Value.String.adopt(ctx.allocator, candidate));
             };
             const dup = ctx.allocator.dupe(u8, resolved) catch {
-                try ctx.strings.append(ctx.allocator, candidate);
-                return .{ .string = Value.String.borrowed(candidate) };
+                return NativeResult.takeString(try Value.String.adopt(ctx.allocator, candidate));
             };
             ctx.allocator.free(candidate);
-            try ctx.strings.append(ctx.allocator, dup);
-            return .{ .string = Value.String.borrowed(dup) };
+            return NativeResult.takeString(try Value.String.adopt(ctx.allocator, dup));
         } else |_| {
             ctx.allocator.free(candidate);
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 fn buildBacktrace(ctx: *NativeContext, ignore_args: bool, provide_object: bool, limit: usize) RuntimeError!*PhpArray {
@@ -812,7 +807,7 @@ fn buildBacktrace(ctx: *NativeContext, ignore_args: bool, provide_object: bool, 
     return result;
 }
 
-fn native_debug_backtrace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_debug_backtrace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP options: 0 = DEBUG_BACKTRACE_PROVIDE_OBJECT (default), 2 = DEBUG_BACKTRACE_IGNORE_ARGS.
     // PROVIDE_OBJECT is on by default (option=0); only the inverse bit (1) suppresses it
     const options = if (args.len >= 1) Value.toInt(args[0]) else 0;
@@ -820,10 +815,10 @@ fn native_debug_backtrace(ctx: *NativeContext, args: []const Value) RuntimeError
     const ignore_args = (options & 2) != 0;
     const provide_object = (options & 1) == 0;
     const limit: usize = if (limit_raw > 0) @intCast(limit_raw) else 0;
-    return .{ .array = try buildBacktrace(ctx, ignore_args, provide_object, limit) };
+    return NativeResult.borrowed(.{ .array = try buildBacktrace(ctx, ignore_args, provide_object, limit) });
 }
 
-fn native_debug_print_backtrace(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_debug_print_backtrace(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const options = if (args.len >= 1) Value.toInt(args[0]) else 0;
     const limit_raw = if (args.len >= 2) Value.toInt(args[1]) else 0;
     const ignore_args = (options & 2) != 0;
@@ -856,10 +851,10 @@ fn native_debug_print_backtrace(ctx: *NativeContext, args: []const Value) Runtim
         try out.appendSlice(alloc, if (func == .string) func.string.bytes() else "{main}");
         try out.appendSlice(alloc, "()\n");
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_get_defined_functions(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_defined_functions(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const vm = ctx.vm;
     const alloc = ctx.allocator;
     var result = try ctx.createArray();
@@ -878,15 +873,15 @@ fn native_get_defined_functions(ctx: *NativeContext, _: []const Value) RuntimeEr
 
     try result.set(alloc, .{ .string = Value.String.borrowed("internal") }, .{ .array = internal });
     try result.set(alloc, .{ .string = Value.String.borrowed("user") }, .{ .array = user });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_get_defined_vars(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_defined_vars(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const vm = ctx.vm;
     const alloc = ctx.allocator;
     var result = try ctx.createArray();
 
-    if (vm.frame_count == 0) return .{ .array = result };
+    if (vm.frame_count == 0) return NativeResult.borrowed(.{ .array = result });
     const frame = &vm.frames[vm.frame_count - 1];
 
     // slot-based locals first (compile-time named slots). PHP excludes $this
@@ -914,10 +909,10 @@ fn native_get_defined_vars(ctx: *NativeContext, _: []const Value) RuntimeError!V
         if (std.mem.eql(u8, name, "this")) continue;
         try result.set(alloc, .{ .string = Value.String.borrowed(name) }, entry.value_ptr.*);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_get_defined_classes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_defined_classes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const vm = ctx.vm;
     const alloc = ctx.allocator;
     var result = try ctx.createArray();
@@ -926,10 +921,10 @@ fn native_get_defined_classes(ctx: *NativeContext, _: []const Value) RuntimeErro
     while (iter.next()) |entry| {
         try result.append(alloc, .{ .string = Value.String.borrowed(entry.key_ptr.*) });
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_set_time_limit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_set_time_limit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP: set_time_limit(int $seconds): bool. 0 = no limit. each call resets
     // the countdown from "now". negative is the same as 0
     var seconds: i64 = 0;
@@ -937,15 +932,15 @@ fn native_set_time_limit(ctx: *NativeContext, args: []const Value) RuntimeError!
     if (seconds < 0) seconds = 0;
     ctx.vm.setExecutionLimit(seconds);
     // mirror into the ini directive so subsequent ini_get sees the new value
-    const repr = std.fmt.allocPrint(ctx.allocator, "{d}", .{seconds}) catch return .{ .bool = false };
+    const repr = std.fmt.allocPrint(ctx.allocator, "{d}", .{seconds}) catch return NativeResult.scalar(.{ .bool = false });
     try ctx.vm.strings.append(ctx.allocator, repr);
-    const owned_name = ctx.allocator.dupe(u8, "max_execution_time") catch return .{ .bool = false };
+    const owned_name = ctx.allocator.dupe(u8, "max_execution_time") catch return NativeResult.scalar(.{ .bool = false });
     try ctx.vm.strings.append(ctx.allocator, owned_name);
     try ctx.vm.ini_settings.put(ctx.allocator, owned_name, repr);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_request_parse_body(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_request_parse_body(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var post = try ctx.createArray();
     var files = try ctx.createArray();
     if (ctx.vm.request_vars.get("$_POST")) |post_val| {
@@ -957,14 +952,14 @@ fn native_request_parse_body(ctx: *NativeContext, _: []const Value) RuntimeError
     var result = try ctx.createArray();
     try result.append(ctx.allocator, .{ .array = post });
     try result.append(ctx.allocator, .{ .array = files });
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_trait_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_trait_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const raw = args[0].string.bytes();
     const name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
-    return .{ .bool = ctx.vm.traits.contains(name) };
+    return NativeResult.scalar(.{ .bool = ctx.vm.traits.contains(name) });
 }
 
 fn runShell(allocator: std.mem.Allocator, command: []const u8, capture: bool) !std.process.Child.RunResult {
@@ -976,21 +971,20 @@ fn runShell(allocator: std.mem.Allocator, command: []const u8, capture: bool) !s
     });
 }
 
-fn native_shell_exec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return .null;
+fn native_shell_exec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return NativeResult.scalar(.null);
     defer ctx.allocator.free(result.stderr);
     if (result.stdout.len == 0) {
         ctx.allocator.free(result.stdout);
-        return .null;
+        return NativeResult.scalar(.null);
     }
-    try ctx.vm.strings.append(ctx.allocator, result.stdout);
-    return .{ .string = Value.String.borrowed(result.stdout) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, result.stdout));
 }
 
-fn native_exec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return .{ .bool = false };
+fn native_exec(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(result.stderr);
     defer ctx.allocator.free(result.stdout);
 
@@ -1029,16 +1023,14 @@ fn native_exec(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     };
     if (args.len >= 3) ctx.setCallerVar(2, args.len, .{ .int = exit_code });
 
-    if (lines.items.len == 0) return .{ .string = Value.String.borrowed("") };
+    if (lines.items.len == 0) return NativeResult.literal("");
     const last = lines.items[lines.items.len - 1];
-    const copy = try ctx.allocator.dupe(u8, last);
-    try ctx.vm.strings.append(ctx.allocator, copy);
-    return .{ .string = Value.String.borrowed(copy) };
+    return try NativeResult.copyString(ctx.allocator, last);
 }
 
-fn native_system(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return .{ .bool = false };
+fn native_system(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(result.stderr);
     defer ctx.allocator.free(result.stdout);
 
@@ -1059,14 +1051,12 @@ fn native_system(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const start = if (std.mem.lastIndexOfScalar(u8, result.stdout[0..end], '\n')) |i| i + 1 else 0;
         last_line = result.stdout[start..end];
     }
-    const copy = try ctx.allocator.dupe(u8, last_line);
-    try ctx.vm.strings.append(ctx.allocator, copy);
-    return .{ .string = Value.String.borrowed(copy) };
+    return try NativeResult.copyString(ctx.allocator, last_line);
 }
 
-fn native_passthru(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return .{ .bool = false };
+fn native_passthru(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const result = runShell(ctx.allocator, args[0].string.bytes(), true) catch return NativeResult.scalar(.{ .bool = false });
     defer ctx.allocator.free(result.stderr);
     defer ctx.allocator.free(result.stdout);
     try ctx.vm.output.appendSlice(ctx.allocator, result.stdout);
@@ -1078,11 +1068,11 @@ fn native_passthru(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     if (args.len >= 2 and args[1] == .array) {
         try args[1].array.append(ctx.allocator, .{ .int = exit_code });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_escapeshellarg(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .string = Value.String.borrowed("''") };
+fn native_escapeshellarg(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.literal("''");
     const s = args[0].string.bytes();
     var buf = std.ArrayListUnmanaged(u8){};
     try buf.append(ctx.allocator, '\'');
@@ -1097,12 +1087,11 @@ fn native_escapeshellarg(ctx: *NativeContext, args: []const Value) RuntimeError!
     try buf.append(ctx.allocator, '\'');
     const out = try ctx.allocator.dupe(u8, buf.items);
     buf.deinit(ctx.allocator);
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }
 
-fn native_escapeshellcmd(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
+fn native_escapeshellcmd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.literal("");
     const s = args[0].string.bytes();
     var buf = std.ArrayListUnmanaged(u8){};
     var in_squote = false;
@@ -1124,6 +1113,5 @@ fn native_escapeshellcmd(ctx: *NativeContext, args: []const Value) RuntimeError!
     }
     const out = try ctx.allocator.dupe(u8, buf.items);
     buf.deinit(ctx.allocator);
-    try ctx.vm.strings.append(ctx.allocator, out);
-    return .{ .string = Value.String.borrowed(out) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, out));
 }

--- a/src/stdlib/testing.zig
+++ b/src/stdlib/testing.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
@@ -12,23 +13,25 @@ pub const entries = .{
     .{ "assert_contains", assertContains },
 };
 
-fn failAssertion(ctx: *NativeContext, msg: []const u8) RuntimeError!Value {
-    if (try ctx.vm.throwBuiltinException("AssertionError", msg)) return .null;
-    ctx.vm.error_msg = msg;
+fn failAssertion(ctx: *NativeContext, msg: []const u8) RuntimeError!NativeResult {
+    if (try ctx.vm.throwBuiltinException("AssertionError", msg)) return NativeResult.scalar(.null);
+    ctx.vm.error_msg = try ctx.createString(msg);
     return error.RuntimeError;
 }
 
-fn assertEq(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn assertEq(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2) return failAssertion(ctx, "assert_eq requires 2 arguments");
-    if (Value.identical(args[0], args[1])) return .null;
+    if (Value.identical(args[0], args[1])) return NativeResult.scalar(.null);
 
     // build error message
     var buf1 = std.ArrayListUnmanaged(u8){};
+    defer buf1.deinit(ctx.allocator);
     try args[0].format(&buf1, ctx.allocator);
     const s1 = try buf1.toOwnedSlice(ctx.allocator);
     defer ctx.allocator.free(s1);
 
     var buf2 = std.ArrayListUnmanaged(u8){};
+    defer buf2.deinit(ctx.allocator);
     try args[1].format(&buf2, ctx.allocator);
     const s2 = try buf2.toOwnedSlice(ctx.allocator);
     defer ctx.allocator.free(s2);
@@ -44,42 +47,42 @@ fn assertEq(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     return failAssertion(ctx, msg);
 }
 
-fn assertTrue(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn assertTrue(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) return failAssertion(ctx, "assert_true requires 1 argument");
-    if (args[0].isTruthy()) return .null;
+    if (args[0].isTruthy()) return NativeResult.scalar(.null);
     const msg = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "expected true, got false";
     return failAssertion(ctx, msg);
 }
 
-fn assertFalse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn assertFalse(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) return failAssertion(ctx, "assert_false requires 1 argument");
-    if (!args[0].isTruthy()) return .null;
+    if (!args[0].isTruthy()) return NativeResult.scalar(.null);
     const msg = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "expected false, got true";
     return failAssertion(ctx, msg);
 }
 
-fn assertNull(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn assertNull(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) return failAssertion(ctx, "assert_null requires 1 argument");
-    if (args[0] == .null) return .null;
+    if (args[0] == .null) return NativeResult.scalar(.null);
     const msg = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "expected null";
     return failAssertion(ctx, msg);
 }
 
-fn assertNotNull(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn assertNotNull(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) return failAssertion(ctx, "assert_not_null requires 1 argument");
-    if (args[0] != .null) return .null;
+    if (args[0] != .null) return NativeResult.scalar(.null);
     const msg = if (args.len >= 2 and args[1] == .string) args[1].string.bytes() else "expected non-null";
     return failAssertion(ctx, msg);
 }
 
-fn assertContains(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn assertContains(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2) return failAssertion(ctx, "assert_contains requires 2 arguments");
     if (args[0] == .string and args[1] == .string) {
-        if (std.mem.indexOf(u8, args[0].string.bytes(), args[1].string.bytes()) != null) return .null;
+        if (std.mem.indexOf(u8, args[0].string.bytes(), args[1].string.bytes()) != null) return NativeResult.scalar(.null);
     }
     if (args[0] == .array and args.len >= 2) {
         for (args[0].array.entries.items) |entry| {
-            if (Value.identical(entry.value, args[1])) return .null;
+            if (Value.identical(entry.value, args[1])) return NativeResult.scalar(.null);
         }
     }
     const msg = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else "value not found in haystack";

--- a/src/stdlib/types.zig
+++ b/src/stdlib/types.zig
@@ -1,3 +1,4 @@
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -170,46 +171,44 @@ pub const entries = .{
     .{ "token_name", native_token_name },
 };
 
-fn native_define(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return .{ .bool = false };
-    if (ctx.vm.php_constants.contains(args[0].string.bytes())) return .{ .bool = false };
+fn native_define(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.php_constants.contains(args[0].string.bytes())) return NativeResult.scalar(.{ .bool = false });
     const name = try ctx.createString(args[0].string.bytes());
     try ctx.vm.user_constants.put(ctx.allocator, name, {});
     try ctx.vm.php_constants.put(ctx.allocator, name, args[1]);
     VM.retainValue(args[1]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_defined(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_defined(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
-    if (ctx.vm.php_constants.contains(name)) return .{ .bool = true };
+    if (ctx.vm.php_constants.contains(name)) return NativeResult.scalar(.{ .bool = true });
     // PHP treats leading-backslash and no-leading-backslash equivalently
     // for fully qualified constant lookups: defined('\M\PI') == defined('M\PI')
     if (name.len > 0 and name[0] == '\\') {
-        if (ctx.vm.php_constants.contains(name[1..])) return .{ .bool = true };
+        if (ctx.vm.php_constants.contains(name[1..])) return NativeResult.scalar(.{ .bool = true });
     }
     if (std.mem.indexOf(u8, name, "::")) |sep| {
         const class_name = name[0..sep];
         const prop_name = name[sep + 2 ..];
-        if (ctx.vm.getStaticProp(class_name, prop_name) != null) return .{ .bool = true };
+        if (ctx.vm.getStaticProp(class_name, prop_name) != null) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_constant(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .null;
+fn native_constant(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.null);
     const name = args[0].string.bytes();
     if (ctx.vm.php_constants.get(name)) |v| {
-        if (v == .string) v.string.retain();
-        return v;
+        return NativeResult.share(v);
     }
     if (std.mem.indexOf(u8, name, "::")) |sep| {
         const class_name = name[0..sep];
         const prop_name = name[sep + 2 ..];
         if (ctx.vm.getStaticProp(class_name, prop_name)) |v| {
-            if (v == .string) v.string.retain();
-            return v;
+            return NativeResult.share(v);
         }
     }
     const msg = try std.fmt.allocPrint(ctx.allocator, "Undefined constant \"{s}\"", .{name});
@@ -218,7 +217,7 @@ fn native_constant(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     return error.RuntimeError;
 }
 
-fn native_get_defined_constants(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_get_defined_constants(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const categorize = args.len >= 1 and args[0].isTruthy();
     if (categorize) {
         const root = try ctx.createArray();
@@ -235,14 +234,14 @@ fn native_get_defined_constants(ctx: *NativeContext, args: []const Value) Runtim
         }
         try root.set(ctx.allocator, .{ .string = Value.String.borrowed("Core") }, .{ .array = internal });
         try root.set(ctx.allocator, .{ .string = Value.String.borrowed("user") }, .{ .array = user });
-        return .{ .array = root };
+        return NativeResult.borrowed(.{ .array = root });
     }
     const flat = try ctx.createArray();
     var it = ctx.vm.php_constants.iterator();
     while (it.next()) |entry| {
         try flat.set(ctx.allocator, .{ .string = Value.String.borrowed(entry.key_ptr.*) }, entry.value_ptr.*);
     }
-    return .{ .array = flat };
+    return NativeResult.borrowed(.{ .array = flat });
 }
 
 fn countRecursive(a: *const PhpArray) i64 {
@@ -255,14 +254,14 @@ fn countRecursive(a: *const PhpArray) i64 {
     return total;
 }
 
-fn count(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn count(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
     const recursive = args.len >= 2 and args[1] == .int and args[1].int == 1;
     return switch (args[0]) {
-        .array => |a| .{ .int = if (recursive) countRecursive(a) else a.length() },
+        .array => |a| NativeResult.scalar(.{ .int = if (recursive) countRecursive(a) else a.length() }),
         .object => |obj| {
             if (ctx.vm.hasMethod(obj.class_name, "count")) {
-                return ctx.vm.callMethod(obj, "count", &.{}) catch .{ .int = 1 };
+                return NativeResult.share(ctx.vm.callMethod(obj, "count", &.{}) catch .{ .int = 1 });
             }
             const msg = try std.fmt.allocPrint(ctx.allocator, "count(): Argument #1 ($value) must be of type Countable|array, {s} given", .{phpTypeName(args[0])});
             try ctx.vm.strings.append(ctx.allocator, msg);
@@ -295,8 +294,8 @@ pub fn phpTypeName(v: Value) []const u8 {
     };
 }
 
-fn intval(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn intval(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
     if (args.len >= 2 and args[1] == .int and args[1].int != 10 and args[0] == .string) {
         var base: u8 = @intCast(@max(0, @min(36, args[1].int)));
         var s = std.mem.trim(u8, args[0].string.bytes(), " \t\n\r");
@@ -332,101 +331,101 @@ fn intval(_: *NativeContext, args: []const Value) RuntimeError!Value {
             if (digit >= base) break;
         }
         const v = if (end == 0) @as(i64, 0) else (std.fmt.parseInt(i64, s[0..end], base) catch 0);
-        return .{ .int = if (negative) -v else v };
+        return NativeResult.scalar(.{ .int = if (negative) -v else v });
     }
     // PHP: intval(array) is 0 for empty array, 1 for non-empty
     if (args[0] == .array) {
-        return .{ .int = if (args[0].array.entries.items.len == 0) @as(i64, 0) else @as(i64, 1) };
+        return NativeResult.scalar(.{ .int = if (args[0].array.entries.items.len == 0) @as(i64, 0) else @as(i64, 1) });
     }
-    return .{ .int = Value.toInt(args[0]) };
+    return NativeResult.scalar(.{ .int = Value.toInt(args[0]) });
 }
 
-fn floatval(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .float = 0.0 };
-    return .{ .float = Value.toFloat(args[0]) };
+fn floatval(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .float = 0.0 });
+    return NativeResult.scalar(.{ .float = Value.toFloat(args[0]) });
 }
 
-fn strval(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
-    if (args[0] == .string) return args[0];
+fn strval(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
+    if (args[0] == .string) return NativeResult.share(args[0]);
     // PHP's strval on an object dispatches through __toString. Without this,
     // we'd print "Object" instead of the user-defined string form
     if (args[0] == .object) {
         const obj = args[0].object;
         if (ctx.vm.hasMethod(obj.class_name, "__toString")) {
             const r = try ctx.vm.callMethod(obj, "__toString", &.{});
-            if (r == .string) return r;
+            if (r == .string) return NativeResult.share(r);
         }
     }
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     try args[0].format(&buf, ctx.allocator);
     const s = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, s);
-    return .{ .string = Value.String.borrowed(s) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
 }
 
-fn gettype(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("NULL") };
-    return .{ .string = Value.String.borrowed(switch (args[0]) {
-        .null => "NULL",
-        .bool => "boolean",
-        .int => "integer",
-        .float => "double",
-        .string => |s| if (std.mem.startsWith(u8, s.bytes(), "__closure_")) "object" else "string",
-        .array => "array",
-        .object => |o| if (std.mem.eql(u8, o.class_name, "FileHandle")) "resource" else "object",
-        .generator, .fiber => "object",
-    }) };
+fn gettype(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("NULL");
+    return switch (args[0]) {
+        .null => NativeResult.literal("NULL"),
+        .bool => NativeResult.literal("boolean"),
+        .int => NativeResult.literal("integer"),
+        .float => NativeResult.literal("double"),
+        .string => |s| if (std.mem.startsWith(u8, s.bytes(), "__closure_")) NativeResult.literal("object") else NativeResult.literal("string"),
+        .array => NativeResult.literal("array"),
+        .object => |o| if (std.mem.eql(u8, o.class_name, "FileHandle")) NativeResult.literal("resource") else NativeResult.literal("object"),
+        .generator, .fiber => NativeResult.literal("object"),
+    };
 }
 
-fn get_debug_type(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("null") };
-    return .{ .string = Value.String.borrowed(switch (args[0]) {
-        .null => "null",
-        .bool => "bool",
-        .int => "int",
-        .float => "float",
-        .string => |s| if (std.mem.startsWith(u8, s.bytes(), "__closure_")) "Closure" else "string",
-        .array => "array",
-        .object => |o| if (std.mem.eql(u8, o.class_name, "FileHandle")) "resource (stream)" else o.class_name,
-        .generator => "Generator",
-        .fiber => "Fiber",
-    }) };
+fn get_debug_type(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("null");
+    return switch (args[0]) {
+        .null => NativeResult.literal("null"),
+        .bool => NativeResult.literal("bool"),
+        .int => NativeResult.literal("int"),
+        .float => NativeResult.literal("float"),
+        .string => |s| if (std.mem.startsWith(u8, s.bytes(), "__closure_")) NativeResult.literal("Closure") else NativeResult.literal("string"),
+        .array => NativeResult.literal("array"),
+        .object => |o| if (std.mem.eql(u8, o.class_name, "FileHandle")) NativeResult.literal("resource (stream)") else try NativeResult.copyString(ctx.allocator, o.class_name),
+        .generator => NativeResult.literal("Generator"),
+        .fiber => NativeResult.literal("Fiber"),
+    };
 }
 
-fn is_array(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = args.len > 0 and args[0] == .array };
+fn is_array(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = args.len > 0 and args[0] == .array });
 }
 
-fn is_null(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = args.len == 0 or args[0] == .null };
+fn is_null(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = args.len == 0 or args[0] == .null });
 }
 
-fn is_int(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = args.len > 0 and args[0] == .int };
+fn is_int(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = args.len > 0 and args[0] == .int });
 }
 
-fn is_float(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = args.len > 0 and args[0] == .float };
+fn is_float(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = args.len > 0 and args[0] == .float });
 }
 
-fn is_string(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    if (args[0] != .string) return .{ .bool = false };
-    return .{ .bool = !std.mem.startsWith(u8, args[0].string.bytes(), "__closure_") };
+fn is_string(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = !std.mem.startsWith(u8, args[0].string.bytes(), "__closure_") });
 }
 
-fn is_bool(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return .{ .bool = args.len > 0 and args[0] == .bool };
+fn is_bool(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = args.len > 0 and args[0] == .bool });
 }
 
-fn is_numeric(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    return .{ .bool = switch (args[0]) {
+fn is_numeric(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = switch (args[0]) {
         .int, .float => true,
         .string => |s| isNumericString(s.bytes()),
         else => false,
-    } };
+    } });
 }
 
 // PHP's is_numeric: optional sign, digits, optional fractional/exponent.
@@ -462,18 +461,18 @@ fn isNumericString(input: []const u8) bool {
     return i == s.len;
 }
 
-fn native_isset(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    return .{ .bool = args[0] != .null };
+fn native_isset(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = args[0] != .null });
 }
 
-fn native_empty(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = true };
-    return .{ .bool = !args[0].isTruthy() };
+fn native_empty(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = !args[0].isTruthy() });
 }
 
-fn strlen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn strlen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
     return switch (args[0]) {
         .string => |s| blk: {
             // closures live as '__closure_<id>' strings in zphp; treat them
@@ -484,24 +483,24 @@ fn strlen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
                 try ctx.vm.setPendingException("TypeError", msg);
                 break :blk error.RuntimeError;
             }
-            break :blk .{ .int = @intCast(s.bytes().len) };
+            break :blk NativeResult.scalar(.{ .int = @intCast(s.bytes().len) });
         },
         .int => |i| blk: {
             var buf: [32]u8 = undefined;
-            const s = std.fmt.bufPrint(&buf, "{d}", .{i}) catch break :blk .{ .int = 0 };
-            break :blk .{ .int = @intCast(s.len) };
+            const s = std.fmt.bufPrint(&buf, "{d}", .{i}) catch break :blk NativeResult.scalar(.{ .int = 0 });
+            break :blk NativeResult.scalar(.{ .int = @intCast(s.len) });
         },
         .float => |f| blk: {
             var buf: [64]u8 = undefined;
-            const s = std.fmt.bufPrint(&buf, "{d}", .{f}) catch break :blk .{ .int = 0 };
-            break :blk .{ .int = @intCast(s.len) };
+            const s = std.fmt.bufPrint(&buf, "{d}", .{f}) catch break :blk NativeResult.scalar(.{ .int = 0 });
+            break :blk NativeResult.scalar(.{ .int = @intCast(s.len) });
         },
-        .bool => |b| .{ .int = if (b) 1 else 0 },
-        .null => .{ .int = 0 },
+        .bool => |b| NativeResult.scalar(.{ .int = if (b) 1 else 0 }),
+        .null => NativeResult.scalar(.{ .int = 0 }),
         .object => |obj| blk: {
             if (ctx.vm.hasMethod(obj.class_name, "__toString")) {
                 const result = try ctx.vm.callMethod(obj, "__toString", &.{});
-                if (result == .string) break :blk .{ .int = @intCast(result.string.bytes().len) };
+                if (result == .string) break :blk NativeResult.scalar(.{ .int = @intCast(result.string.bytes().len) });
             }
             // object without __toString: PHP throws TypeError with the class name
             const msg = try std.fmt.allocPrint(ctx.allocator, "strlen(): Argument #1 ($string) must be of type string, {s} given", .{phpTypeName(args[0])});
@@ -513,27 +512,27 @@ fn strlen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             try ctx.vm.setPendingException("TypeError", "strlen(): Argument #1 ($string) must be of type string, array given");
             break :blk error.RuntimeError;
         },
-        else => .{ .int = 0 },
+        else => NativeResult.scalar(.{ .int = 0 }),
     };
 }
 
-fn boolval(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    return .{ .bool = args[0].isTruthy() };
+fn boolval(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = args[0].isTruthy() });
 }
 
-fn is_object(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    if (args[0] == .object) return .{ .bool = true };
-    if (args[0] == .generator) return .{ .bool = true };
-    if (args[0] == .fiber) return .{ .bool = true };
-    if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) return .{ .bool = true };
-    return .{ .bool = false };
+fn is_object(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] == .object) return NativeResult.scalar(.{ .bool = true });
+    if (args[0] == .generator) return NativeResult.scalar(.{ .bool = true });
+    if (args[0] == .fiber) return NativeResult.scalar(.{ .bool = true });
+    if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn is_scalar(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    return .{
+fn is_scalar(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{
         .bool = switch (args[0]) {
             .int, .float, .bool => true,
             // closures are stored as a Value.string with a "__closure_" prefix;
@@ -541,32 +540,32 @@ fn is_scalar(_: *NativeContext, args: []const Value) RuntimeError!Value {
             .string => |s| !std.mem.startsWith(u8, s.bytes(), "__closure_"),
             else => false,
         },
-    };
+    });
 }
 
-fn is_iterable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    if (args[0] == .array or args[0] == .generator) return .{ .bool = true };
+fn is_iterable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] == .array or args[0] == .generator) return NativeResult.scalar(.{ .bool = true });
     if (args[0] == .object) {
         const cn = args[0].object.class_name;
-        if (ctx.vm.isInstanceOf(cn, "Traversable")) return .{ .bool = true };
-        if (ctx.vm.isInstanceOf(cn, "Iterator")) return .{ .bool = true };
-        if (ctx.vm.isInstanceOf(cn, "IteratorAggregate")) return .{ .bool = true };
-        if (ctx.vm.hasMethod(cn, "getIterator")) return .{ .bool = true };
-        if (ctx.vm.hasMethod(cn, "current") and ctx.vm.hasMethod(cn, "next")) return .{ .bool = true };
+        if (ctx.vm.isInstanceOf(cn, "Traversable")) return NativeResult.scalar(.{ .bool = true });
+        if (ctx.vm.isInstanceOf(cn, "Iterator")) return NativeResult.scalar(.{ .bool = true });
+        if (ctx.vm.isInstanceOf(cn, "IteratorAggregate")) return NativeResult.scalar(.{ .bool = true });
+        if (ctx.vm.hasMethod(cn, "getIterator")) return NativeResult.scalar(.{ .bool = true });
+        if (ctx.vm.hasMethod(cn, "current") and ctx.vm.hasMethod(cn, "next")) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn is_countable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    if (args[0] == .array) return .{ .bool = true };
+fn is_countable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
+    if (args[0] == .array) return NativeResult.scalar(.{ .bool = true });
     if (args[0] == .object) {
         const cn = args[0].object.class_name;
-        if (ctx.vm.isInstanceOf(cn, "Countable")) return .{ .bool = true };
-        if (ctx.vm.hasMethod(cn, "count")) return .{ .bool = true };
+        if (ctx.vm.isInstanceOf(cn, "Countable")) return NativeResult.scalar(.{ .bool = true });
+        if (ctx.vm.hasMethod(cn, "count")) return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 fn ctypeCheck(args: []const Value, comptime pred: fn (u8) bool) Value {
@@ -593,38 +592,38 @@ fn ctypeCheck(args: []const Value, comptime pred: fn (u8) bool) Value {
     return .{ .bool = true };
 }
 
-fn ctype_alpha(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isAlphabetic);
+fn ctype_alpha(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isAlphabetic));
 }
-fn ctype_digit(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isDigit);
+fn ctype_digit(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isDigit));
 }
-fn ctype_alnum(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isAlphanumeric);
+fn ctype_alnum(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isAlphanumeric));
 }
-fn ctype_space(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isWhitespace);
+fn ctype_space(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isWhitespace));
 }
-fn ctype_upper(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isUpper);
+fn ctype_upper(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isUpper));
 }
-fn ctype_lower(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isLower);
+fn ctype_lower(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isLower));
 }
-fn ctype_xdigit(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isHex);
+fn ctype_xdigit(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isHex));
 }
-fn ctype_print(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isPrint);
+fn ctype_print(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isPrint));
 }
-fn ctype_punct(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, isPunct);
+fn ctype_punct(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, isPunct));
 }
-fn ctype_cntrl(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, std.ascii.isControl);
+fn ctype_cntrl(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, std.ascii.isControl));
 }
-fn ctype_graph(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    return ctypeCheck(args, isGraph);
+fn ctype_graph(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(ctypeCheck(args, isGraph));
 }
 
 // PHP's setlocale wraps libc setlocale. zphp doesn't actually flip the process
@@ -643,10 +642,10 @@ fn ensureLocaleInit() void {
     current_locale_initialized = true;
 }
 
-fn native_setlocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_setlocale(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     ensureLocaleInit();
     // PHP: setlocale($category, ...$locales). first arg is category (int)
-    if (args.len < 1) return .{ .string = Value.String.borrowed(try dupString(ctx, current_locale[0..current_locale_len])) };
+    if (args.len < 1) return NativeResult.copyString(ctx.allocator, current_locale[0..current_locale_len]);
 
     // collect candidate locale strings from args 1..n. each may be a string or an
     // array (variadic / array form). first one that "works" wins; "0" queries
@@ -655,7 +654,7 @@ fn native_setlocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         switch (args[i]) {
             .string => |s| {
                 if (std.mem.eql(u8, s.bytes(), "0")) {
-                    return .{ .string = Value.String.borrowed(try dupString(ctx, current_locale[0..current_locale_len])) };
+                    return NativeResult.copyString(ctx.allocator, current_locale[0..current_locale_len]);
                 }
                 // accept the string verbatim. empty string maps to "C"
                 const new = if (s.bytes().len == 0) "C" else s.bytes();
@@ -663,7 +662,7 @@ fn native_setlocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value
                     @memcpy(current_locale[0..new.len], new);
                     current_locale_len = new.len;
                 }
-                return .{ .string = Value.String.borrowed(try dupString(ctx, new)) };
+                return NativeResult.copyString(ctx.allocator, new);
             },
             .array => |arr| {
                 for (arr.entries.items) |e| {
@@ -674,45 +673,45 @@ fn native_setlocale(ctx: *NativeContext, args: []const Value) RuntimeError!Value
                         @memcpy(current_locale[0..s.len], s);
                         current_locale_len = s.len;
                     }
-                    return .{ .string = Value.String.borrowed(try dupString(ctx, s)) };
+                    return NativeResult.copyString(ctx.allocator, s);
                 }
             },
             else => continue,
         }
     }
     // no acceptable locale provided
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 // minimal localeconv: returns a default "C" locale info array. real apps use
 // this for currency formatting fallbacks; the intl extension is the real path
-fn native_localeconv(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_localeconv(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
-    const empty = try dupString(ctx, "");
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "decimal_point")) }, .{ .string = Value.String.borrowed(try dupString(ctx, ".")) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "thousands_sep")) }, .{ .string = Value.String.borrowed(empty) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "int_curr_symbol")) }, .{ .string = Value.String.borrowed(empty) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "currency_symbol")) }, .{ .string = Value.String.borrowed(empty) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "mon_decimal_point")) }, .{ .string = Value.String.borrowed(empty) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "mon_thousands_sep")) }, .{ .string = Value.String.borrowed(empty) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "positive_sign")) }, .{ .string = Value.String.borrowed(empty) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "negative_sign")) }, .{ .string = Value.String.borrowed(empty) });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "int_frac_digits")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "frac_digits")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "p_cs_precedes")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "p_sep_by_space")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "n_cs_precedes")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "n_sep_by_space")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "p_sign_posn")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "n_sign_posn")) }, .{ .int = 127 });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "grouping")) }, .{ .array = try ctx.createArray() });
-    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(try dupString(ctx, "mon_grouping")) }, .{ .array = try ctx.createArray() });
-    return .{ .array = arr };
+    const empty = "";
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("decimal_point") }, .{ .string = Value.String.borrowed(".") });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("thousands_sep") }, .{ .string = Value.String.borrowed(empty) });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("int_curr_symbol") }, .{ .string = Value.String.borrowed(empty) });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("currency_symbol") }, .{ .string = Value.String.borrowed(empty) });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("mon_decimal_point") }, .{ .string = Value.String.borrowed(empty) });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("mon_thousands_sep") }, .{ .string = Value.String.borrowed(empty) });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("positive_sign") }, .{ .string = Value.String.borrowed(empty) });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("negative_sign") }, .{ .string = Value.String.borrowed(empty) });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("int_frac_digits") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("frac_digits") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("p_cs_precedes") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("p_sep_by_space") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("n_cs_precedes") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("n_sep_by_space") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("p_sign_posn") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("n_sign_posn") }, .{ .int = 127 });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("grouping") }, .{ .array = try ctx.createArray() });
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("mon_grouping") }, .{ .array = try ctx.createArray() });
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_nl_langinfo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_nl_langinfo(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     _ = args;
-    return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    return NativeResult.literal("");
 }
 
 fn dupString(ctx: *NativeContext, s: []const u8) ![]const u8 {
@@ -728,53 +727,53 @@ fn isGraph(c: u8) bool {
     return std.ascii.isPrint(c) and c != ' ';
 }
 
-fn get_class(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn get_class(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) {
-        const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return Value{ .bool = false };
-        if (this_val != .object) return .{ .bool = false };
-        return .{ .string = Value.String.borrowed(this_val.object.class_name) };
+        const this_val = ctx.vm.currentFrame().vars.get("$this") orelse return NativeResult.scalar(Value{ .bool = false });
+        if (this_val != .object) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.copyString(ctx.allocator, this_val.object.class_name);
     }
-    if (args[0] == .object) return .{ .string = Value.String.borrowed(args[0].object.class_name) };
-    if (args[0] == .generator) return .{ .string = Value.String.borrowed("Generator") };
-    if (args[0] == .fiber) return .{ .string = Value.String.borrowed("Fiber") };
-    if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) return .{ .string = Value.String.borrowed("Closure") };
-    return .{ .bool = false };
+    if (args[0] == .object) return NativeResult.copyString(ctx.allocator, args[0].object.class_name);
+    if (args[0] == .generator) return NativeResult.literal("Generator");
+    if (args[0] == .fiber) return NativeResult.literal("Fiber");
+    if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) return NativeResult.literal("Closure");
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn get_called_class(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn get_called_class(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var i = ctx.vm.frame_count;
     while (i > 0) {
         i -= 1;
-        if (ctx.vm.frames[i].called_class) |cc| return .{ .string = Value.String.borrowed(cc) };
+        if (ctx.vm.frames[i].called_class) |cc| return NativeResult.copyString(ctx.allocator, cc);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_get_declared_classes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_declared_classes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     var it = ctx.vm.classes.iterator();
     while (it.next()) |e| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(e.key_ptr.*) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_get_declared_interfaces(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_declared_interfaces(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     var it = ctx.vm.interfaces.iterator();
     while (it.next()) |e| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(e.key_ptr.*) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_get_declared_traits(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_declared_traits(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     var it = ctx.vm.traits.iterator();
     while (it.next()) |e| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(e.key_ptr.*) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn classExistsCaseInsensitive(ctx: *NativeContext, name: []const u8) bool {
@@ -786,32 +785,32 @@ fn classExistsCaseInsensitive(ctx: *NativeContext, name: []const u8) bool {
     return false;
 }
 
-fn class_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn class_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const raw = args[0].string.bytes();
     const name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
-    if (std.ascii.eqlIgnoreCase(name, "stdClass") or std.ascii.eqlIgnoreCase(name, "Attribute")) return .{ .bool = true };
-    if (std.ascii.eqlIgnoreCase(name, "Closure") or std.ascii.eqlIgnoreCase(name, "Generator") or std.ascii.eqlIgnoreCase(name, "Fiber")) return .{ .bool = true };
-    if (ctx.vm.interfaces.contains(name)) return .{ .bool = false };
-    if (ctx.vm.traits.contains(name)) return .{ .bool = false };
-    if (classExistsCaseInsensitive(ctx, name)) return .{ .bool = true };
+    if (std.ascii.eqlIgnoreCase(name, "stdClass") or std.ascii.eqlIgnoreCase(name, "Attribute")) return NativeResult.scalar(.{ .bool = true });
+    if (std.ascii.eqlIgnoreCase(name, "Closure") or std.ascii.eqlIgnoreCase(name, "Generator") or std.ascii.eqlIgnoreCase(name, "Fiber")) return NativeResult.scalar(.{ .bool = true });
+    if (ctx.vm.interfaces.contains(name)) return NativeResult.scalar(.{ .bool = false });
+    if (ctx.vm.traits.contains(name)) return NativeResult.scalar(.{ .bool = false });
+    if (classExistsCaseInsensitive(ctx, name)) return NativeResult.scalar(.{ .bool = true });
     const autoload = args.len < 2 or !(args[1] == .bool and !args[1].bool);
     if (autoload and ctx.vm.autoload_callbacks.items.len > 0) {
         try ctx.vm.tryAutoload(name);
-        return .{ .bool = classExistsCaseInsensitive(ctx, name) and !ctx.vm.interfaces.contains(name) };
+        return NativeResult.scalar(.{ .bool = classExistsCaseInsensitive(ctx, name) and !ctx.vm.interfaces.contains(name) });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn method_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn method_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     // closures (stored as unique name strings) report themselves as the
     // 'Closure' class. they always have __invoke + the public Closure API
     if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) {
         const m = args[1].string.bytes();
         const closure_methods = [_][]const u8{ "__invoke", "bindTo", "bind", "call", "fromCallable", "getClosureScopeClass", "getClosureThis", "getClosureCalledClass", "getClosureUsedVariables" };
-        for (closure_methods) |cm| if (std.ascii.eqlIgnoreCase(cm, m)) return .{ .bool = true };
-        return .{ .bool = false };
+        for (closure_methods) |cm| if (std.ascii.eqlIgnoreCase(cm, m)) return NativeResult.scalar(.{ .bool = true });
+        return NativeResult.scalar(.{ .bool = false });
     }
     var current: ?[]const u8 = if (args[0] == .object)
         args[0].object.class_name
@@ -830,13 +829,13 @@ fn method_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     // method tables so method_exists works on tagged values and "Generator"/"Fiber" strings.
     if (std.mem.eql(u8, current.?, "Generator")) {
         const gen_methods = [_][]const u8{ "current", "key", "next", "rewind", "send", "throw", "getReturn", "valid" };
-        for (gen_methods) |m| if (std.ascii.eqlIgnoreCase(m, method_name)) return .{ .bool = true };
-        return .{ .bool = false };
+        for (gen_methods) |m| if (std.ascii.eqlIgnoreCase(m, method_name)) return NativeResult.scalar(.{ .bool = true });
+        return NativeResult.scalar(.{ .bool = false });
     }
     if (std.mem.eql(u8, current.?, "Fiber")) {
         const fiber_methods = [_][]const u8{ "start", "resume", "throw", "getReturn", "isStarted", "isSuspended", "isRunning", "isTerminated", "suspend", "getCurrent" };
-        for (fiber_methods) |m| if (std.ascii.eqlIgnoreCase(m, method_name)) return .{ .bool = true };
-        return .{ .bool = false };
+        for (fiber_methods) |m| if (std.ascii.eqlIgnoreCase(m, method_name)) return NativeResult.scalar(.{ .bool = true });
+        return NativeResult.scalar(.{ .bool = false });
     }
     var buf: [256]u8 = undefined;
     var depth: usize = 0;
@@ -857,10 +856,10 @@ fn method_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         if (depth > 0 and private_at_this_class) {
             // skip this class's match; continue up
         } else {
-            const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ cn, canonical_method }) catch return Value{ .bool = false };
-            if (ctx.vm.native_fns.contains(full)) return .{ .bool = true };
-            if (ctx.vm.functions.contains(full)) return .{ .bool = true };
-            if (!std.mem.eql(u8, canonical_method, method_name)) return .{ .bool = true };
+            const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ cn, canonical_method }) catch return NativeResult.scalar(Value{ .bool = false });
+            if (ctx.vm.native_fns.contains(full)) return NativeResult.scalar(.{ .bool = true });
+            if (ctx.vm.functions.contains(full)) return NativeResult.scalar(.{ .bool = true });
+            if (!std.mem.eql(u8, canonical_method, method_name)) return NativeResult.scalar(.{ .bool = true });
         }
         if (ctx.vm.classes.get(cn)) |cls| {
             current = cls.parent;
@@ -872,28 +871,28 @@ fn method_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         }
         depth += 1;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn property_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn property_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const prop_name = args[1].string.bytes();
     if (args[0] == .object) {
         const obj = args[0].object;
-        if (obj.getSlotIndex(prop_name) != null) return .{ .bool = true };
-        if (obj.properties.contains(prop_name)) return .{ .bool = true };
+        if (obj.getSlotIndex(prop_name) != null) return NativeResult.scalar(.{ .bool = true });
+        if (obj.properties.contains(prop_name)) return NativeResult.scalar(.{ .bool = true });
         // a static property (or a declared instance property not yet
         // materialized) of the object's class or an ancestor also counts
         var current: ?[]const u8 = obj.class_name;
         while (current) |name| {
             const cls = ctx.vm.classes.get(name) orelse break;
-            if (cls.static_props.contains(prop_name)) return .{ .bool = true };
+            if (cls.static_props.contains(prop_name)) return NativeResult.scalar(.{ .bool = true });
             for (cls.properties.items) |p| {
-                if (std.mem.eql(u8, p.name, prop_name)) return .{ .bool = true };
+                if (std.mem.eql(u8, p.name, prop_name)) return NativeResult.scalar(.{ .bool = true });
             }
             current = cls.parent;
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     if (args[0] == .string) {
         const raw = args[0].string.bytes();
@@ -905,23 +904,23 @@ fn property_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
             for (cls.properties.items) |p| {
                 if (std.mem.eql(u8, p.name, prop_name)) {
                     if (!is_own and p.visibility == .private) break;
-                    return .{ .bool = true };
+                    return NativeResult.scalar(.{ .bool = true });
                 }
             }
             if (cls.static_props.get(prop_name)) |_| {
                 const vis = cls.const_visibility.get(prop_name) orelse @as(ClassDef.Visibility, .public);
-                if (is_own or vis != .private) return .{ .bool = true };
+                if (is_own or vis != .private) return NativeResult.scalar(.{ .bool = true });
             }
             current = cls.parent;
             is_own = false;
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_is_callable(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_is_callable(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const val = args[0];
     // PHP's 3rd by-ref param receives the resolved callable name on success
     // (or its string form). populated regardless of return value so caller
@@ -938,36 +937,36 @@ fn native_is_callable(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         const raw = val.string.bytes();
         const name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
         fillName(ctx, args, name);
-        if (ctx.vm.native_fns.contains(name)) return .{ .bool = true };
-        if (ctx.vm.functions.contains(name)) return .{ .bool = true };
+        if (ctx.vm.native_fns.contains(name)) return NativeResult.scalar(.{ .bool = true });
+        if (ctx.vm.functions.contains(name)) return NativeResult.scalar(.{ .bool = true });
         // Class::method string form
         if (std.mem.indexOf(u8, name, "::")) |sep| {
             const class_part = name[0..sep];
             const method_part = name[sep + 2 ..];
-            if (ctx.vm.hasMethod(class_part, method_part)) return .{ .bool = true };
+            if (ctx.vm.hasMethod(class_part, method_part)) return NativeResult.scalar(.{ .bool = true });
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     if (val == .object) {
-        if (std.mem.eql(u8, val.object.class_name, "Closure")) return .{ .bool = true };
+        if (std.mem.eql(u8, val.object.class_name, "Closure")) return NativeResult.scalar(.{ .bool = true });
         var buf: [256]u8 = undefined;
         const full = std.fmt.bufPrint(&buf, "{s}::__invoke", .{val.object.class_name}) catch "";
         fillName(ctx, args, full);
-        return .{ .bool = ctx.vm.hasMethod(val.object.class_name, "__invoke") };
+        return NativeResult.scalar(.{ .bool = ctx.vm.hasMethod(val.object.class_name, "__invoke") });
     }
     if (val == .array) {
         const arr = val.array;
-        if (arr.entries.items.len != 2) return .{ .bool = false };
+        if (arr.entries.items.len != 2) return NativeResult.scalar(.{ .bool = false });
         const target = arr.entries.items[0].value;
         const method_val = arr.entries.items[1].value;
-        if (method_val != .string) return .{ .bool = false };
+        if (method_val != .string) return NativeResult.scalar(.{ .bool = false });
         const method = method_val.string.bytes();
         const raw_class = if (target == .object)
             target.object.class_name
         else if (target == .string)
             target.string.bytes()
         else
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         const class_name = if (raw_class.len > 0 and raw_class[0] == '\\') raw_class[1..] else raw_class;
         {
             var name_buf: [256]u8 = undefined;
@@ -976,44 +975,45 @@ fn native_is_callable(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         }
         if (ctx.vm.classes.get(class_name)) |cdef| {
             if (cdef.methods.get(method)) |mi| {
-                if (mi.visibility != .public) return .{ .bool = false };
+                if (mi.visibility != .public) return NativeResult.scalar(.{ .bool = false });
                 // [ClassName, 'method'] is only callable when method is static.
                 // instance methods need an actual object on the left
-                if (target == .string and !mi.is_static) return .{ .bool = false };
+                if (target == .string and !mi.is_static) return NativeResult.scalar(.{ .bool = false });
             }
         }
         var buf: [256]u8 = undefined;
-        const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ class_name, method }) catch return .{ .bool = false };
-        if (ctx.vm.native_fns.contains(full)) return .{ .bool = true };
-        if (ctx.vm.functions.contains(full)) return .{ .bool = true };
-        return .{ .bool = false };
+        const full = std.fmt.bufPrint(&buf, "{s}::{s}", .{ class_name, method }) catch return NativeResult.scalar(.{ .bool = false });
+        if (ctx.vm.native_fns.contains(full)) return NativeResult.scalar(.{ .bool = true });
+        if (ctx.vm.functions.contains(full)) return NativeResult.scalar(.{ .bool = true });
+        return NativeResult.scalar(.{ .bool = false });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_settype(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return args[0];
+fn native_settype(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    if (args.len < 2 or args[1] != .string) return NativeResult.share(args[0]);
     const type_name = args[1].string.bytes();
     const val = args[0];
     if (std.mem.eql(u8, type_name, "int") or std.mem.eql(u8, type_name, "integer"))
-        return .{ .int = Value.toInt(val) };
+        return NativeResult.scalar(.{ .int = Value.toInt(val) });
     if (std.mem.eql(u8, type_name, "float") or std.mem.eql(u8, type_name, "double"))
-        return .{ .float = Value.toFloat(val) };
+        return NativeResult.scalar(.{ .float = Value.toFloat(val) });
     if (std.mem.eql(u8, type_name, "string")) {
-        if (val == .string) return val;
+        if (val == .string) return NativeResult.share(val);
         if (val == .array) ctx.vm.emitWarning("Array to string conversion");
         var buf = std.ArrayListUnmanaged(u8){};
+        defer buf.deinit(ctx.allocator);
         try val.format(&buf, ctx.allocator);
         const s = try buf.toOwnedSlice(ctx.allocator);
-        try ctx.strings.append(ctx.allocator, s);
-        return .{ .string = Value.String.borrowed(s) };
+        return NativeResult.takeString(try Value.String.adopt(ctx.allocator, s));
     }
     if (std.mem.eql(u8, type_name, "bool") or std.mem.eql(u8, type_name, "boolean"))
-        return .{ .bool = val.isTruthy() };
+        return NativeResult.scalar(.{ .bool = val.isTruthy() });
     if (std.mem.eql(u8, type_name, "null"))
-        return .null;
+        return NativeResult.scalar(.null);
     if (std.mem.eql(u8, type_name, "array")) {
-        if (val == .array) return val;
+        if (val == .array) return NativeResult.share(val);
         if (val == .object) {
             const obj = val.object;
             const arr = try ctx.allocator.create(PhpArray);
@@ -1030,7 +1030,7 @@ fn native_settype(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
             while (dyn_iter.next()) |entry| {
                 try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(entry.key_ptr.*) }, entry.value_ptr.*);
             }
-            return .{ .array = arr };
+            return NativeResult.borrowed(.{ .array = arr });
         }
         const arr = try ctx.allocator.create(PhpArray);
         arr.* = .{};
@@ -1038,10 +1038,10 @@ fn native_settype(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         // scalar becomes a single-element array [value]
         if (val != .null) try arr.append(ctx.allocator, val);
         try ctx.arrays.append(ctx.allocator, arr);
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
     if (std.mem.eql(u8, type_name, "object")) {
-        if (val == .object) return val;
+        if (val == .object) return NativeResult.share(val);
         const obj = try ctx.allocator.create(PhpObject);
         obj.* = .{ .class_name = "stdClass" };
         try ctx.vm.objects.append(ctx.allocator, obj);
@@ -1059,44 +1059,44 @@ fn native_settype(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         } else if (val != .null) {
             try obj.set(ctx.allocator, "scalar", val);
         }
-        return .{ .object = obj };
+        return NativeResult.borrowed(.{ .object = obj });
     }
     try ctx.vm.setPendingException("ValueError", "settype(): Argument #2 ($type) must be a valid type");
     return error.RuntimeError;
 }
 
-fn native_call_user_func(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    return ctx.invokeCallable(args[0], args[1..]);
+fn native_call_user_func(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
+    return NativeResult.share(try ctx.invokeCallable(args[0], args[1..]));
 }
 
-fn native_call_user_func_array(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .null;
-    if (args[1] != .array) return ctx.invokeCallable(args[0], &.{});
+fn native_call_user_func_array(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.null);
+    if (args[1] != .array) return NativeResult.share(try ctx.invokeCallable(args[0], &.{}));
     const arr = args[1].array;
     var call_args: [16]Value = undefined;
     const count_val: usize = @min(16, arr.entries.items.len);
     for (0..count_val) |i| call_args[i] = arr.entries.items[i].value;
-    return ctx.invokeCallable(args[0], call_args[0..count_val]);
+    return NativeResult.share(try ctx.invokeCallable(args[0], call_args[0..count_val]));
 }
 
-fn native_function_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_function_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const raw = args[0].string.bytes();
     const name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
-    if (ctx.vm.native_fns.contains(name)) return .{ .bool = true };
-    if (ctx.vm.functions.contains(name)) return .{ .bool = true };
-    return .{ .bool = false };
+    if (ctx.vm.native_fns.contains(name)) return NativeResult.scalar(.{ .bool = true });
+    if (ctx.vm.functions.contains(name)) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_get_object_vars(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_get_object_vars(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // closures are stored as name strings and report as 'object'/'Closure'
     // but have no user-visible properties - return empty array per PHP
     if (args.len > 0 and args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) {
         const empty = try ctx.createArray();
-        return .{ .array = empty };
+        return NativeResult.borrowed(.{ .array = empty });
     }
-    if (args.len == 0 or args[0] != .object) return Value{ .bool = false };
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(Value{ .bool = false });
     try ctx.vm.triggerLazyInit(args[0].object);
     const obj = args[0].object.storage();
     var arr = try ctx.createArray();
@@ -1140,7 +1140,7 @@ fn native_get_object_vars(ctx: *NativeContext, args: []const Value) RuntimeError
         if (vis == .protected and !can_see_protected) continue;
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(name) }, entry.value_ptr.*);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn propVisibility(class_def: ?@import("../runtime/vm.zig").ClassDef, name: []const u8) @import("../runtime/vm.zig").ClassDef.Visibility {
@@ -1191,14 +1191,14 @@ fn isInClassHierarchy(vm: *@import("../runtime/vm.zig").VM, candidate: []const u
     return false;
 }
 
-fn native_get_class_methods(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return Value{ .bool = false };
+fn native_get_class_methods(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(Value{ .bool = false });
     // closures (stored as name strings) report the standard Closure API
     if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) {
         var arr = try ctx.createArray();
         const methods = [_][]const u8{ "bind", "bindTo", "call", "fromCallable", "__invoke" };
         for (methods) |m| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(m) });
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
     const class_name = if (args[0] == .object)
         args[0].object.class_name
@@ -1209,19 +1209,19 @@ fn native_get_class_methods(ctx: *NativeContext, args: []const Value) RuntimeErr
     else if (args[0] == .string)
         args[0].string.bytes()
     else
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
 
     if (std.mem.eql(u8, class_name, "Generator")) {
         var arr = try ctx.createArray();
         const methods = [_][]const u8{ "rewind", "valid", "current", "key", "next", "send", "throw", "getReturn", "__debugInfo" };
         for (methods) |m| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(m) });
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
     if (std.mem.eql(u8, class_name, "Fiber")) {
         var arr = try ctx.createArray();
         const methods = [_][]const u8{ "__construct", "start", "resume", "throw", "isStarted", "isSuspended", "isRunning", "isTerminated", "getReturn", "getCurrent", "suspend" };
         for (methods) |m| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(m) });
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
     // visibility: caller in same class sees all; subclass sees public+protected;
@@ -1265,7 +1265,7 @@ fn native_get_class_methods(ctx: *NativeContext, args: []const Value) RuntimeErr
         } else break;
         depth += 1;
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
 fn isInClassChain(vm: *@import("../runtime/vm.zig").VM, a: []const u8, b: []const u8) bool {
@@ -1283,11 +1283,11 @@ fn isInClassChain(vm: *@import("../runtime/vm.zig").VM, a: []const u8, b: []cons
     return false;
 }
 
-fn native_get_class_vars(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return Value{ .bool = false };
+fn native_get_class_vars(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(Value{ .bool = false });
     const raw = args[0].string.bytes();
     const class_name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
-    const cls = ctx.vm.classes.get(class_name) orelse return Value{ .bool = false };
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(Value{ .bool = false });
     const caller = ctx.vm.currentDefiningClass();
     var arr = try ctx.createArray();
     for (cls.properties.items) |prop| {
@@ -1306,100 +1306,100 @@ fn native_get_class_vars(ctx: *NativeContext, args: []const Value) RuntimeError!
         if (cls.constant_names.contains(e.key_ptr.*)) continue;
         try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(e.key_ptr.*) }, e.value_ptr.*);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_get_parent_class(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_get_parent_class(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) {
         // no-arg form: use the calling class
-        const caller = ctx.vm.currentDefiningClass() orelse return Value{ .bool = false };
-        const cls = ctx.vm.classes.get(caller) orelse return Value{ .bool = false };
-        if (cls.parent) |p| return Value{ .string = Value.String.borrowed(p) };
-        return Value{ .bool = false };
+        const caller = ctx.vm.currentDefiningClass() orelse return NativeResult.scalar(Value{ .bool = false });
+        const cls = ctx.vm.classes.get(caller) orelse return NativeResult.scalar(Value{ .bool = false });
+        if (cls.parent) |p| return NativeResult.copyString(ctx.allocator, p);
+        return NativeResult.scalar(Value{ .bool = false });
     }
     // closures (string-form) report as Closure with no parent
     if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) {
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
     }
     const raw = if (args[0] == .object)
         args[0].object.class_name
     else if (args[0] == .string)
         args[0].string.bytes()
     else
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
     const class_name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
-    if (ctx.vm.traits.contains(class_name) or ctx.vm.interfaces.contains(class_name)) return .{ .bool = false };
+    if (ctx.vm.traits.contains(class_name) or ctx.vm.interfaces.contains(class_name)) return NativeResult.scalar(.{ .bool = false });
     const cls = ctx.vm.classes.get(class_name) orelse {
         try ctx.vm.setPendingException("TypeError", "get_parent_class(): Argument #1 ($object_or_class) must be an object or a valid class name");
         return error.RuntimeError;
     };
-    if (cls.parent) |p| return Value{ .string = Value.String.borrowed(p) };
-    return Value{ .bool = false };
+    if (cls.parent) |p| return NativeResult.copyString(ctx.allocator, p);
+    return NativeResult.scalar(Value{ .bool = false });
 }
 
-fn native_is_a(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_is_a(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const raw_target = args[1].string.bytes();
     const target = if (raw_target.len > 0 and raw_target[0] == '\\') raw_target[1..] else raw_target;
     if (args[0] == .generator) {
-        return .{ .bool = std.mem.eql(u8, target, "Generator") or std.mem.eql(u8, target, "Iterator") or std.mem.eql(u8, target, "Traversable") };
+        return NativeResult.scalar(.{ .bool = std.mem.eql(u8, target, "Generator") or std.mem.eql(u8, target, "Iterator") or std.mem.eql(u8, target, "Traversable") });
     }
-    if (args[0] == .fiber) return .{ .bool = std.mem.eql(u8, target, "Fiber") };
+    if (args[0] == .fiber) return NativeResult.scalar(.{ .bool = std.mem.eql(u8, target, "Fiber") });
     // closures stored as unique name strings present as object/Closure
     if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) {
-        return .{ .bool = std.mem.eql(u8, target, "Closure") };
+        return NativeResult.scalar(.{ .bool = std.mem.eql(u8, target, "Closure") });
     }
     if (args[0] == .string) {
         // string arg requires explicit allow_string=true (3rd arg)
         const allow_string = args.len >= 3 and args[2].isTruthy();
-        if (!allow_string) return .{ .bool = false };
-        return .{ .bool = ctx.vm.isInstanceOf(args[0].string.bytes(), target) };
+        if (!allow_string) return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .bool = ctx.vm.isInstanceOf(args[0].string.bytes(), target) });
     }
-    const class_name = if (args[0] == .object) args[0].object.class_name else return .{ .bool = false };
-    return .{ .bool = ctx.vm.isInstanceOf(class_name, target) };
+    const class_name = if (args[0] == .object) args[0].object.class_name else return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = ctx.vm.isInstanceOf(class_name, target) });
 }
 
-fn native_is_subclass_of(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[1] != .string) return .{ .bool = false };
+fn native_is_subclass_of(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     if (args[0] == .generator) {
         const t = args[1].string.bytes();
-        return .{ .bool = std.mem.eql(u8, t, "Iterator") or std.mem.eql(u8, t, "Traversable") };
+        return NativeResult.scalar(.{ .bool = std.mem.eql(u8, t, "Iterator") or std.mem.eql(u8, t, "Traversable") });
     }
-    if (args[0] == .fiber) return .{ .bool = false };
+    if (args[0] == .fiber) return NativeResult.scalar(.{ .bool = false });
     const class_name = if (args[0] == .object)
         args[0].object.class_name
     else if (args[0] == .string)
         args[0].string.bytes()
     else
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
     const target_name = args[1].string.bytes();
     ctx.vm.tryAutoload(class_name) catch {};
     ctx.vm.tryAutoload(target_name) catch {};
     // is_subclass_of returns false if same class, only true for actual subclasses
-    if (std.mem.eql(u8, class_name, target_name)) return .{ .bool = false };
-    return .{ .bool = ctx.vm.isInstanceOf(class_name, target_name) };
+    if (std.mem.eql(u8, class_name, target_name)) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = ctx.vm.isInstanceOf(class_name, target_name) });
 }
 
-fn native_spl_object_id(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return Value{ .int = 0 };
+fn native_spl_object_id(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(Value{ .int = 0 });
     if (args[0] == .object) {
         if (args[0].object.id == 0) {
             ctx.vm.next_object_id += 1;
             args[0].object.id = ctx.vm.next_object_id;
         }
-        return .{ .int = @intCast(args[0].object.id) };
+        return NativeResult.scalar(.{ .int = @intCast(args[0].object.id) });
     }
-    if (args[0] == .generator) return .{ .int = @intCast(@intFromPtr(args[0].generator)) };
-    if (args[0] == .fiber) return .{ .int = @intCast(@intFromPtr(args[0].fiber)) };
+    if (args[0] == .generator) return NativeResult.scalar(.{ .int = @intCast(@intFromPtr(args[0].generator)) });
+    if (args[0] == .fiber) return NativeResult.scalar(.{ .int = @intCast(@intFromPtr(args[0].fiber)) });
     // closures stored as unique name strings - mirror spl_object_hash by
     // using the string's pointer as the id
     if (args[0] == .string and std.mem.startsWith(u8, args[0].string.bytes(), "__closure_")) {
-        return .{ .int = @intCast(@intFromPtr(args[0].string.bytes().ptr)) };
+        return NativeResult.scalar(.{ .int = @intCast(@intFromPtr(args[0].string.bytes().ptr)) });
     }
-    return Value{ .int = 0 };
+    return NativeResult.scalar(Value{ .int = 0 });
 }
 
-fn native_exit(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_exit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len > 0) {
         if (args[0] == .string) {
             try ctx.vm.output.appendSlice(ctx.allocator, args[0].string.bytes());
@@ -1458,8 +1458,8 @@ fn tokenizeVersion(s: []const u8, out: *[16]VersionToken) usize {
     return tok_count;
 }
 
-fn native_version_compare(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .null;
+fn native_version_compare(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
     const v1 = args[0].string.bytes();
     const v2 = args[1].string.bytes();
 
@@ -1556,42 +1556,42 @@ fn native_version_compare(ctx: *NativeContext, args: []const Value) RuntimeError
             cmp != 0
         else
             false;
-        return .{ .bool = result };
+        return NativeResult.scalar(.{ .bool = result });
     }
 
     _ = ctx;
-    return .{ .int = cmp };
+    return NativeResult.scalar(.{ .int = cmp });
 }
 
-fn native_php_sapi_name(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed("cli") };
+fn native_php_sapi_name(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal("cli");
 }
 
-fn native_php_version(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed("8.4.1") };
+fn native_php_version(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal("8.4.1");
 }
 
-fn native_getmypid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(std.c.getpid()) };
+fn native_getmypid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(std.c.getpid()) });
 }
 
-fn native_getmyuid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(std.c.getuid()) };
+fn native_getmyuid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(std.c.getuid()) });
 }
 
 extern "c" fn getgid() c_uint;
 
-fn native_getmygid(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = @intCast(getgid()) };
+fn native_getmygid(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = @intCast(getgid()) });
 }
 
-fn native_get_cfg_var(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return Value{ .bool = false };
+fn native_get_cfg_var(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(Value{ .bool = false });
 }
 
 extern "c" fn getlogin() ?[*:0]const u8;
 
-fn native_get_current_user(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_current_user(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP returns the owner of the running script. for the CLI that's the
     // current process user; for SAPIs without that distinction, it's the
     // login. fall back to USER / LOGNAME env vars when the syscall returns
@@ -1599,21 +1599,17 @@ fn native_get_current_user(ctx: *NativeContext, _: []const Value) RuntimeError!V
     if (getlogin()) |raw| {
         const span = std.mem.span(raw);
         if (span.len > 0) {
-            const owned = try ctx.allocator.dupe(u8, span);
-            try ctx.strings.append(ctx.allocator, owned);
-            return .{ .string = Value.String.borrowed(owned) };
+            return NativeResult.copyString(ctx.allocator, span);
         }
     }
     inline for ([_][]const u8{ "USER", "LOGNAME" }) |key| {
         if (std.posix.getenv(key)) |val| {
             if (val.len > 0) {
-                const owned = try ctx.allocator.dupe(u8, val);
-                try ctx.strings.append(ctx.allocator, owned);
-                return .{ .string = Value.String.borrowed(owned) };
+                return NativeResult.copyString(ctx.allocator, val);
             }
         }
     }
-    return .{ .string = Value.String.borrowed("") };
+    return NativeResult.literal("");
 }
 
 fn iniDefault(name: []const u8) ?[]const u8 {
@@ -1661,20 +1657,21 @@ fn iniDefault(name: []const u8) ?[]const u8 {
     return null;
 }
 
-fn native_ini_get(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return Value{ .bool = false };
+fn native_ini_get(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(Value{ .bool = false });
     const name = args[0].string.bytes();
-    if (ctx.vm.ini_settings.get(name)) |stored| return .{ .string = Value.String.borrowed(stored) };
-    if (iniDefault(name)) |def| return .{ .string = Value.String.borrowed(def) };
-    return Value{ .bool = false };
+    if (ctx.vm.ini_settings.get(name)) |stored| return NativeResult.copyString(ctx.allocator, stored);
+    if (iniDefault(name)) |def| return NativeResult.copyString(ctx.allocator, def);
+    return NativeResult.scalar(Value{ .bool = false });
 }
 
-fn native_ini_set(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string) return Value{ .bool = false };
+fn native_ini_set(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string) return NativeResult.scalar(Value{ .bool = false });
     const name = args[0].string.bytes();
     // PHP rejects unknown directives. Only allow known names.
-    const previous: []const u8 = if (ctx.vm.ini_settings.get(name)) |s| s else if (iniDefault(name)) |d| d else return Value{ .bool = false };
+    const previous: []const u8 = if (ctx.vm.ini_settings.get(name)) |s| s else if (iniDefault(name)) |d| d else return NativeResult.scalar(Value{ .bool = false });
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     try args[1].format(&buf, ctx.allocator);
     const new_val = try buf.toOwnedSlice(ctx.allocator);
     try ctx.vm.strings.append(ctx.allocator, new_val);
@@ -1687,7 +1684,7 @@ fn native_ini_set(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         const seconds = std.fmt.parseInt(i64, std.mem.trim(u8, new_val, " \t\r\n"), 10) catch 0;
         ctx.vm.setExecutionLimit(seconds);
     }
-    return .{ .string = Value.String.borrowed(previous) };
+    return NativeResult.copyString(ctx.allocator, previous);
 }
 
 const SUPPORTED_EXTENSIONS = [_][]const u8{
@@ -1701,25 +1698,25 @@ const SUPPORTED_EXTENSIONS = [_][]const u8{
     "soap",      "zlib",       "posix",     "pcntl",     "random",
 };
 
-fn native_extension_loaded(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_extension_loaded(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     for (SUPPORTED_EXTENSIONS) |s| {
-        if (std.ascii.eqlIgnoreCase(name, s)) return .{ .bool = true };
+        if (std.ascii.eqlIgnoreCase(name, s)) return NativeResult.scalar(.{ .bool = true });
     }
     // also accept the historic "datetime" alias for "date"
-    if (std.ascii.eqlIgnoreCase(name, "datetime")) return .{ .bool = true };
-    return .{ .bool = false };
+    if (std.ascii.eqlIgnoreCase(name, "datetime")) return NativeResult.scalar(.{ .bool = true });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_get_loaded_extensions(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_loaded_extensions(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     for (SUPPORTED_EXTENSIONS) |s| try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_get_extension_funcs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_get_extension_funcs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     // not granular about which fn belongs to which extension - PHP code that
     // calls this typically just checks for non-false. return false for unknown
@@ -1727,43 +1724,43 @@ fn native_get_extension_funcs(ctx: *NativeContext, args: []const Value) RuntimeE
     // functions enumerable" behavior
     for (SUPPORTED_EXTENSIONS) |s| {
         if (std.ascii.eqlIgnoreCase(name, s)) {
-            return .{ .array = try ctx.createArray() };
+            return NativeResult.borrowed(.{ .array = try ctx.createArray() });
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_get_included_files(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_get_included_files(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     var arr = try ctx.createArray();
     var iter = ctx.vm.loaded_files.iterator();
     while (iter.next()) |entry| {
         try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(entry.key_ptr.*) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_register_shutdown_function(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .null;
-    VM.retainValue(args[0]);
+fn native_register_shutdown_function(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.null);
     try ctx.vm.shutdown_callbacks.append(ctx.allocator, args[0]);
-    return .null;
+    VM.retainValue(args[0]);
+    return NativeResult.scalar(.null);
 }
 
-fn native_memory_get_usage(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_memory_get_usage(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // pull current process RSS via getrusage. PHP distinguishes "current" from
     // "peak" usage; zphp's arena doesn't track byte-accurate current bytes per
     // call, so we report the OS-level resident-set peak. matches the common
     // "did memory grow?" check and stays monotonic, while giving a value that's
     // proportional to actual usage (unlike the previous 1024-byte stub)
     var usage: std.c.rusage = undefined;
-    if (std.c.getrusage(std.c.rusage.SELF, &usage) != 0) return .{ .int = 0 };
+    if (std.c.getrusage(std.c.rusage.SELF, &usage) != 0) return NativeResult.scalar(.{ .int = 0 });
     // ru_maxrss is bytes on macOS, kilobytes on Linux/BSD
     const builtin = @import("builtin");
     const mult: i64 = if (builtin.target.os.tag == .macos or builtin.target.os.tag == .ios) 1 else 1024;
-    return .{ .int = @as(i64, @intCast(usage.maxrss)) * mult };
+    return NativeResult.scalar(.{ .int = @as(i64, @intCast(usage.maxrss)) * mult });
 }
 
-fn native_set_error_handler(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_set_error_handler(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const prev = ctx.vm.user_error_handler orelse Value.null;
     if (ctx.vm.user_error_handler) |h| {
         try ctx.vm.error_handler_stack.append(ctx.allocator, .{ .handler = h, .mask = ctx.vm.user_error_handler_mask });
@@ -1774,20 +1771,19 @@ fn native_set_error_handler(ctx: *NativeContext, args: []const Value) RuntimeErr
     } else {
         ctx.vm.user_error_handler = null;
     }
-    ctx.returnShared(prev);
     ctx.vm.user_error_handler_mask = if (args.len >= 2 and args[1] == .int) args[1].int else -1;
-    return prev;
+    return NativeResult.share(prev);
 }
 
-fn native_error_clear_last(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_error_clear_last(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ctx.vm.last_error_type = 0;
     ctx.vm.last_error_message = "";
     ctx.vm.last_error_file = "";
     ctx.vm.last_error_line = 0;
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_set_exception_handler(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_set_exception_handler(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // push onto stack so restore_exception_handler can pop later. PHP
     // exposes a real LIFO of installed handlers - code that inventories the
     // active handlers by repeatedly calling set then restore spins forever
@@ -1800,34 +1796,33 @@ fn native_set_exception_handler(ctx: *NativeContext, args: []const Value) Runtim
     } else {
         ctx.vm.user_exception_handler = null;
     }
-    ctx.returnShared(prev);
-    return prev;
+    return NativeResult.share(prev);
 }
 
-fn native_get_error_handler(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return ctx.vm.user_error_handler orelse Value.null;
+fn native_get_error_handler(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.share(ctx.vm.user_error_handler orelse Value.null);
 }
 
-fn native_get_exception_handler(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return ctx.vm.user_exception_handler orelse Value.null;
+fn native_get_exception_handler(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.share(ctx.vm.user_exception_handler orelse Value.null);
 }
 
-fn native_eval(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    return ctx.vm.evalSource(args[0].string.bytes());
+fn native_eval(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    return NativeResult.transfer(try ctx.vm.evalSource(args[0].string.bytes()));
 }
 
-fn native_restore_exception_handler(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_restore_exception_handler(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     if (ctx.vm.user_exception_handler) |h| ctx.vm.releaseValue(h);
     if (ctx.vm.exception_handler_stack.items.len > 0) {
         ctx.vm.user_exception_handler = ctx.vm.exception_handler_stack.pop().?;
     } else {
         ctx.vm.user_exception_handler = null;
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_restore_error_handler(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_restore_error_handler(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     if (ctx.vm.user_error_handler) |h| ctx.vm.releaseValue(h);
     if (ctx.vm.error_handler_stack.items.len > 0) {
         const entry = ctx.vm.error_handler_stack.pop().?;
@@ -1837,14 +1832,14 @@ fn native_restore_error_handler(ctx: *NativeContext, _: []const Value) RuntimeEr
         ctx.vm.user_error_handler = null;
         ctx.vm.user_error_handler_mask = -1;
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_assert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = true };
+fn native_assert(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = true });
     const active = ctx.vm.ini_settings.get("assert.active") orelse "1";
-    if (std.mem.eql(u8, active, "0")) return .{ .bool = true };
-    if (args[0].isTruthy()) return .{ .bool = true };
+    if (std.mem.eql(u8, active, "0")) return NativeResult.scalar(.{ .bool = true });
+    if (args[0].isTruthy()) return NativeResult.scalar(.{ .bool = true });
     // a Throwable as the 2nd arg is always thrown on failure, regardless of assert.exception
     if (args.len >= 2 and args[1] == .object) {
         ctx.vm.pending_exception = args[1];
@@ -1863,15 +1858,15 @@ fn native_assert(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
         try ctx.vm.setPendingException("AssertionError", msg);
         return error.RuntimeError;
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_noop_true(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_noop_true(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_assert_options(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_assert_options(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const opt = Value.toInt(args[0]);
     const key: []const u8 = switch (opt) {
         1 => "assert.active",
@@ -1880,7 +1875,7 @@ fn native_assert_options(ctx: *NativeContext, args: []const Value) RuntimeError!
         4 => "assert.warning",
         5 => "assert.quiet_eval",
         6 => "assert.exception",
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     };
 
     // get previous value (defaults match PHP: ACTIVE=1, EXCEPTION=1, others=0)
@@ -1888,7 +1883,6 @@ fn native_assert_options(ctx: *NativeContext, args: []const Value) RuntimeError!
     if (opt == 2) {
         if (ctx.vm.ini_callbacks.get("assert.callback")) |cb| {
             prev = cb;
-            ctx.returnShared(prev);
         }
     } else {
         const default_v: i64 = if (opt == 1 or opt == 6) 1 else 0;
@@ -1898,6 +1892,8 @@ fn native_assert_options(ctx: *NativeContext, args: []const Value) RuntimeError!
         prev = .{ .int = std.fmt.parseInt(i64, s, 10) catch 0 };
     }
 
+    const result = NativeResult.share(prev);
+    errdefer if (result.value == .string) result.value.string.release();
     if (args.len >= 2) {
         if (opt == 2) {
             VM.retainValue(args[1]);
@@ -1906,7 +1902,7 @@ fn native_assert_options(ctx: *NativeContext, args: []const Value) RuntimeError!
         } else {
             var buf: [32]u8 = undefined;
             const v = Value.toInt(args[1]);
-            const s = std.fmt.bufPrint(&buf, "{d}", .{v}) catch return prev;
+            const s = std.fmt.bufPrint(&buf, "{d}", .{v}) catch return result;
             const owned = try ctx.allocator.dupe(u8, s);
             try ctx.vm.strings.append(ctx.allocator, owned);
             const key_owned = try ctx.allocator.dupe(u8, key);
@@ -1914,65 +1910,65 @@ fn native_assert_options(ctx: *NativeContext, args: []const Value) RuntimeError!
             try ctx.vm.ini_settings.put(ctx.allocator, key_owned, owned);
         }
     }
-    return prev;
+    return result;
 }
 
-fn native_noop_null(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn native_noop_null(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn native_noop_zero(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .int = 0 };
+fn native_noop_zero(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_gc_enabled(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = ctx.vm.gc_enabled };
+fn native_gc_enabled(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = ctx.vm.gc_enabled });
 }
 
-fn native_gc_disable(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_gc_disable(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ctx.vm.gc_enabled = false;
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_gc_enable(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_gc_enable(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ctx.vm.gc_enabled = true;
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_gc_collect_cycles(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_gc_collect_cycles(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const collected = ctx.vm.collectCycles();
-    return .{ .int = @intCast(collected) };
+    return NativeResult.scalar(.{ .int = @intCast(collected) });
 }
 
-fn native_noop_false(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = false };
+fn native_noop_false(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_ini_get_all(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_ini_get_all(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // returns an empty array - PHP returns a dict of all settings, but most
     // userland code just iterates it or queries specific keys (use ini_get)
-    return .{ .array = try ctx.createArray() };
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
-fn native_ini_restore(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn native_ini_restore(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn native_opcache_get_status(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_opcache_get_status(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("opcache_enabled") }, .{ .bool = false });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_opcache_get_configuration(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_opcache_get_configuration(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     const directives = try ctx.createArray();
     try directives.set(ctx.allocator, .{ .string = Value.String.borrowed("opcache.enable") }, .{ .bool = false });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("directives") }, .{ .array = directives });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_gc_status(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_gc_status(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // PHP 8.3+ adds several GC introspection keys (application_time,
     // collector_time, etc.). emit the full key set so callers that read
     // them via array access don't see undefined-index notices
@@ -1990,27 +1986,27 @@ fn native_gc_status(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("collector_time") }, .{ .float = 0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("destructor_time") }, .{ .float = 0 });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("free_time") }, .{ .float = 0 });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_highlight_string(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_highlight_string(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // PHP returns syntax-highlighted HTML; we return false (PHP errors on bad input
     // also return false, so this is safe as a "no-op" while still being callable)
     if (args.len >= 2 and args[1] == .bool and args[1].bool) {
-        if (args.len >= 1 and args[0] == .string) return args[0];
-        return .{ .string = Value.String.borrowed("") };
+        if (args.len >= 1 and args[0] == .string) return NativeResult.share(args[0]);
+        return NativeResult.literal("");
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_highlight_file(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .bool = true };
+fn native_highlight_file(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_strftime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_strftime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // strftime is deprecated since 8.1; we delegate to date() with a best-effort
     // format remap for the most common specifiers
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const fmt = args[0].string.bytes();
     const ts: Value = if (args.len >= 2) args[1] else try ctx.vm.callByName("time", &.{});
     var buf: std.ArrayListUnmanaged(u8) = .{};
@@ -2051,24 +2047,22 @@ fn native_strftime(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
         const r = try ctx.vm.callByName("date", &.{ .{ .string = Value.String.borrowed(mapped) }, ts });
         if (r == .string) try buf.appendSlice(ctx.allocator, r.string.bytes());
     }
-    const owned = try ctx.allocator.dupe(u8, buf.items);
-    try ctx.vm.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, try buf.toOwnedSlice(ctx.allocator)));
 }
 
-fn native_gmstrftime(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_gmstrftime(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return native_strftime(ctx, args);
 }
 
-fn native_getmxrr(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_getmxrr(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // empty MX array, return false (no records found) - matches PHP behavior
     // when MX query fails. tools that branch on this still work.
     _ = ctx;
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_spl_autoload_call(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
+fn native_spl_autoload_call(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const name = args[0].string.bytes();
     var i: usize = 0;
     while (i < ctx.vm.autoload_callbacks.items.len) : (i += 1) {
@@ -2076,10 +2070,10 @@ fn native_spl_autoload_call(ctx: *NativeContext, args: []const Value) RuntimeErr
         _ = ctx.invokeCallable(cb, &.{.{ .string = Value.String.borrowed(name) }}) catch {};
         if (ctx.vm.classes.contains(name)) break;
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_spl_classes(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_spl_classes(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     const names = [_][]const u8{
         "AppendIterator",                  "ArrayIterator",              "ArrayObject",              "BadFunctionCallException",
@@ -2097,40 +2091,40 @@ fn native_spl_classes(ctx: *NativeContext, _: []const Value) RuntimeError!Value 
         "SplStack",                        "SplTempFileObject",          "UnderflowException",       "UnexpectedValueException",
     };
     for (names) |n| try arr.set(ctx.allocator, .{ .string = Value.String.borrowed(n) }, .{ .string = Value.String.borrowed(n) });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_iconv_mime_decode(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_iconv_mime_decode(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // best-effort: return the input as-is, ignoring mime encoding
-    if (args.len == 0 or args[0] != .string) return .{ .string = Value.String.borrowed("") };
-    return args[0];
+    if (args.len == 0 or args[0] != .string) return NativeResult.literal("");
+    return NativeResult.share(args[0]);
 }
 
-fn native_iconv_mime_decode_headers(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .array = try ctx.createArray() };
-    return .{ .array = try ctx.createArray() };
+fn native_iconv_mime_decode_headers(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
-fn native_iconv_mime_encode(_: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_iconv_mime_encode(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // best-effort: emit "Header: value" unencoded
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    return args[1];
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(args[1]);
 }
 
-fn native_get_include_path(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed(".") };
+fn native_get_include_path(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal(".");
 }
 
-fn native_set_include_path(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .{ .string = Value.String.borrowed(".") };
+fn native_set_include_path(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.literal(".");
 }
 
-fn native_error_reporting(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_error_reporting(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const prev = ctx.vm.error_reporting_level;
     if (args.len > 0) {
         ctx.vm.error_reporting_level = Value.toInt(args[0]);
     }
-    return .{ .int = prev };
+    return NativeResult.scalar(.{ .int = prev });
 }
 
 // runtime helper emitted by the compiler for match-without-default. produces
@@ -2138,9 +2132,10 @@ fn native_error_reporting(ctx: *NativeContext, args: []const Value) RuntimeError
 //   int/float/bool/null  -> "Unhandled match case 99"
 //   string               -> "Unhandled match case 'hello'"
 //   array/object         -> "Unhandled match case of type array" / "...stdClass"
-fn native_match_unhandled_msg(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn native_match_unhandled_msg(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     const v = if (args.len > 0) args[0] else Value{ .null = {} };
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     try buf.appendSlice(ctx.allocator, "Unhandled match case ");
     switch (v) {
         .int => |i| try std.fmt.format(buf.writer(ctx.allocator), "{d}", .{i}),
@@ -2166,24 +2161,23 @@ fn native_match_unhandled_msg(ctx: *NativeContext, args: []const Value) RuntimeE
         .fiber => try buf.appendSlice(ctx.allocator, "of type Fiber"),
     }
     const owned = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, owned);
-    return .{ .string = Value.String.borrowed(owned) };
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, owned));
 }
 
-fn native_error_log(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_error_log(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const message = args[0].string.bytes();
     const msg_type: i64 = if (args.len >= 2) Value.toInt(args[1]) else 0;
     switch (msg_type) {
         3 => {
             // append to the file named by arg #3
-            if (args.len < 3 or args[2] != .string) return .{ .bool = false };
+            if (args.len < 3 or args[2] != .string) return NativeResult.scalar(.{ .bool = false });
             const path = args[2].string.bytes();
-            const f = std.fs.cwd().createFile(path, .{ .truncate = false }) catch return .{ .bool = false };
+            const f = std.fs.cwd().createFile(path, .{ .truncate = false }) catch return NativeResult.scalar(.{ .bool = false });
             defer f.close();
             f.seekFromEnd(0) catch {};
-            f.writeAll(message) catch return .{ .bool = false };
-            return .{ .bool = true };
+            f.writeAll(message) catch return NativeResult.scalar(.{ .bool = false });
+            return NativeResult.scalar(.{ .bool = true });
         },
         else => {
             // type 0 (system logger) / 4 (SAPI) - PHP's CLI SAPI writes to
@@ -2196,15 +2190,15 @@ fn native_error_log(ctx: *NativeContext, args: []const Value) RuntimeError!Value
                 vm.output.clearRetainingCapacity();
             }
             const stderr_file = std.fs.File{ .handle = 2 };
-            stderr_file.writeAll(message) catch return .{ .bool = false };
+            stderr_file.writeAll(message) catch return NativeResult.scalar(.{ .bool = false });
             stderr_file.writeAll("\n") catch {};
-            return .{ .bool = true };
+            return NativeResult.scalar(.{ .bool = true });
         },
     }
 }
 
-fn native_trigger_error(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_trigger_error(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const message = args[0].string.bytes();
     const errno: i64 = if (args.len >= 2) Value.toInt(args[1]) else 1024; // E_USER_NOTICE
 
@@ -2238,7 +2232,7 @@ fn native_trigger_error(ctx: *NativeContext, args: []const Value) RuntimeError!V
             };
             const result = try ctx.invokeCallable(handler, call_args);
             // returning false (or null in PHP 8+) lets the default handler run
-            if (result != .bool or result.bool) return .{ .bool = true };
+            if (result != .bool or result.bool) return NativeResult.scalar(.{ .bool = true });
         }
     }
 
@@ -2256,17 +2250,17 @@ fn native_trigger_error(ctx: *NativeContext, args: []const Value) RuntimeError!V
             _ = stdout_file.write(ctx.vm.output.items) catch {};
             ctx.vm.output.clearRetainingCapacity();
         }
-        const stderr_text = std.fmt.allocPrint(ctx.allocator, "PHP {s}:  {s} in {s} on line {d}\n", .{ label, message, file, line }) catch return Value{ .bool = true };
-        try ctx.vm.strings.append(ctx.allocator, stderr_text);
+        const stderr_text = std.fmt.allocPrint(ctx.allocator, "PHP {s}:  {s} in {s} on line {d}\n", .{ label, message, file, line }) catch return NativeResult.scalar(Value{ .bool = true });
+        defer ctx.allocator.free(stderr_text);
         const stderr_file = std.fs.File{ .handle = 2 };
         _ = stderr_file.write(stderr_text) catch {};
         if (ctx.vm.displayErrorsEnabled()) {
-            const stdout_text = std.fmt.allocPrint(ctx.allocator, "\n{s}: {s} in {s} on line {d}\n", .{ label, message, file, line }) catch return Value{ .bool = true };
-            try ctx.vm.strings.append(ctx.allocator, stdout_text);
+            const stdout_text = std.fmt.allocPrint(ctx.allocator, "\n{s}: {s} in {s} on line {d}\n", .{ label, message, file, line }) catch return NativeResult.scalar(Value{ .bool = true });
+            defer ctx.allocator.free(stdout_text);
             try ctx.vm.output.appendSlice(ctx.allocator, stdout_text);
         }
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn errnoLabel(errno: i64) []const u8 {
@@ -2286,23 +2280,23 @@ fn errnoLabel(errno: i64) []const u8 {
     };
 }
 
-fn native_error_get_last(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    if (ctx.vm.last_error_type == 0) return .null;
+fn native_error_get_last(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    if (ctx.vm.last_error_type == 0) return NativeResult.scalar(.null);
     var arr = try ctx.createArray();
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("type") }, .{ .int = ctx.vm.last_error_type });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("message") }, .{ .string = Value.String.borrowed(ctx.vm.last_error_message) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("file") }, .{ .string = Value.String.borrowed(ctx.vm.last_error_file) });
     try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("line") }, .{ .int = ctx.vm.last_error_line });
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_class_alias(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
+fn native_class_alias(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const original = args[0].string.bytes();
     const alias = args[1].string.bytes();
     const autoload = if (args.len >= 3) args[2].isTruthy() else true;
     if (autoload and !ctx.vm.classes.contains(original)) {
-        ctx.vm.tryAutoload(original) catch return Value{ .bool = false };
+        ctx.vm.tryAutoload(original) catch return NativeResult.scalar(.{ .bool = false });
     }
     if (ctx.vm.classes.get(original)) |cls| {
         var alias_def = ClassDef{ .name = alias, .parent = original };
@@ -2320,30 +2314,28 @@ fn native_class_alias(ctx: *NativeContext, args: []const Value) RuntimeError!Val
         // don't register alias::method in functions map - resolveMethod walks
         // the parent chain and must find the original class name for correct
         // private visibility checks in currentDefiningClass
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_spl_autoload_register(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
-    VM.retainValue(args[0]);
+fn native_spl_autoload_register(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     try ctx.vm.autoload_callbacks.append(ctx.allocator, args[0]);
-    return .{ .bool = true };
+    VM.retainValue(args[0]);
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn native_spl_autoload_functions(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    var arr = try ctx.allocator.create(PhpArray);
-    arr.* = .{};
-    try ctx.vm.arrays.append(ctx.allocator, arr);
+fn native_spl_autoload_functions(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const arr = try ctx.createArray();
     for (ctx.vm.autoload_callbacks.items) |cb| {
         try arr.append(ctx.allocator, cb);
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_spl_autoload_unregister(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_spl_autoload_unregister(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const target = args[0];
     var i: usize = 0;
     while (i < ctx.vm.autoload_callbacks.items.len) {
@@ -2355,7 +2347,7 @@ fn native_spl_autoload_unregister(ctx: *NativeContext, args: []const Value) Runt
             i += 1;
         }
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
 fn callablesEqual(a: Value, b: Value) bool {
@@ -2387,18 +2379,18 @@ fn getFrameParamValue(frame: anytype, slot_names: []const []const u8, param: []c
     return frame.vars.get(param) orelse .null;
 }
 
-fn native_func_get_args(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_func_get_args(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
 
     if (ctx.vm.getFrameArgs()) |saved_args| {
         for (saved_args) |val| {
             try arr.append(ctx.allocator, val);
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
     const frame = ctx.vm.currentFrame();
-    const func = frame.func orelse return .{ .array = arr };
+    const func = frame.func orelse return NativeResult.borrowed(.{ .array = arr });
     const slot_names = func.slot_names;
     const actual_ac: usize = if (ctx.vm.getFrameArgCount()) |ac| ac else func.arity;
 
@@ -2420,14 +2412,14 @@ fn native_func_get_args(ctx: *NativeContext, _: []const Value) RuntimeError!Valu
             try arr.append(ctx.allocator, val);
         }
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_func_num_args(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_func_num_args(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const frame = ctx.vm.currentFrame();
-    const func = frame.func orelse return .{ .int = 0 };
+    const func = frame.func orelse return NativeResult.scalar(.{ .int = 0 });
 
-    if (ctx.vm.getFrameArgCount()) |ac| return .{ .int = @intCast(ac) };
+    if (ctx.vm.getFrameArgCount()) |ac| return NativeResult.scalar(.{ .int = @intCast(ac) });
 
     if (func.is_variadic) {
         const fixed: usize = func.arity - 1;
@@ -2437,86 +2429,86 @@ fn native_func_num_args(ctx: *NativeContext, _: []const Value) RuntimeError!Valu
         if (variadic_val == .array) {
             total += variadic_val.array.length();
         }
-        return .{ .int = total };
+        return NativeResult.scalar(.{ .int = total });
     }
-    return .{ .int = @intCast(func.arity) };
+    return NativeResult.scalar(.{ .int = @intCast(func.arity) });
 }
 
-fn native_func_get_arg(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_func_get_arg(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const idx = Value.toInt(args[0]);
-    if (idx < 0) return .{ .bool = false };
+    if (idx < 0) return NativeResult.scalar(.{ .bool = false });
     const index: usize = @intCast(idx);
 
     if (ctx.vm.getFrameArgs()) |saved_args| {
-        if (index < saved_args.len) return saved_args[index];
-        return .{ .bool = false };
+        if (index < saved_args.len) return NativeResult.share(saved_args[index]);
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     const frame = ctx.vm.currentFrame();
-    const func = frame.func orelse return .{ .bool = false };
+    const func = frame.func orelse return NativeResult.scalar(.{ .bool = false });
     const slot_names = func.slot_names;
 
     if (func.is_variadic) {
         const fixed: usize = func.arity - 1;
         if (index < fixed) {
-            return getFrameParamValue(frame, slot_names, func.params[index]);
+            return NativeResult.share(getFrameParamValue(frame, slot_names, func.params[index]));
         }
         const variadic_val = getFrameParamValue(frame, slot_names, func.params[fixed]);
         if (variadic_val == .array) {
             const vi: i64 = @intCast(index - fixed);
             const result = variadic_val.array.get(.{ .int = vi });
-            if (result != .null) return result;
+            if (result != .null) return NativeResult.share(result);
         }
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
 
-    if (index >= func.arity) return .{ .bool = false };
-    return getFrameParamValue(frame, slot_names, func.params[index]);
+    if (index >= func.arity) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(getFrameParamValue(frame, slot_names, func.params[index]));
 }
 
-fn native_interface_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_interface_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const raw = args[0].string.bytes();
     const name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
-    if (ctx.vm.interfaces.contains(name)) return .{ .bool = true };
+    if (ctx.vm.interfaces.contains(name)) return NativeResult.scalar(.{ .bool = true });
     const autoload = if (args.len > 1 and args[1] == .bool) args[1].bool else true;
     if (autoload) {
         ctx.vm.tryAutoload(name) catch {};
-        return .{ .bool = ctx.vm.interfaces.contains(name) };
+        return NativeResult.scalar(.{ .bool = ctx.vm.interfaces.contains(name) });
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_enum_exists(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .bool = false };
+fn native_enum_exists(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     if (ctx.vm.classes.get(name)) |cls| {
-        if (cls.is_enum) return .{ .bool = true };
+        if (cls.is_enum) return NativeResult.scalar(.{ .bool = true });
     }
     const autoload = if (args.len > 1 and args[1] == .bool) args[1].bool else true;
     if (autoload) {
         ctx.vm.tryAutoload(name) catch {};
         if (ctx.vm.classes.get(name)) |cls| {
-            return .{ .bool = cls.is_enum };
+            return NativeResult.scalar(.{ .bool = cls.is_enum });
         }
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_class_implements(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_class_implements(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const raw = if (args[0] == .object)
         args[0].object.class_name
     else if (args[0] == .string)
         args[0].string.bytes()
     else
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
     const class_name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
 
     const cls = ctx.vm.classes.get(class_name);
     const interface = ctx.vm.interfaces.get(class_name);
-    if (cls == null and interface == null and !ctx.vm.traits.contains(class_name)) return .{ .bool = false };
+    if (cls == null and interface == null and !ctx.vm.traits.contains(class_name)) return NativeResult.scalar(.{ .bool = false });
 
     var result = try ctx.createArray();
     var queue = std.ArrayListUnmanaged([]const u8){};
@@ -2566,22 +2558,22 @@ fn native_class_implements(ctx: *NativeContext, args: []const Value) RuntimeErro
         }
     }
 
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_class_parents(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_class_parents(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const raw = if (args[0] == .object)
         args[0].object.class_name
     else if (args[0] == .string)
         args[0].string.bytes()
     else
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
     const class_name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
 
     const cls = ctx.vm.classes.get(class_name) orelse {
         try ctx.vm.tryAutoload(class_name);
-        if (ctx.vm.classes.get(class_name) == null) return Value{ .bool = false };
+        if (ctx.vm.classes.get(class_name) == null) return NativeResult.scalar(Value{ .bool = false });
         const normalized = [_]Value{.{ .string = Value.String.borrowed(class_name) }};
         return native_class_parents(ctx, &normalized);
     };
@@ -2594,22 +2586,22 @@ fn native_class_parents(ctx: *NativeContext, args: []const Value) RuntimeError!V
         parent = pcls.parent;
     }
 
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_class_uses(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_class_uses(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     const raw = if (args[0] == .object)
         args[0].object.class_name
     else if (args[0] == .string)
         args[0].string.bytes()
     else
-        return Value{ .bool = false };
+        return NativeResult.scalar(Value{ .bool = false });
     const class_name = if (raw.len > 0 and raw[0] == '\\') raw[1..] else raw;
 
     if (!ctx.vm.classes.contains(class_name) and !ctx.vm.traits.contains(class_name) and !ctx.vm.interfaces.contains(class_name)) {
         if (args.len < 2 or args[1].isTruthy()) try ctx.vm.tryAutoload(class_name);
-        if (!ctx.vm.classes.contains(class_name) and !ctx.vm.traits.contains(class_name) and !ctx.vm.interfaces.contains(class_name)) return .{ .bool = false };
+        if (!ctx.vm.classes.contains(class_name) and !ctx.vm.traits.contains(class_name) and !ctx.vm.interfaces.contains(class_name)) return NativeResult.scalar(.{ .bool = false });
     }
     const used_traits = if (ctx.vm.classes.get(class_name)) |cls|
         cls.used_traits.items
@@ -2620,13 +2612,13 @@ fn native_class_uses(ctx: *NativeContext, args: []const Value) RuntimeError!Valu
     for (used_traits) |trait| {
         try result.set(ctx.allocator, .{ .string = Value.String.borrowed(trait) }, .{ .string = Value.String.borrowed(trait) });
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_iterator_to_array(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .array = try ctx.createArray() };
+fn native_iterator_to_array(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 
-    if (args[0] == .array) return args[0];
+    if (args[0] == .array) return NativeResult.borrowed(args[0]);
     const preserve_keys = if (args.len > 1 and args[1] == .bool) args[1].bool else true;
 
     if (args[0] == .generator) {
@@ -2637,7 +2629,7 @@ fn native_iterator_to_array(ctx: *NativeContext, args: []const Value) RuntimeErr
 
         while (gen.state != .completed) {
             if (preserve_keys) {
-                try arr.set(ctx.allocator, switch (gen.current_key) {
+                try ctx.vm.arraySetOwned(arr, switch (gen.current_key) {
                     .int => |i| .{ .int = i },
                     .string => |s| .{ .string = s },
                     else => .{ .int = arr.length() },
@@ -2647,7 +2639,7 @@ fn native_iterator_to_array(ctx: *NativeContext, args: []const Value) RuntimeErr
             }
             try ctx.vm.resumeGenerator(gen, .null);
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
     if (args[0] == .object) {
@@ -2667,15 +2659,17 @@ fn native_iterator_to_array(ctx: *NativeContext, args: []const Value) RuntimeErr
             return native_iterator_to_array(ctx, inner_args[0..n]);
         }
         const has_traversal = ctx.vm.hasMethod(obj.class_name, "rewind") and ctx.vm.hasMethod(obj.class_name, "valid") and ctx.vm.hasMethod(obj.class_name, "current");
-        if (!is_iterator and !has_traversal) return .{ .array = arr };
-        if (!ctx.vm.hasMethod(obj.class_name, "rewind")) return .{ .array = arr };
+        if (!is_iterator and !has_traversal) return NativeResult.borrowed(.{ .array = arr });
+        if (!ctx.vm.hasMethod(obj.class_name, "rewind")) return NativeResult.borrowed(.{ .array = arr });
         _ = try ctx.vm.callMethod(obj, "rewind", &.{});
         var valid_v = try ctx.vm.callMethod(obj, "valid", &.{});
         while (valid_v.isTruthy()) {
             const cur = try ctx.vm.callMethod(obj, "current", &.{});
+            if (cur == .string) cur.string.retain();
+            defer if (cur == .string) cur.string.release();
             if (preserve_keys) {
                 const key = try ctx.vm.callMethod(obj, "key", &.{});
-                try arr.set(ctx.allocator, switch (key) {
+                try ctx.vm.arraySetOwned(arr, switch (key) {
                     .int => |i| .{ .int = i },
                     .string => |s| .{ .string = s },
                     else => .{ .int = arr.length() },
@@ -2686,16 +2680,16 @@ fn native_iterator_to_array(ctx: *NativeContext, args: []const Value) RuntimeErr
             _ = try ctx.vm.callMethod(obj, "next", &.{});
             valid_v = try ctx.vm.callMethod(obj, "valid", &.{});
         }
-        return .{ .array = arr };
+        return NativeResult.borrowed(.{ .array = arr });
     }
 
-    return .{ .array = try ctx.createArray() };
+    return NativeResult.borrowed(.{ .array = try ctx.createArray() });
 }
 
-fn native_iterator_count(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .int = 0 };
+fn native_iterator_count(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .int = 0 });
 
-    if (args[0] == .array) return .{ .int = args[0].array.length() };
+    if (args[0] == .array) return NativeResult.scalar(.{ .int = args[0].array.length() });
 
     if (args[0] == .generator) {
         const gen = args[0].generator;
@@ -2707,7 +2701,7 @@ fn native_iterator_count(ctx: *NativeContext, args: []const Value) RuntimeError!
             n += 1;
             try ctx.vm.resumeGenerator(gen, .null);
         }
-        return .{ .int = n };
+        return NativeResult.scalar(.{ .int = n });
     }
 
     if (args[0] == .object) {
@@ -2723,10 +2717,10 @@ fn native_iterator_count(ctx: *NativeContext, args: []const Value) RuntimeError!
                     n += 1;
                     try ctx.vm.resumeGenerator(gen, .null);
                 }
-                return .{ .int = n };
+                return NativeResult.scalar(.{ .int = n });
             }
         }
-        if (!ctx.vm.hasMethod(obj.class_name, "rewind")) return .{ .int = 0 };
+        if (!ctx.vm.hasMethod(obj.class_name, "rewind")) return NativeResult.scalar(.{ .int = 0 });
         _ = try ctx.vm.callMethod(obj, "rewind", &.{});
         var n: i64 = 0;
         while (true) {
@@ -2735,14 +2729,14 @@ fn native_iterator_count(ctx: *NativeContext, args: []const Value) RuntimeError!
             n += 1;
             _ = try ctx.vm.callMethod(obj, "next", &.{});
         }
-        return .{ .int = n };
+        return NativeResult.scalar(.{ .int = n });
     }
 
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_iterator_apply(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2) return .{ .int = 0 };
+fn native_iterator_apply(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2) return NativeResult.scalar(.{ .int = 0 });
 
     var tmp_buf: ?[]Value = null;
     defer if (tmp_buf) |b| ctx.allocator.free(b);
@@ -2765,7 +2759,7 @@ fn native_iterator_apply(ctx: *NativeContext, args: []const Value) RuntimeError!
             if (!r.isTruthy()) break;
             try ctx.vm.resumeGenerator(gen, .null);
         }
-        return .{ .int = n };
+        return NativeResult.scalar(.{ .int = n });
     }
 
     if (args[0] == .array) {
@@ -2775,7 +2769,7 @@ fn native_iterator_apply(ctx: *NativeContext, args: []const Value) RuntimeError!
             n += 1;
             if (!r.isTruthy()) break;
         }
-        return .{ .int = n };
+        return NativeResult.scalar(.{ .int = n });
     }
 
     if (args[0] == .object) {
@@ -2806,15 +2800,15 @@ fn native_iterator_apply(ctx: *NativeContext, args: []const Value) RuntimeError!
                 if (!r.isTruthy()) break;
                 _ = try ctx.vm.callMethod(obj, "next", &.{});
             }
-            return .{ .int = n };
+            return NativeResult.scalar(.{ .int = n });
         }
     }
 
-    return .{ .int = 0 };
+    return NativeResult.scalar(.{ .int = 0 });
 }
 
-fn native_filter_id(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn native_filter_id(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const name = args[0].string.bytes();
     // PHP's filter_id maps a filter name to its numeric ID (matches the
     // FILTER_VALIDATE_*/FILTER_SANITIZE_* / FILTER_DEFAULT constants)
@@ -2843,11 +2837,11 @@ fn native_filter_id(_: *NativeContext, args: []const Value) RuntimeError!Value {
         .{ .name = "unsafe_html", .id = 521 },
         .{ .name = "callback", .id = 1024 },
     };
-    for (filters) |f| if (std.mem.eql(u8, f.name, name)) return .{ .int = f.id };
-    return .{ .bool = false };
+    for (filters) |f| if (std.mem.eql(u8, f.name, name)) return NativeResult.scalar(.{ .int = f.id });
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_filter_list(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_filter_list(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const arr = try ctx.createArray();
     const names = [_][]const u8{
         "int",          "boolean",        "float",         "validate_regexp",    "validate_domain",
@@ -2860,32 +2854,32 @@ fn native_filter_list(ctx: *NativeContext, _: []const Value) RuntimeError!Value 
     while (i < names.len) : (i += 1) {
         try arr.set(ctx.allocator, .{ .int = @intCast(i) }, .{ .string = Value.String.borrowed(names[i]) });
     }
-    return .{ .array = arr };
+    return NativeResult.borrowed(.{ .array = arr });
 }
 
-fn native_filter_has_var(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_filter_has_var(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // filter_has_var inspects INPUT_* superglobals which zphp populates per
     // request. for the CLI / generic context, returning false is the safest
     // PHP-compatible answer
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_filter_input(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn native_filter_input(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // CLI / no-request context: no INPUT_* values to read, return null
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
-fn native_filter_input_array(_: *NativeContext, _: []const Value) RuntimeError!Value {
-    return .null;
+fn native_filter_input_array(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return NativeResult.scalar(.null);
 }
 
-fn native_filter_var_array(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .array) return .{ .bool = false };
+fn native_filter_var_array(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.{ .bool = false });
     const data = args[0].array;
     const result = try ctx.createArray();
     if (args.len < 2 or args[1] != .array) {
         for (data.entries.items) |entry| try result.set(ctx.allocator, entry.key, entry.value);
-        return .{ .array = result };
+        return NativeResult.borrowed(.{ .array = result });
     }
     const rules = args[1].array;
     for (rules.entries.items) |rule_entry| {
@@ -2893,9 +2887,10 @@ fn native_filter_var_array(ctx: *NativeContext, args: []const Value) RuntimeErro
         const data_v = data.get(key);
         const sub_args = [_]Value{ data_v, rule_entry.value };
         const filtered = try native_filter_var(ctx, &sub_args);
-        try result.set(ctx.allocator, key, filtered);
+        defer if (filtered.value == .string) filtered.value.string.release();
+        try result.set(ctx.allocator, key, filtered.value);
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
 // validates the integer part of a thousands-separated number: an optional
@@ -2925,13 +2920,13 @@ fn validThousandGrouping(s: []const u8) bool {
     return true;
 }
 
-fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
+fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     const value = args[0];
 
-    if (args.len < 2) return value;
+    if (args.len < 2) return NativeResult.share(value);
 
-    const filter = if (args[1] == .int) args[1].int else return .{ .bool = false };
+    const filter = if (args[1] == .int) args[1].int else return NativeResult.scalar(.{ .bool = false });
     const flags: i64 = if (args.len > 2 and args[2] == .int) args[2].int else 0;
 
     // resolve options array if 3rd arg is array: ["options" => [...], "flags" => ...]
@@ -2959,55 +2954,57 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
     const force_array = (eff_flags & 0x04000000) != 0; // FILTER_FORCE_ARRAY
     if (require_array or force_array) {
         if (value != .array) {
-            if (require_array) return fail_default;
+            if (require_array) return NativeResult.share(fail_default);
             // force_array wraps scalar
             const out = try _ctx.createArray();
             const single_flags = eff_flags & ~@as(i64, 0x05000000);
             const sub_args = [_]Value{ value, args[1], .{ .int = single_flags } };
             const filtered = try native_filter_var(_ctx, &sub_args);
-            try out.append(_ctx.allocator, filtered);
-            return .{ .array = out };
+            defer if (filtered.value == .string) filtered.value.string.release();
+            try out.append(_ctx.allocator, filtered.value);
+            return NativeResult.borrowed(.{ .array = out });
         }
         const out = try _ctx.createArray();
         const single_flags = eff_flags & ~@as(i64, 0x05000000);
         for (value.array.entries.items) |e| {
             const sub_args = [_]Value{ e.value, args[1], .{ .int = single_flags } };
             const filtered = try native_filter_var(_ctx, &sub_args);
+            defer if (filtered.value == .string) filtered.value.string.release();
             try out.set(_ctx.allocator, switch (e.key) {
                 .int => |i| .{ .int = i },
                 .string => |s| .{ .string = s },
-            }, filtered);
+            }, filtered.value);
         }
-        return .{ .array = out };
+        return NativeResult.borrowed(.{ .array = out });
     }
 
     switch (filter) {
         275 => { // FILTER_VALIDATE_IP
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
             const ipv4_only = (flags & 1048576) != 0;
             const ipv6_only = (flags & 2097152) != 0;
             const no_priv = (flags & 8388608) != 0;
             const no_res = (flags & 4194304) != 0;
             if (!ipv6_only and isValidIPv4(s)) {
-                if (no_priv and isPrivateIPv4(s)) return .{ .bool = false };
-                if (no_res and isReservedIPv4(s)) return .{ .bool = false };
-                return value;
+                if (no_priv and isPrivateIPv4(s)) return NativeResult.scalar(.{ .bool = false });
+                if (no_res and isReservedIPv4(s)) return NativeResult.scalar(.{ .bool = false });
+                return NativeResult.share(value);
             }
-            if (ipv4_only) return .{ .bool = false };
-            if (!ipv4_only and isValidIPv6(s)) return value;
-            return .{ .bool = false };
+            if (ipv4_only) return NativeResult.scalar(.{ .bool = false });
+            if (!ipv4_only and isValidIPv6(s)) return NativeResult.share(value);
+            return NativeResult.scalar(.{ .bool = false });
         },
         274 => { // FILTER_VALIDATE_EMAIL
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
             if (std.mem.indexOf(u8, s, "@")) |at| {
-                if (at > 0 and at < s.len - 1 and std.mem.indexOf(u8, s[at + 1 ..], ".") != null) return value;
+                if (at > 0 and at < s.len - 1 and std.mem.indexOf(u8, s[at + 1 ..], ".") != null) return NativeResult.share(value);
             }
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         },
         273 => { // FILTER_VALIDATE_URL
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
-            if (std.mem.startsWith(u8, s, "http://") or std.mem.startsWith(u8, s, "https://") or std.mem.startsWith(u8, s, "ftp://")) return value;
-            return .{ .bool = false };
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
+            if (std.mem.startsWith(u8, s, "http://") or std.mem.startsWith(u8, s, "https://") or std.mem.startsWith(u8, s, "ftp://")) return NativeResult.share(value);
+            return NativeResult.scalar(.{ .bool = false });
         },
         257 => { // FILTER_VALIDATE_INT
             const allow_octal = (eff_flags & 1) != 0; // FILTER_FLAG_ALLOW_OCTAL
@@ -3020,13 +3017,13 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                 // filter: true->"1"->1, false->""->fail, 3.0->"3"->3, 3.7->fail
                 const s: []const u8 = if (value == .string) value.string.bytes() else sblk: {
                     if (value == .bool or value == .float) {
-                        value.format(&str_buf, _ctx.allocator) catch return fail_default;
+                        value.format(&str_buf, _ctx.allocator) catch return NativeResult.share(fail_default);
                         break :sblk str_buf.items;
                     }
-                    return fail_default;
+                    return NativeResult.share(fail_default);
                 };
                 const trimmed = std.mem.trim(u8, s, " \t\n\r");
-                if (trimmed.len == 0) return fail_default;
+                if (trimmed.len == 0) return NativeResult.share(fail_default);
                 // optional sign
                 var rest = trimmed;
                 var sign: i64 = 1;
@@ -3036,39 +3033,39 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                     sign = -1;
                     rest = rest[1..];
                 }
-                if (rest.len == 0) return fail_default;
+                if (rest.len == 0) return NativeResult.share(fail_default);
                 // hex with ALLOW_HEX
                 if (allow_hex and rest.len > 2 and rest[0] == '0' and (rest[1] == 'x' or rest[1] == 'X')) {
-                    const v = std.fmt.parseInt(i64, rest[2..], 16) catch return fail_default;
+                    const v = std.fmt.parseInt(i64, rest[2..], 16) catch return NativeResult.share(fail_default);
                     break :blk sign * v;
                 }
                 // octal with ALLOW_OCTAL, "0o" prefix
                 if (allow_octal and rest.len > 2 and rest[0] == '0' and (rest[1] == 'o' or rest[1] == 'O')) {
-                    const v = std.fmt.parseInt(i64, rest[2..], 8) catch return fail_default;
+                    const v = std.fmt.parseInt(i64, rest[2..], 8) catch return NativeResult.share(fail_default);
                     break :blk sign * v;
                 }
                 // octal with ALLOW_OCTAL ("0" prefix)
                 if (allow_octal and rest.len > 1 and rest[0] == '0' and std.ascii.isDigit(rest[1])) {
-                    const v = std.fmt.parseInt(i64, rest[1..], 8) catch return fail_default;
+                    const v = std.fmt.parseInt(i64, rest[1..], 8) catch return NativeResult.share(fail_default);
                     break :blk sign * v;
                 }
                 // default: decimal, reject leading-zero ints (except plain "0")
-                if (rest.len > 1 and rest[0] == '0') return fail_default;
-                if (!std.ascii.isDigit(rest[0])) return fail_default;
-                const parsed = std.fmt.parseInt(i64, rest, 10) catch return fail_default;
+                if (rest.len > 1 and rest[0] == '0') return NativeResult.share(fail_default);
+                if (!std.ascii.isDigit(rest[0])) return NativeResult.share(fail_default);
+                const parsed = std.fmt.parseInt(i64, rest, 10) catch return NativeResult.share(fail_default);
                 break :blk sign * parsed;
             };
             if (opts_arr) |opts| {
                 const min_v = opts.get(.{ .string = Value.String.borrowed("min_range") });
-                if (min_v != .null and n < Value.toInt(min_v)) return fail_default;
+                if (min_v != .null and n < Value.toInt(min_v)) return NativeResult.share(fail_default);
                 const max_v = opts.get(.{ .string = Value.String.borrowed("max_range") });
-                if (max_v != .null and n > Value.toInt(max_v)) return fail_default;
+                if (max_v != .null and n > Value.toInt(max_v)) return NativeResult.share(fail_default);
             }
-            return .{ .int = n };
+            return NativeResult.scalar(.{ .int = n });
         },
         259 => { // FILTER_VALIDATE_FLOAT
-            if (value == .float or value == .int) return value;
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
+            if (value == .float or value == .int) return NativeResult.share(value);
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
             const trimmed = std.mem.trim(u8, s, " ");
             var parse_src: []const u8 = trimmed;
             var cleaned = std.ArrayListUnmanaged(u8){};
@@ -3076,53 +3073,53 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
             if (std.mem.indexOfScalar(u8, trimmed, ',') != null) {
                 // a ',' is only valid with FILTER_FLAG_ALLOW_THOUSAND, and only
                 // as a \d{1,3}(,\d{3})* grouping in the integer part
-                if ((eff_flags & 8192) == 0) return .{ .bool = false };
-                if (!validThousandGrouping(trimmed)) return .{ .bool = false };
+                if ((eff_flags & 8192) == 0) return NativeResult.scalar(.{ .bool = false });
+                if (!validThousandGrouping(trimmed)) return NativeResult.scalar(.{ .bool = false });
                 for (trimmed) |c| {
-                    if (c != ',') cleaned.append(_ctx.allocator, c) catch return .{ .bool = false };
+                    if (c != ',') cleaned.append(_ctx.allocator, c) catch return NativeResult.scalar(.{ .bool = false });
                 }
                 parse_src = cleaned.items;
             }
-            const f = std.fmt.parseFloat(f64, parse_src) catch return .{ .bool = false };
-            return .{ .float = f };
+            const f = std.fmt.parseFloat(f64, parse_src) catch return NativeResult.scalar(.{ .bool = false });
+            return NativeResult.scalar(.{ .float = f });
         },
         258 => { // FILTER_VALIDATE_BOOLEAN
             const null_on_fail = (eff_flags & 134217728) != 0; // FILTER_NULL_ON_FAILURE
             const fail_val: Value = if (null_on_fail) .null else .{ .bool = false };
-            if (value == .bool) return value;
-            if (value == .int) return .{ .bool = value.int != 0 };
-            const s = if (value == .string) value.string.bytes() else return fail_val;
-            if (std.mem.eql(u8, s, "true") or std.mem.eql(u8, s, "1") or std.mem.eql(u8, s, "yes") or std.mem.eql(u8, s, "on")) return .{ .bool = true };
-            if (std.mem.eql(u8, s, "false") or std.mem.eql(u8, s, "0") or std.mem.eql(u8, s, "no") or std.mem.eql(u8, s, "off")) return .{ .bool = false };
-            return fail_val;
+            if (value == .bool) return NativeResult.share(value);
+            if (value == .int) return NativeResult.scalar(.{ .bool = value.int != 0 });
+            const s = if (value == .string) value.string.bytes() else return NativeResult.share(fail_val);
+            if (std.mem.eql(u8, s, "true") or std.mem.eql(u8, s, "1") or std.mem.eql(u8, s, "yes") or std.mem.eql(u8, s, "on")) return NativeResult.scalar(.{ .bool = true });
+            if (std.mem.eql(u8, s, "false") or std.mem.eql(u8, s, "0") or std.mem.eql(u8, s, "no") or std.mem.eql(u8, s, "off")) return NativeResult.scalar(.{ .bool = false });
+            return NativeResult.share(fail_val);
         },
         272 => { // FILTER_VALIDATE_REGEXP
             const s = if (value == .string) value.string.bytes() else if (value == .int) (try _ctx.createString(blk: {
                 var b: [32]u8 = undefined;
                 break :blk std.fmt.bufPrint(&b, "{d}", .{value.int}) catch "";
-            })) else return fail_default;
+            })) else return NativeResult.share(fail_default);
             if (opts_arr) |opts| {
                 const re_v = opts.get(.{ .string = Value.String.borrowed("regexp") });
                 if (re_v == .string) {
-                    const r = _ctx.vm.callByName("preg_match", &.{ re_v, .{ .string = Value.String.borrowed(s) } }) catch return fail_default;
-                    if (r == .int and r.int > 0) return value;
+                    const r = _ctx.vm.callByName("preg_match", &.{ re_v, .{ .string = Value.String.borrowed(s) } }) catch return NativeResult.share(fail_default);
+                    if (r == .int and r.int > 0) return NativeResult.share(value);
                 }
             }
-            return fail_default;
+            return NativeResult.share(fail_default);
         },
         277 => { // FILTER_VALIDATE_DOMAIN
-            const s = if (value == .string) value.string.bytes() else return fail_default;
-            if (s.len == 0 or s.len > 253) return fail_default;
+            const s = if (value == .string) value.string.bytes() else return NativeResult.share(fail_default);
+            if (s.len == 0 or s.len > 253) return NativeResult.share(fail_default);
             const strict = (eff_flags & 1048576) != 0; // FILTER_FLAG_HOSTNAME
             if (strict) {
                 for (s) |c| {
-                    if (!std.ascii.isAlphanumeric(c) and c != '.' and c != '-') return fail_default;
+                    if (!std.ascii.isAlphanumeric(c) and c != '.' and c != '-') return NativeResult.share(fail_default);
                 }
             }
-            return value;
+            return NativeResult.share(value);
         },
         276 => { // FILTER_VALIDATE_MAC
-            const s = if (value == .string) value.string.bytes() else return fail_default;
+            const s = if (value == .string) value.string.bytes() else return NativeResult.share(fail_default);
             // colon: 6 hex pairs separated by ":" or "-", or 3 quads of 4 hex separated by "."
             const HexHelpers = struct {
                 fn isHex(c: u8) bool {
@@ -3137,41 +3134,42 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                 var it = std.mem.splitScalar(u8, s, sep);
                 var n: usize = 0;
                 while (it.next()) |p| {
-                    if (p.len != 2) return fail_default;
-                    if (!HexHelpers.isHex(p[0]) or !HexHelpers.isHex(p[1])) return fail_default;
+                    if (p.len != 2) return NativeResult.share(fail_default);
+                    if (!HexHelpers.isHex(p[0]) or !HexHelpers.isHex(p[1])) return NativeResult.share(fail_default);
                     n += 1;
                 }
-                if (n == 6) return value;
-                return fail_default;
+                if (n == 6) return NativeResult.share(value);
+                return NativeResult.share(fail_default);
             }
             if (parts_dot == 3) {
                 var it = std.mem.splitScalar(u8, s, '.');
                 var n: usize = 0;
                 while (it.next()) |p| {
-                    if (p.len != 4) return fail_default;
-                    for (p) |c| if (!HexHelpers.isHex(c)) return fail_default;
+                    if (p.len != 4) return NativeResult.share(fail_default);
+                    for (p) |c| if (!HexHelpers.isHex(c)) return NativeResult.share(fail_default);
                     n += 1;
                 }
-                if (n == 3) return value;
+                if (n == 3) return NativeResult.share(value);
             }
-            return fail_default;
+            return NativeResult.share(fail_default);
         },
         519 => { // FILTER_SANITIZE_NUMBER_INT
-            const s = if (value == .string) value.string.bytes() else return fail_default;
+            const s = if (value == .string) value.string.bytes() else return NativeResult.share(fail_default);
             var buf = std.ArrayListUnmanaged(u8){};
+            defer buf.deinit(_ctx.allocator);
             for (s) |c| {
                 if (std.ascii.isDigit(c) or c == '+' or c == '-') try buf.append(_ctx.allocator, c);
             }
             const out = try buf.toOwnedSlice(_ctx.allocator);
-            try _ctx.strings.append(_ctx.allocator, out);
-            return .{ .string = Value.String.borrowed(out) };
+            return NativeResult.takeString(try Value.String.adopt(_ctx.allocator, out));
         },
         520 => { // FILTER_SANITIZE_NUMBER_FLOAT
-            const s = if (value == .string) value.string.bytes() else return fail_default;
+            const s = if (value == .string) value.string.bytes() else return NativeResult.share(fail_default);
             const allow_frac = (eff_flags & 4096) != 0;
             const allow_thou = (eff_flags & 8192) != 0;
             const allow_sci = (eff_flags & 16384) != 0;
             var buf = std.ArrayListUnmanaged(u8){};
+            defer buf.deinit(_ctx.allocator);
             for (s) |c| {
                 if (std.ascii.isDigit(c) or c == '+' or c == '-') {
                     try buf.append(_ctx.allocator, c);
@@ -3184,16 +3182,16 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                 }
             }
             const out = try buf.toOwnedSlice(_ctx.allocator);
-            try _ctx.strings.append(_ctx.allocator, out);
-            return .{ .string = Value.String.borrowed(out) };
+            return NativeResult.takeString(try Value.String.adopt(_ctx.allocator, out));
         },
         515 => { // FILTER_SANITIZE_SPECIAL_CHARS
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
-            return .{ .string = Value.String.borrowed(try sanitizeSpecialChars(_ctx, s)) };
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
+            return NativeResult.takeString(try sanitizeSpecialChars(_ctx, s));
         },
         522 => { // FILTER_SANITIZE_FULL_SPECIAL_CHARS
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
             var buf = std.ArrayListUnmanaged(u8){};
+            defer buf.deinit(_ctx.allocator);
             for (s) |c| {
                 switch (c) {
                     '<' => try buf.appendSlice(_ctx.allocator, "&lt;"),
@@ -3205,12 +3203,12 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                 }
             }
             const out = try buf.toOwnedSlice(_ctx.allocator);
-            try _ctx.strings.append(_ctx.allocator, out);
-            return .{ .string = Value.String.borrowed(out) };
+            return NativeResult.takeString(try Value.String.adopt(_ctx.allocator, out));
         },
         518 => { // FILTER_SANITIZE_URL
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
             var buf = std.ArrayListUnmanaged(u8){};
+            defer buf.deinit(_ctx.allocator);
             for (s) |c| {
                 // PHP strips all chars except a-zA-Z0-9 and the URL-reserved set
                 if (std.ascii.isAlphanumeric(c)) {
@@ -3223,12 +3221,12 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                 }
             }
             const out = try buf.toOwnedSlice(_ctx.allocator);
-            try _ctx.strings.append(_ctx.allocator, out);
-            return .{ .string = Value.String.borrowed(out) };
+            return NativeResult.takeString(try Value.String.adopt(_ctx.allocator, out));
         },
         517 => { // FILTER_SANITIZE_EMAIL
-            const s = if (value == .string) value.string.bytes() else return .{ .bool = false };
+            const s = if (value == .string) value.string.bytes() else return NativeResult.scalar(.{ .bool = false });
             var buf = std.ArrayListUnmanaged(u8){};
+            defer buf.deinit(_ctx.allocator);
             for (s) |c| {
                 if (std.ascii.isAlphanumeric(c) or c == '@' or c == '.' or c == '!' or c == '#' or
                     c == '$' or c == '%' or c == '&' or c == '\'' or c == '*' or c == '+' or
@@ -3239,8 +3237,7 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                 }
             }
             const out = try buf.toOwnedSlice(_ctx.allocator);
-            try _ctx.strings.append(_ctx.allocator, out);
-            return .{ .string = Value.String.borrowed(out) };
+            return NativeResult.takeString(try Value.String.adopt(_ctx.allocator, out));
         },
         1024 => { // FILTER_CALLBACK
             // options is the callable; PHP invokes it with the value and uses
@@ -3251,17 +3248,18 @@ fn native_filter_var(_ctx: *NativeContext, args: []const Value) RuntimeError!Val
                 const top = args[2].array;
                 const o = top.get(.{ .string = Value.String.borrowed("options") });
                 if (o != .null) {
-                    return _ctx.invokeCallable(o, &.{value}) catch return .{ .bool = false };
+                    return NativeResult.share(_ctx.invokeCallable(o, &.{value}) catch return NativeResult.scalar(.{ .bool = false }));
                 }
             }
-            return .{ .bool = false };
+            return NativeResult.scalar(.{ .bool = false });
         },
-        else => return value,
+        else => return NativeResult.share(value),
     }
 }
 
-fn sanitizeSpecialChars(ctx: *NativeContext, s: []const u8) ![]const u8 {
+fn sanitizeSpecialChars(ctx: *NativeContext, s: []const u8) !Value.String {
     var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
     for (s) |c| {
         switch (c) {
             '<' => try buf.appendSlice(ctx.allocator, "&#60;"),
@@ -3281,8 +3279,7 @@ fn sanitizeSpecialChars(ctx: *NativeContext, s: []const u8) ![]const u8 {
         }
     }
     const out = try buf.toOwnedSlice(ctx.allocator);
-    try ctx.strings.append(ctx.allocator, out);
-    return out;
+    return Value.String.adopt(ctx.allocator, out);
 }
 
 fn isValidIPv4(s: []const u8) bool {
@@ -3350,23 +3347,23 @@ fn isValidIPv6(s: []const u8) bool {
     return groups == 8;
 }
 
-fn native_is_resource(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
-    return .{ .bool = args[0] == .object and isResourceObject(args[0].object.class_name) };
+fn native_is_resource(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = args[0] == .object and isResourceObject(args[0].object.class_name) });
 }
 
-fn native_get_resource_type(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1) return .{ .bool = false };
+fn native_get_resource_type(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1) return NativeResult.scalar(.{ .bool = false });
     if (args[0] == .object) {
         const cn = args[0].object.class_name;
         // map zphp internal class names to PHP-canonical resource type strings
-        if (std.mem.eql(u8, cn, "FileHandle")) return .{ .string = Value.String.borrowed("stream") };
-        if (std.mem.eql(u8, cn, "StreamContext")) return .{ .string = Value.String.borrowed("stream-context") };
-        if (std.mem.eql(u8, cn, "CurlHandle")) return .{ .string = Value.String.borrowed("curl") };
-        if (std.mem.eql(u8, cn, "GdImage")) return .{ .string = Value.String.borrowed("gd") };
-        return .{ .string = Value.String.borrowed(cn) };
+        if (std.mem.eql(u8, cn, "FileHandle")) return NativeResult.literal("stream");
+        if (std.mem.eql(u8, cn, "StreamContext")) return NativeResult.literal("stream-context");
+        if (std.mem.eql(u8, cn, "CurlHandle")) return NativeResult.literal("curl");
+        if (std.mem.eql(u8, cn, "GdImage")) return NativeResult.literal("gd");
+        return NativeResult.copyString(ctx.allocator, cn);
     }
-    return .{ .bool = false };
+    return NativeResult.scalar(.{ .bool = false });
 }
 
 pub fn isResourceObject(name: []const u8) bool {
@@ -3376,8 +3373,8 @@ pub fn isResourceObject(name: []const u8) bool {
         std.mem.eql(u8, name, "FileHandle");
 }
 
-fn native_spl_object_hash(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .bool = false };
+fn native_spl_object_hash(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.scalar(.{ .bool = false });
     var id: u64 = 0;
     switch (args[0]) {
         .object => |o| {
@@ -3396,15 +3393,14 @@ fn native_spl_object_hash(ctx: *NativeContext, args: []const Value) RuntimeError
             if (std.mem.startsWith(u8, s.bytes(), "__closure_")) {
                 id = @intCast(@intFromPtr(s.bytes().ptr));
             } else {
-                return .{ .bool = false };
+                return NativeResult.scalar(.{ .bool = false });
             }
         },
-        else => return .{ .bool = false },
+        else => return NativeResult.scalar(.{ .bool = false }),
     }
     // PHP format: 16 hex chars of id, then 16 zeros
-    const hash = std.fmt.allocPrint(ctx.allocator, "{x:0>16}0000000000000000", .{id}) catch return .{ .bool = false };
-    ctx.vm.strings.append(ctx.allocator, hash) catch {};
-    return .{ .string = Value.String.borrowed(hash) };
+    const hash = try std.fmt.allocPrint(ctx.allocator, "{x:0>16}0000000000000000", .{id});
+    return NativeResult.takeString(try Value.String.adopt(ctx.allocator, hash));
 }
 
 const T_INLINE_HTML: i64 = 267;
@@ -3488,15 +3484,15 @@ fn keywordTokenId(ident: []const u8) ?i64 {
 fn makeToken(ctx: *NativeContext, id: i64, text: []const u8, line: i64) RuntimeError!Value {
     const arr = try ctx.createArray();
     try arr.append(ctx.allocator, .{ .int = id });
-    const s = try std.fmt.allocPrint(ctx.allocator, "{s}", .{text});
-    try ctx.strings.append(ctx.allocator, s);
-    try arr.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+    const s = try Value.String.create(ctx.allocator, text);
+    defer s.release();
+    try arr.append(ctx.allocator, .{ .string = s });
     try arr.append(ctx.allocator, .{ .int = line });
     return .{ .array = arr };
 }
 
-fn native_token_get_all(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .string) return .{ .array = try ctx.createArray() };
+fn native_token_get_all(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .string) return NativeResult.borrowed(.{ .array = try ctx.createArray() });
     const input = args[0].string.bytes();
     const result = try ctx.createArray();
     var pos: usize = 0;
@@ -3613,171 +3609,171 @@ fn native_token_get_all(ctx: *NativeContext, args: []const Value) RuntimeError!V
                 try result.append(ctx.allocator, try makeToken(ctx, tok_id, ident, line));
             } else {
                 // single character token returned as string
-                const s = try std.fmt.allocPrint(ctx.allocator, "{c}", .{input[pos]});
-                try ctx.strings.append(ctx.allocator, s);
-                try result.append(ctx.allocator, .{ .string = Value.String.borrowed(s) });
+                const s = try Value.String.create(ctx.allocator, input[pos .. pos + 1]);
+                defer s.release();
+                try result.append(ctx.allocator, .{ .string = s });
                 pos += 1;
             }
         }
     }
-    return .{ .array = result };
+    return NativeResult.borrowed(.{ .array = result });
 }
 
-fn native_token_name(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0 or args[0] != .int) return .{ .string = Value.String.borrowed("UNKNOWN") };
-    return .{ .string = Value.String.borrowed(switch (args[0].int) {
-        322 => "T_ABSTRACT",
-        409 => "T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG",
-        410 => "T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG",
-        362 => "T_AND_EQUAL",
-        344 => "T_ARRAY",
-        384 => "T_ARRAY_CAST",
-        301 => "T_AS",
-        355 => "T_ATTRIBUTE",
-        411 => "T_BAD_CHARACTER",
-        369 => "T_BOOLEAN_AND",
-        368 => "T_BOOLEAN_OR",
-        386 => "T_BOOL_CAST",
-        307 => "T_BREAK",
-        345 => "T_CALLABLE",
-        304 => "T_CASE",
-        315 => "T_CATCH",
-        336 => "T_CLASS",
-        349 => "T_CLASS_C",
-        285 => "T_CLONE",
-        396 => "T_CLOSE_TAG",
-        405 => "T_COALESCE",
-        367 => "T_COALESCE_EQUAL",
-        392 => "T_COMMENT",
-        360 => "T_CONCAT_EQUAL",
-        312 => "T_CONST",
-        269 => "T_CONSTANT_ENCAPSED_STRING",
-        308 => "T_CONTINUE",
-        401 => "T_CURLY_OPEN",
-        380 => "T_DEC",
-        299 => "T_DECLARE",
-        305 => "T_DEFAULT",
-        348 => "T_DIR",
-        359 => "T_DIV_EQUAL",
-        261 => "T_DNUMBER",
-        292 => "T_DO",
-        393 => "T_DOC_COMMENT",
-        400 => "T_DOLLAR_OPEN_CURLY_BRACES",
-        391 => "T_DOUBLE_ARROW",
-        382 => "T_DOUBLE_CAST",
-        402 => "T_DOUBLE_COLON",
-        291 => "T_ECHO",
-        404 => "T_ELLIPSIS",
-        289 => "T_ELSE",
-        288 => "T_ELSEIF",
-        334 => "T_EMPTY",
-        268 => "T_ENCAPSED_AND_WHITESPACE",
-        300 => "T_ENDDECLARE",
-        296 => "T_ENDFOR",
-        298 => "T_ENDFOREACH",
-        290 => "T_ENDIF",
-        303 => "T_ENDSWITCH",
-        294 => "T_ENDWHILE",
-        399 => "T_END_HEREDOC",
-        339 => "T_ENUM",
-        274 => "T_EVAL",
-        286 => "T_EXIT",
-        340 => "T_EXTENDS",
-        347 => "T_FILE",
-        323 => "T_FINAL",
-        316 => "T_FINALLY",
-        311 => "T_FN",
-        295 => "T_FOR",
-        297 => "T_FOREACH",
-        310 => "T_FUNCTION",
-        352 => "T_FUNC_C",
-        320 => "T_GLOBAL",
-        309 => "T_GOTO",
-        335 => "T_HALT_COMPILER",
-        287 => "T_IF",
-        341 => "T_IMPLEMENTS",
-        379 => "T_INC",
-        272 => "T_INCLUDE",
-        273 => "T_INCLUDE_ONCE",
-        267 => "T_INLINE_HTML",
-        283 => "T_INSTANCEOF",
-        319 => "T_INSTEADOF",
-        338 => "T_INTERFACE",
-        381 => "T_INT_CAST",
-        333 => "T_ISSET",
-        370 => "T_IS_EQUAL",
-        375 => "T_IS_GREATER_OR_EQUAL",
-        372 => "T_IS_IDENTICAL",
-        371 => "T_IS_NOT_EQUAL",
-        373 => "T_IS_NOT_IDENTICAL",
-        374 => "T_IS_SMALLER_OR_EQUAL",
-        346 => "T_LINE",
-        343 => "T_LIST",
-        260 => "T_LNUMBER",
-        279 => "T_LOGICAL_AND",
-        277 => "T_LOGICAL_OR",
-        278 => "T_LOGICAL_XOR",
-        306 => "T_MATCH",
-        351 => "T_METHOD_C",
-        357 => "T_MINUS_EQUAL",
-        361 => "T_MOD_EQUAL",
-        358 => "T_MUL_EQUAL",
-        342 => "T_NAMESPACE",
-        263 => "T_NAME_FULLY_QUALIFIED",
-        265 => "T_NAME_QUALIFIED",
-        264 => "T_NAME_RELATIVE",
-        284 => "T_NEW",
-        354 => "T_NS_C",
-        403 => "T_NS_SEPARATOR",
-        390 => "T_NULLSAFE_OBJECT_OPERATOR",
-        271 => "T_NUM_STRING",
-        385 => "T_OBJECT_CAST",
-        389 => "T_OBJECT_OPERATOR",
-        394 => "T_OPEN_TAG",
-        395 => "T_OPEN_TAG_WITH_ECHO",
-        363 => "T_OR_EQUAL",
-        408 => "T_PIPE",
-        356 => "T_PLUS_EQUAL",
-        406 => "T_POW",
-        407 => "T_POW_EQUAL",
-        280 => "T_PRINT",
-        324 => "T_PRIVATE",
-        327 => "T_PRIVATE_SET",
-        353 => "T_PROPERTY_C",
-        325 => "T_PROTECTED",
-        328 => "T_PROTECTED_SET",
-        326 => "T_PUBLIC",
-        329 => "T_PUBLIC_SET",
-        330 => "T_READONLY",
-        275 => "T_REQUIRE",
-        276 => "T_REQUIRE_ONCE",
-        313 => "T_RETURN",
-        377 => "T_SL",
-        365 => "T_SL_EQUAL",
-        376 => "T_SPACESHIP",
-        378 => "T_SR",
-        366 => "T_SR_EQUAL",
-        398 => "T_START_HEREDOC",
-        321 => "T_STATIC",
-        262 => "T_STRING",
-        383 => "T_STRING_CAST",
-        270 => "T_STRING_VARNAME",
-        302 => "T_SWITCH",
-        317 => "T_THROW",
-        337 => "T_TRAIT",
-        350 => "T_TRAIT_C",
-        314 => "T_TRY",
-        332 => "T_UNSET",
-        387 => "T_UNSET_CAST",
-        318 => "T_USE",
-        331 => "T_VAR",
-        266 => "T_VARIABLE",
-        388 => "T_VOID_CAST",
-        293 => "T_WHILE",
-        397 => "T_WHITESPACE",
-        364 => "T_XOR_EQUAL",
-        281 => "T_YIELD",
-        282 => "T_YIELD_FROM",
-        else => "UNKNOWN",
-    }) };
+fn native_token_name(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .int) return NativeResult.literal("UNKNOWN");
+    return switch (args[0].int) {
+        322 => NativeResult.literal("T_ABSTRACT"),
+        409 => NativeResult.literal("T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG"),
+        410 => NativeResult.literal("T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG"),
+        362 => NativeResult.literal("T_AND_EQUAL"),
+        344 => NativeResult.literal("T_ARRAY"),
+        384 => NativeResult.literal("T_ARRAY_CAST"),
+        301 => NativeResult.literal("T_AS"),
+        355 => NativeResult.literal("T_ATTRIBUTE"),
+        411 => NativeResult.literal("T_BAD_CHARACTER"),
+        369 => NativeResult.literal("T_BOOLEAN_AND"),
+        368 => NativeResult.literal("T_BOOLEAN_OR"),
+        386 => NativeResult.literal("T_BOOL_CAST"),
+        307 => NativeResult.literal("T_BREAK"),
+        345 => NativeResult.literal("T_CALLABLE"),
+        304 => NativeResult.literal("T_CASE"),
+        315 => NativeResult.literal("T_CATCH"),
+        336 => NativeResult.literal("T_CLASS"),
+        349 => NativeResult.literal("T_CLASS_C"),
+        285 => NativeResult.literal("T_CLONE"),
+        396 => NativeResult.literal("T_CLOSE_TAG"),
+        405 => NativeResult.literal("T_COALESCE"),
+        367 => NativeResult.literal("T_COALESCE_EQUAL"),
+        392 => NativeResult.literal("T_COMMENT"),
+        360 => NativeResult.literal("T_CONCAT_EQUAL"),
+        312 => NativeResult.literal("T_CONST"),
+        269 => NativeResult.literal("T_CONSTANT_ENCAPSED_STRING"),
+        308 => NativeResult.literal("T_CONTINUE"),
+        401 => NativeResult.literal("T_CURLY_OPEN"),
+        380 => NativeResult.literal("T_DEC"),
+        299 => NativeResult.literal("T_DECLARE"),
+        305 => NativeResult.literal("T_DEFAULT"),
+        348 => NativeResult.literal("T_DIR"),
+        359 => NativeResult.literal("T_DIV_EQUAL"),
+        261 => NativeResult.literal("T_DNUMBER"),
+        292 => NativeResult.literal("T_DO"),
+        393 => NativeResult.literal("T_DOC_COMMENT"),
+        400 => NativeResult.literal("T_DOLLAR_OPEN_CURLY_BRACES"),
+        391 => NativeResult.literal("T_DOUBLE_ARROW"),
+        382 => NativeResult.literal("T_DOUBLE_CAST"),
+        402 => NativeResult.literal("T_DOUBLE_COLON"),
+        291 => NativeResult.literal("T_ECHO"),
+        404 => NativeResult.literal("T_ELLIPSIS"),
+        289 => NativeResult.literal("T_ELSE"),
+        288 => NativeResult.literal("T_ELSEIF"),
+        334 => NativeResult.literal("T_EMPTY"),
+        268 => NativeResult.literal("T_ENCAPSED_AND_WHITESPACE"),
+        300 => NativeResult.literal("T_ENDDECLARE"),
+        296 => NativeResult.literal("T_ENDFOR"),
+        298 => NativeResult.literal("T_ENDFOREACH"),
+        290 => NativeResult.literal("T_ENDIF"),
+        303 => NativeResult.literal("T_ENDSWITCH"),
+        294 => NativeResult.literal("T_ENDWHILE"),
+        399 => NativeResult.literal("T_END_HEREDOC"),
+        339 => NativeResult.literal("T_ENUM"),
+        274 => NativeResult.literal("T_EVAL"),
+        286 => NativeResult.literal("T_EXIT"),
+        340 => NativeResult.literal("T_EXTENDS"),
+        347 => NativeResult.literal("T_FILE"),
+        323 => NativeResult.literal("T_FINAL"),
+        316 => NativeResult.literal("T_FINALLY"),
+        311 => NativeResult.literal("T_FN"),
+        295 => NativeResult.literal("T_FOR"),
+        297 => NativeResult.literal("T_FOREACH"),
+        310 => NativeResult.literal("T_FUNCTION"),
+        352 => NativeResult.literal("T_FUNC_C"),
+        320 => NativeResult.literal("T_GLOBAL"),
+        309 => NativeResult.literal("T_GOTO"),
+        335 => NativeResult.literal("T_HALT_COMPILER"),
+        287 => NativeResult.literal("T_IF"),
+        341 => NativeResult.literal("T_IMPLEMENTS"),
+        379 => NativeResult.literal("T_INC"),
+        272 => NativeResult.literal("T_INCLUDE"),
+        273 => NativeResult.literal("T_INCLUDE_ONCE"),
+        267 => NativeResult.literal("T_INLINE_HTML"),
+        283 => NativeResult.literal("T_INSTANCEOF"),
+        319 => NativeResult.literal("T_INSTEADOF"),
+        338 => NativeResult.literal("T_INTERFACE"),
+        381 => NativeResult.literal("T_INT_CAST"),
+        333 => NativeResult.literal("T_ISSET"),
+        370 => NativeResult.literal("T_IS_EQUAL"),
+        375 => NativeResult.literal("T_IS_GREATER_OR_EQUAL"),
+        372 => NativeResult.literal("T_IS_IDENTICAL"),
+        371 => NativeResult.literal("T_IS_NOT_EQUAL"),
+        373 => NativeResult.literal("T_IS_NOT_IDENTICAL"),
+        374 => NativeResult.literal("T_IS_SMALLER_OR_EQUAL"),
+        346 => NativeResult.literal("T_LINE"),
+        343 => NativeResult.literal("T_LIST"),
+        260 => NativeResult.literal("T_LNUMBER"),
+        279 => NativeResult.literal("T_LOGICAL_AND"),
+        277 => NativeResult.literal("T_LOGICAL_OR"),
+        278 => NativeResult.literal("T_LOGICAL_XOR"),
+        306 => NativeResult.literal("T_MATCH"),
+        351 => NativeResult.literal("T_METHOD_C"),
+        357 => NativeResult.literal("T_MINUS_EQUAL"),
+        361 => NativeResult.literal("T_MOD_EQUAL"),
+        358 => NativeResult.literal("T_MUL_EQUAL"),
+        342 => NativeResult.literal("T_NAMESPACE"),
+        263 => NativeResult.literal("T_NAME_FULLY_QUALIFIED"),
+        265 => NativeResult.literal("T_NAME_QUALIFIED"),
+        264 => NativeResult.literal("T_NAME_RELATIVE"),
+        284 => NativeResult.literal("T_NEW"),
+        354 => NativeResult.literal("T_NS_C"),
+        403 => NativeResult.literal("T_NS_SEPARATOR"),
+        390 => NativeResult.literal("T_NULLSAFE_OBJECT_OPERATOR"),
+        271 => NativeResult.literal("T_NUM_STRING"),
+        385 => NativeResult.literal("T_OBJECT_CAST"),
+        389 => NativeResult.literal("T_OBJECT_OPERATOR"),
+        394 => NativeResult.literal("T_OPEN_TAG"),
+        395 => NativeResult.literal("T_OPEN_TAG_WITH_ECHO"),
+        363 => NativeResult.literal("T_OR_EQUAL"),
+        408 => NativeResult.literal("T_PIPE"),
+        356 => NativeResult.literal("T_PLUS_EQUAL"),
+        406 => NativeResult.literal("T_POW"),
+        407 => NativeResult.literal("T_POW_EQUAL"),
+        280 => NativeResult.literal("T_PRINT"),
+        324 => NativeResult.literal("T_PRIVATE"),
+        327 => NativeResult.literal("T_PRIVATE_SET"),
+        353 => NativeResult.literal("T_PROPERTY_C"),
+        325 => NativeResult.literal("T_PROTECTED"),
+        328 => NativeResult.literal("T_PROTECTED_SET"),
+        326 => NativeResult.literal("T_PUBLIC"),
+        329 => NativeResult.literal("T_PUBLIC_SET"),
+        330 => NativeResult.literal("T_READONLY"),
+        275 => NativeResult.literal("T_REQUIRE"),
+        276 => NativeResult.literal("T_REQUIRE_ONCE"),
+        313 => NativeResult.literal("T_RETURN"),
+        377 => NativeResult.literal("T_SL"),
+        365 => NativeResult.literal("T_SL_EQUAL"),
+        376 => NativeResult.literal("T_SPACESHIP"),
+        378 => NativeResult.literal("T_SR"),
+        366 => NativeResult.literal("T_SR_EQUAL"),
+        398 => NativeResult.literal("T_START_HEREDOC"),
+        321 => NativeResult.literal("T_STATIC"),
+        262 => NativeResult.literal("T_STRING"),
+        383 => NativeResult.literal("T_STRING_CAST"),
+        270 => NativeResult.literal("T_STRING_VARNAME"),
+        302 => NativeResult.literal("T_SWITCH"),
+        317 => NativeResult.literal("T_THROW"),
+        337 => NativeResult.literal("T_TRAIT"),
+        350 => NativeResult.literal("T_TRAIT_C"),
+        314 => NativeResult.literal("T_TRY"),
+        332 => NativeResult.literal("T_UNSET"),
+        387 => NativeResult.literal("T_UNSET_CAST"),
+        318 => NativeResult.literal("T_USE"),
+        331 => NativeResult.literal("T_VAR"),
+        266 => NativeResult.literal("T_VARIABLE"),
+        388 => NativeResult.literal("T_VOID_CAST"),
+        293 => NativeResult.literal("T_WHILE"),
+        397 => NativeResult.literal("T_WHITESPACE"),
+        364 => NativeResult.literal("T_XOR_EQUAL"),
+        281 => NativeResult.literal("T_YIELD"),
+        282 => NativeResult.literal("T_YIELD_FROM"),
+        else => NativeResult.literal("UNKNOWN"),
+    };
 }

--- a/src/stdlib/websocket.zig
+++ b/src/stdlib/websocket.zig
@@ -7,6 +7,7 @@ const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 const ws = @import("../websocket.zig");
 const tls = @import("../tls.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 
 const Allocator = std.mem.Allocator;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
@@ -48,22 +49,22 @@ fn getWriter(obj: *PhpObject) ?WsWriter {
     return .{ .fd = @intCast(fd_val.int), .ssl = ssl_ptr };
 }
 
-fn wsSend(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn wsSend(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const closed = obj.get("__ws_closed");
-    if (closed == .bool and closed.bool) return .null;
-    var writer = getWriter(obj) orelse return .null;
-    if (args.len < 1 or args[0] != .string) return .null;
-    ws.writeFrame(&writer, .text, args[0].string.bytes()) catch return .null;
-    return .null;
+    if (closed == .bool and closed.bool) return NativeResult.scalar(.null);
+    var writer = getWriter(obj) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    ws.writeFrame(&writer, .text, args[0].string.bytes()) catch return NativeResult.scalar(.null);
+    return NativeResult.scalar(.null);
 }
 
-fn wsClose(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .null;
+fn wsClose(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const closed = obj.get("__ws_closed");
-    if (closed == .bool and closed.bool) return .null;
-    var writer = getWriter(obj) orelse return .null;
+    if (closed == .bool and closed.bool) return NativeResult.scalar(.null);
+    var writer = getWriter(obj) orelse return NativeResult.scalar(.null);
     ws.writeCloseFrame(&writer, 1000) catch {};
     try obj.set(ctx.allocator, "__ws_closed", .{ .bool = true });
-    return .null;
+    return NativeResult.scalar(.null);
 }

--- a/src/stdlib/xml_parser.zig
+++ b/src/stdlib/xml_parser.zig
@@ -3,6 +3,7 @@ const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -50,7 +51,7 @@ fn dupString(ctx: *NativeContext, s: []const u8) ![]const u8 {
     return owned;
 }
 
-fn create(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn create(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("XMLParser");
     try obj.set(ctx.allocator, "__case_fold", .{ .bool = true });
     try obj.set(ctx.allocator, "__skip_white", .{ .bool = false });
@@ -58,10 +59,10 @@ fn create(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     try obj.set(ctx.allocator, "__col", .{ .int = 0 });
     try obj.set(ctx.allocator, "__byte", .{ .int = 0 });
     try obj.set(ctx.allocator, "__error", .{ .int = 0 });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn createNs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn createNs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return create(ctx, args);
 }
 
@@ -70,95 +71,95 @@ fn parserObj(args: []const Value) ?*PhpObject {
     return args[0].object;
 }
 
-fn setElementHandler(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .bool = false };
+fn setElementHandler(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len >= 2) try p.set(ctx.allocator, "__start_handler", args[1]);
     if (args.len >= 3) try p.set(ctx.allocator, "__end_handler", args[2]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn setCharHandler(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .bool = false };
+fn setCharHandler(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len >= 2) try p.set(ctx.allocator, "__char_handler", args[1]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn setDefaultHandler(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .bool = false };
+fn setDefaultHandler(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len >= 2) try p.set(ctx.allocator, "__default_handler", args[1]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn setPiHandler(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .bool = false };
+fn setPiHandler(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len >= 2) try p.set(ctx.allocator, "__pi_handler", args[1]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn setObject(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .bool = false };
+fn setObject(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len >= 2 and args[1] == .object) try p.set(ctx.allocator, "__bound_object", args[1]);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn setOption(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .bool = false };
-    if (args.len < 3) return .{ .bool = false };
+fn setOption(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 3) return NativeResult.scalar(.{ .bool = false });
     const opt: i64 = Value.toInt(args[1]);
     switch (opt) {
         1 => try p.set(ctx.allocator, "__case_fold", .{ .bool = Value.isTruthy(args[2]) }),
         4 => try p.set(ctx.allocator, "__skip_white", .{ .bool = Value.isTruthy(args[2]) }),
         else => {},
     }
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn getOption(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .bool = false };
-    if (args.len < 2) return .{ .bool = false };
+fn getOption(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .bool = false });
+    if (args.len < 2) return NativeResult.scalar(.{ .bool = false });
     const opt: i64 = Value.toInt(args[1]);
-    return switch (opt) {
+    return NativeResult.scalar(switch (opt) {
         1 => .{ .bool = (p.get("__case_fold") == .bool and p.get("__case_fold").bool) },
         4 => .{ .bool = (p.get("__skip_white") == .bool and p.get("__skip_white").bool) },
         else => .{ .bool = false },
-    };
+    });
 }
 
-fn parserFree(_: *NativeContext, _: []const Value) RuntimeError!Value {
+fn parserFree(_: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // arena-based memory; nothing to free explicitly
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn getErrorCode(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .int = 0 };
-    return p.get("__error");
+fn getErrorCode(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(p.get("__error"));
 }
 
-fn errorString(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len == 0) return .{ .string = Value.String.borrowed("") };
+fn errorString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0) return NativeResult.literal("");
     const code: i64 = Value.toInt(args[0]);
-    return .{ .string = Value.String.borrowed(switch (code) {
+    return try NativeResult.copyString(ctx.allocator, switch (code) {
         0 => "No error",
         1 => "Out of memory",
         2 => "Syntax error",
         4 => "Invalid token",
         else => "Unknown error",
-    }) };
+    });
 }
 
-fn getCurrentLine(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .int = 0 };
-    return p.get("__line");
+fn getCurrentLine(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(p.get("__line"));
 }
 
-fn getCurrentCol(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .int = 0 };
-    return p.get("__col");
+fn getCurrentCol(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(p.get("__col"));
 }
 
-fn getCurrentByte(_: *NativeContext, args: []const Value) RuntimeError!Value {
-    const p = parserObj(args) orelse return .{ .int = 0 };
-    return p.get("__byte");
+fn getCurrentByte(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const p = parserObj(args) orelse return NativeResult.scalar(.{ .int = 0 });
+    return NativeResult.share(p.get("__byte"));
 }
 
 const ParseState = struct {
@@ -189,10 +190,10 @@ const ParseState = struct {
     }
 };
 
-fn xmlParse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .object) return .{ .int = 0 };
+fn xmlParse(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.{ .int = 0 });
     const parser = args[0].object;
-    const data = if (args[1] == .string) args[1].string.bytes() else return .{ .int = 0 };
+    const data = if (args[1] == .string) args[1].string.bytes() else return NativeResult.scalar(.{ .int = 0 });
     const is_final = args.len < 3 or Value.isTruthy(args[2]);
     _ = is_final;
 
@@ -337,7 +338,7 @@ fn xmlParse(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     try parser.set(ctx.allocator, "__line", .{ .int = st.line });
     try parser.set(ctx.allocator, "__col", .{ .int = st.col });
     try parser.set(ctx.allocator, "__byte", .{ .int = @intCast(st.pos) });
-    return .{ .int = 1 };
+    return NativeResult.scalar(.{ .int = 1 });
 }
 
 fn foldName(ctx: *NativeContext, name: []const u8, case_fold: bool) ![]const u8 {

--- a/src/stdlib/xmlreader.zig
+++ b/src/stdlib/xmlreader.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -59,9 +60,9 @@ pub fn cleanupObject(obj: *PhpObject) void {
 
 // ---------------- methods ----------------
 
-fn xrOpen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn xrOpen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     closeExisting(obj);
 
     const path_z = try dupZ(ctx, args[0].string.bytes());
@@ -73,13 +74,13 @@ fn xrOpen(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const opts: c_int = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else 0;
 
     const reader = c.xmlReaderForFile(path_z.ptr, enc_ptr, opts);
-    if (reader == null) return .{ .bool = false };
+    if (reader == null) return NativeResult.scalar(.{ .bool = false });
     try setReader(obj, ctx.allocator, reader);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn xrXml(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn xrXml(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const src = args[0].string.bytes();
     const enc_z: ?[:0]u8 = if (args.len > 1 and args[1] == .string and args[1].string.bytes().len > 0)
         try dupZ(ctx, args[1].string.bytes())
@@ -90,8 +91,8 @@ fn xrXml(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
 
     const reader = c.xmlReaderForMemory(src.ptr, @intCast(src.len), null, enc_ptr, opts);
     if (reader == null) {
-        if (getThis(ctx)) |_| return .{ .bool = false };
-        return .{ .bool = false };
+        if (getThis(ctx)) |_| return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .bool = false });
     }
 
     // PHP's XMLReader::XML works both as an instance method (initializes $this and
@@ -100,15 +101,15 @@ fn xrXml(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     if (getThis(ctx)) |obj| {
         closeExisting(obj);
         try setReader(obj, ctx.allocator, reader);
-        return .{ .bool = true };
+        return NativeResult.scalar(.{ .bool = true });
     }
     const obj = try ctx.createObject("XMLReader");
     try setReader(obj, ctx.allocator, reader);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn xrFromString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn xrFromString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("XMLReader");
     const src = args[0].string.bytes();
     const enc_z: ?[:0]u8 = if (args.len > 1 and args[1] == .string and args[1].string.bytes().len > 0)
@@ -118,13 +119,13 @@ fn xrFromString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const enc_ptr: [*c]const u8 = if (enc_z) |e| @ptrCast(e.ptr) else null;
     const opts: c_int = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else 0;
     const reader = c.xmlReaderForMemory(src.ptr, @intCast(src.len), null, enc_ptr, opts);
-    if (reader == null) return .{ .bool = false };
+    if (reader == null) return NativeResult.scalar(.{ .bool = false });
     try setReader(obj, ctx.allocator, reader);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn xrFromUri(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn xrFromUri(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("XMLReader");
     const path_z = try dupZ(ctx, args[0].string.bytes());
     const enc_z: ?[:0]u8 = if (args.len > 1 and args[1] == .string and args[1].string.bytes().len > 0)
@@ -134,161 +135,161 @@ fn xrFromUri(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const enc_ptr: [*c]const u8 = if (enc_z) |e| @ptrCast(e.ptr) else null;
     const opts: c_int = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else 0;
     const reader = c.xmlReaderForFile(path_z.ptr, enc_ptr, opts);
-    if (reader == null) return .{ .bool = false };
+    if (reader == null) return NativeResult.scalar(.{ .bool = false });
     try setReader(obj, ctx.allocator, reader);
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn xrClose(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
+fn xrClose(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     closeExisting(obj);
     try setReader(obj, ctx.allocator, null);
-    return .{ .bool = true };
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn xrRead(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextReaderRead(r) == 1 };
+fn xrRead(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderRead(r) == 1 });
 }
 
-fn xrNext(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
+fn xrNext(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
     if (args.len > 0 and args[0] == .string and args[0].string.bytes().len > 0) {
         const name_z = try dupZ(ctx, args[0].string.bytes());
         // walk until we hit a matching element
         while (true) {
             const rc = c.xmlTextReaderNext(r);
-            if (rc != 1) return .{ .bool = false };
+            if (rc != 1) return NativeResult.scalar(.{ .bool = false });
             const nt = c.xmlTextReaderNodeType(r);
             if (nt == c.XML_READER_TYPE_ELEMENT) {
                 const cur = c.xmlTextReaderConstLocalName(r);
                 if (cur != null and std.mem.eql(u8, cur[0..cstrLen(cur)], name_z[0..name_z.len])) {
-                    return .{ .bool = true };
+                    return NativeResult.scalar(.{ .bool = true });
                 }
             }
         }
     }
-    return .{ .bool = c.xmlTextReaderNext(r) == 1 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderNext(r) == 1 });
 }
 
-fn xrMoveToAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
+fn xrMoveToAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
-    return .{ .bool = c.xmlTextReaderMoveToAttribute(r, @ptrCast(name_z.ptr)) == 1 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderMoveToAttribute(r, @ptrCast(name_z.ptr)) == 1 });
 }
 
-fn xrMoveToAttributeNo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextReaderMoveToAttributeNo(r, @intCast(args[0].int)) == 1 };
+fn xrMoveToAttributeNo(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderMoveToAttributeNo(r, @intCast(args[0].int)) == 1 });
 }
 
-fn xrMoveToAttributeNs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
+fn xrMoveToAttributeNs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const ns_z = try dupZ(ctx, args[1].string.bytes());
-    return .{ .bool = c.xmlTextReaderMoveToAttributeNs(r, @ptrCast(name_z.ptr), @ptrCast(ns_z.ptr)) == 1 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderMoveToAttributeNs(r, @ptrCast(name_z.ptr), @ptrCast(ns_z.ptr)) == 1 });
 }
 
-fn xrMoveToElement(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextReaderMoveToElement(r) == 1 };
+fn xrMoveToElement(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderMoveToElement(r) == 1 });
 }
 
-fn xrMoveToFirstAttribute(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextReaderMoveToFirstAttribute(r) == 1 };
+fn xrMoveToFirstAttribute(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderMoveToFirstAttribute(r) == 1 });
 }
 
-fn xrMoveToNextAttribute(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextReaderMoveToNextAttribute(r) == 1 };
+fn xrMoveToNextAttribute(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderMoveToNextAttribute(r) == 1 });
 }
 
-fn xrGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const r = getReader(obj) orelse return .null;
+fn xrGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const r = getReader(obj) orelse return NativeResult.scalar(.null);
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const v = c.xmlTextReaderGetAttribute(r, @ptrCast(name_z.ptr));
-    if (v == null) return .null;
+    if (v == null) return NativeResult.scalar(.null);
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn xrGetAttributeNo(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .int) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const r = getReader(obj) orelse return .null;
+fn xrGetAttributeNo(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .int) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const r = getReader(obj) orelse return NativeResult.scalar(.null);
     const v = c.xmlTextReaderGetAttributeNo(r, @intCast(args[0].int));
-    if (v == null) return .null;
+    if (v == null) return NativeResult.scalar(.null);
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn xrGetAttributeNs(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const r = getReader(obj) orelse return .null;
+fn xrGetAttributeNs(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const r = getReader(obj) orelse return NativeResult.scalar(.null);
     const name_z = try dupZ(ctx, args[0].string.bytes());
     const ns_z = try dupZ(ctx, args[1].string.bytes());
     const v = c.xmlTextReaderGetAttributeNs(r, @ptrCast(name_z.ptr), @ptrCast(ns_z.ptr));
-    if (v == null) return .null;
+    if (v == null) return NativeResult.scalar(.null);
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn xrReadInnerXml(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
+fn xrReadInnerXml(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const v = c.xmlTextReaderReadInnerXml(r);
-    if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == null) return try NativeResult.copyString(ctx.allocator, "");
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn xrReadOuterXml(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
+fn xrReadOuterXml(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const v = c.xmlTextReaderReadOuterXml(r);
-    if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == null) return try NativeResult.copyString(ctx.allocator, "");
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn xrReadString(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
+fn xrReadString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const v = c.xmlTextReaderReadString(r);
-    if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
+    if (v == null) return try NativeResult.copyString(ctx.allocator, "");
     defer c.xmlFree.?(v);
-    return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+    return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
 }
 
-fn xrIsValid(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextReaderIsValid(r) == 1 };
+fn xrIsValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextReaderIsValid(r) == 1 });
 }
 
-fn xrExpand(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn xrExpand(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // expand() returns a DOMNode for the current node. requires the dom module's
     // wrapping. building a DOMElement/DOMText/etc wrapper here would create a
     // node tied to an internal reader doc; PHP's documented behavior is the
     // same. We pass through to dom.wrapNode equivalent.
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const r = getReader(obj) orelse return .{ .bool = false };
-    const node = c.xmlTextReaderExpand(r) orelse return .{ .bool = false };
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const r = getReader(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    const node = c.xmlTextReaderExpand(r) orelse return NativeResult.scalar(.{ .bool = false });
     // build a minimal DOMNode wrapper. dispatch class name from node type
     const cls = switch (node.*.type) {
         1 => "DOMElement", // XML_ELEMENT_NODE
@@ -300,72 +301,72 @@ fn xrExpand(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
     };
     const dom_obj = try ctx.createObject(cls);
     try dom_obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
-    return .{ .object = dom_obj };
+    return NativeResult.borrowed(.{ .object = dom_obj });
 }
 
-fn xrGet(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .null;
-    const obj = getThis(ctx) orelse return .null;
-    const r = getReader(obj) orelse return .null;
+fn xrGet(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const r = getReader(obj) orelse return NativeResult.scalar(.null);
     const prop = args[0].string.bytes();
 
     if (std.mem.eql(u8, prop, "nodeType")) {
-        return .{ .int = @intCast(c.xmlTextReaderNodeType(r)) };
+        return NativeResult.scalar(.{ .int = @intCast(c.xmlTextReaderNodeType(r)) });
     }
     if (std.mem.eql(u8, prop, "name")) {
         const v = c.xmlTextReaderConstName(r);
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
     if (std.mem.eql(u8, prop, "localName")) {
         const v = c.xmlTextReaderConstLocalName(r);
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
     if (std.mem.eql(u8, prop, "prefix")) {
         const v = c.xmlTextReaderConstPrefix(r);
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
     if (std.mem.eql(u8, prop, "namespaceURI")) {
         const v = c.xmlTextReaderConstNamespaceUri(r);
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
     if (std.mem.eql(u8, prop, "value")) {
         const v = c.xmlTextReaderConstValue(r);
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
     if (std.mem.eql(u8, prop, "baseURI")) {
         const v = c.xmlTextReaderConstBaseUri(r);
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
     if (std.mem.eql(u8, prop, "xmlLang")) {
         const v = c.xmlTextReaderConstXmlLang(r);
-        if (v == null) return .{ .string = Value.String.borrowed(try dupString(ctx, "")) };
-        return .{ .string = Value.String.borrowed(try dupString(ctx, v[0..cstrLen(v)])) };
+        if (v == null) return try NativeResult.copyString(ctx.allocator, "");
+        return try NativeResult.copyString(ctx.allocator, v[0..cstrLen(v)]);
     }
     if (std.mem.eql(u8, prop, "depth")) {
-        return .{ .int = @intCast(c.xmlTextReaderDepth(r)) };
+        return NativeResult.scalar(.{ .int = @intCast(c.xmlTextReaderDepth(r)) });
     }
     if (std.mem.eql(u8, prop, "attributeCount")) {
-        return .{ .int = @intCast(c.xmlTextReaderAttributeCount(r)) };
+        return NativeResult.scalar(.{ .int = @intCast(c.xmlTextReaderAttributeCount(r)) });
     }
     if (std.mem.eql(u8, prop, "hasAttributes")) {
-        return .{ .bool = c.xmlTextReaderHasAttributes(r) == 1 };
+        return NativeResult.scalar(.{ .bool = c.xmlTextReaderHasAttributes(r) == 1 });
     }
     if (std.mem.eql(u8, prop, "hasValue")) {
-        return .{ .bool = c.xmlTextReaderHasValue(r) == 1 };
+        return NativeResult.scalar(.{ .bool = c.xmlTextReaderHasValue(r) == 1 });
     }
     if (std.mem.eql(u8, prop, "isDefault")) {
-        return .{ .bool = c.xmlTextReaderIsDefault(r) == 1 };
+        return NativeResult.scalar(.{ .bool = c.xmlTextReaderIsDefault(r) == 1 });
     }
     if (std.mem.eql(u8, prop, "isEmptyElement")) {
-        return .{ .bool = c.xmlTextReaderIsEmptyElement(r) == 1 };
+        return NativeResult.scalar(.{ .bool = c.xmlTextReaderIsEmptyElement(r) == 1 });
     }
-    return .null;
+    return NativeResult.scalar(.null);
 }
 
 // ---------------- registration ----------------

--- a/src/stdlib/xmlwriter.zig
+++ b/src/stdlib/xmlwriter.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
 const vm_mod = @import("../runtime/vm.zig");
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
@@ -57,27 +58,27 @@ pub fn cleanupObject(obj: *PhpObject) void {
 
 // ---------------- methods ----------------
 
-fn xwOpenMemory(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn xwOpenMemory(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     // if called statically, create object. if instance method, set up on $this
     const obj = getThis(ctx) orelse blk: {
         const o = try ctx.createObject("XMLWriter");
         break :blk o;
     };
     closeExisting(obj);
-    const buf = c.xmlBufferCreate() orelse return .{ .bool = false };
+    const buf = c.xmlBufferCreate() orelse return NativeResult.scalar(.{ .bool = false });
     const writer = c.xmlNewTextWriterMemory(buf, 0);
     if (writer == null) {
         c.xmlBufferFree(buf);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     try obj.set(ctx.allocator, "__buffer", .{ .int = @intCast(@intFromPtr(buf)) });
     try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
-    if (getThis(ctx) == null) return .{ .object = obj };
-    return .{ .bool = true };
+    if (getThis(ctx) == null) return NativeResult.borrowed(.{ .object = obj });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn xwOpenURI(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn xwOpenURI(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const obj = getThis(ctx) orelse blk: {
         const o = try ctx.createObject("XMLWriter");
         break :blk o;
@@ -86,90 +87,90 @@ fn xwOpenURI(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
     const path_z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(path_z);
     const writer = c.xmlNewTextWriterFilename(path_z.ptr, 0);
-    if (writer == null) return .{ .bool = false };
+    if (writer == null) return NativeResult.scalar(.{ .bool = false });
     try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
-    if (getThis(ctx) == null) return .{ .object = obj };
-    return .{ .bool = true };
+    if (getThis(ctx) == null) return NativeResult.borrowed(.{ .object = obj });
+    return NativeResult.scalar(.{ .bool = true });
 }
 
-fn xwToMemory(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn xwToMemory(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("XMLWriter");
-    const buf = c.xmlBufferCreate() orelse return .{ .bool = false };
+    const buf = c.xmlBufferCreate() orelse return NativeResult.scalar(.{ .bool = false });
     const writer = c.xmlNewTextWriterMemory(buf, 0);
     if (writer == null) {
         c.xmlBufferFree(buf);
-        return .{ .bool = false };
+        return NativeResult.scalar(.{ .bool = false });
     }
     try obj.set(ctx.allocator, "__buffer", .{ .int = @intCast(@intFromPtr(buf)) });
     try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn xwToUri(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
+fn xwToUri(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("XMLWriter");
     const path_z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(path_z);
     const writer = c.xmlNewTextWriterFilename(path_z.ptr, 0);
-    if (writer == null) return .{ .bool = false };
+    if (writer == null) return NativeResult.scalar(.{ .bool = false });
     try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
-    return .{ .object = obj };
+    return NativeResult.borrowed(.{ .object = obj });
 }
 
-fn xwOutputMemory(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .string = try dupString(ctx, "") };
-    const writer = getWriter(obj) orelse return .{ .string = try dupString(ctx, "") };
+fn xwOutputMemory(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return try NativeResult.copyString(ctx.allocator, "");
+    const writer = getWriter(obj) orelse return try NativeResult.copyString(ctx.allocator, "");
     var flush = true;
     if (args.len > 0 and args[0] == .bool) flush = args[0].bool;
     if (flush) _ = c.xmlTextWriterFlush(writer);
-    const buf = getBuffer(obj) orelse return .{ .string = try dupString(ctx, "") };
+    const buf = getBuffer(obj) orelse return try NativeResult.copyString(ctx.allocator, "");
     const content = c.xmlBufferContent(buf);
-    if (content == null) return .{ .string = try dupString(ctx, "") };
+    if (content == null) return try NativeResult.copyString(ctx.allocator, "");
     const slice = content[0..cstrLen(content)];
-    const out = try dupString(ctx, slice);
+    const out = try NativeResult.copyString(ctx.allocator, slice);
     if (flush) c.xmlBufferEmpty(buf);
-    return .{ .string = out };
+    return out;
 }
 
-fn xwFlush(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .int = 0 };
-    const writer = getWriter(obj) orelse return .{ .int = 0 };
+fn xwFlush(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .int = 0 });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .int = 0 });
     var empty = true;
     if (args.len > 0 and args[0] == .bool) empty = args[0].bool;
     const rc = c.xmlTextWriterFlush(writer);
     // for memory writers, PHP returns the buffer contents string when emptying
     if (getBuffer(obj)) |buf| {
         const content = c.xmlBufferContent(buf);
-        if (content == null) return .{ .string = try dupString(ctx, "") };
+        if (content == null) return try NativeResult.copyString(ctx.allocator, "");
         const slice = content[0..cstrLen(content)];
-        const out = try dupString(ctx, slice);
+        const out = try NativeResult.copyString(ctx.allocator, slice);
         if (empty) c.xmlBufferEmpty(buf);
-        return .{ .string = out };
+        return out;
     }
-    return .{ .int = @intCast(rc) };
+    return NativeResult.scalar(.{ .int = @intCast(rc) });
 }
 
-fn xwSetIndent(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .bool) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwSetIndent(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .bool) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const rc = c.xmlTextWriterSetIndent(writer, if (args[0].bool) 1 else 0);
-    return .{ .bool = rc >= 0 };
+    return NativeResult.scalar(.{ .bool = rc >= 0 });
 }
 
-fn xwSetIndentString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwSetIndentString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const s_z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(s_z);
     const rc = c.xmlTextWriterSetIndentString(writer, @ptrCast(s_z.ptr));
-    return .{ .bool = rc >= 0 };
+    return NativeResult.scalar(.{ .bool = rc >= 0 });
 }
 
-fn xwStartDocument(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwStartDocument(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const ver_z: ?[:0]u8 = if (args.len > 0 and args[0] == .string) try dupZ(ctx, args[0].string.bytes()) else null;
     defer if (ver_z) |z| ctx.allocator.free(z);
     const enc_z: ?[:0]u8 = if (args.len > 1 and args[1] == .string and args[1].string.bytes().len > 0) try dupZ(ctx, args[1].string.bytes()) else null;
@@ -180,35 +181,35 @@ fn xwStartDocument(ctx: *NativeContext, args: []const Value) RuntimeError!Value 
     const enc_ptr: [*c]const u8 = if (enc_z) |z| @ptrCast(z.ptr) else null;
     const sta_ptr: [*c]const u8 = if (sta_z) |z| @ptrCast(z.ptr) else null;
     const rc = c.xmlTextWriterStartDocument(writer, ver_ptr, enc_ptr, sta_ptr);
-    return .{ .bool = rc >= 0 };
+    return NativeResult.scalar(.{ .bool = rc >= 0 });
 }
 
-fn xwEndDocument(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterEndDocument(writer) >= 0 };
+fn xwEndDocument(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterEndDocument(writer) >= 0 });
 }
 
-fn xwStartElement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwStartElement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(z);
-    return .{ .bool = c.xmlTextWriterStartElement(writer, @ptrCast(z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterStartElement(writer, @ptrCast(z.ptr)) >= 0 });
 }
 
-fn xwStartElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 3) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwStartElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const prefix_z: ?[:0]u8 = if (args[0] == .string and args[0].string.bytes().len > 0)
         try dupZ(ctx, args[0].string.bytes())
     else
         null;
     defer if (prefix_z) |z| ctx.allocator.free(z);
     const prefix_ptr: [*c]const u8 = if (prefix_z) |z| @ptrCast(z.ptr) else null;
-    if (args[1] != .string) return .{ .bool = false };
+    if (args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[1].string.bytes());
     defer ctx.allocator.free(name_z);
     const ns_z: ?[:0]u8 = if (args[2] == .string and args[2].string.bytes().len > 0)
@@ -217,55 +218,55 @@ fn xwStartElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value
         null;
     defer if (ns_z) |z| ctx.allocator.free(z);
     const ns_ptr: [*c]const u8 = if (ns_z) |z| @ptrCast(z.ptr) else null;
-    return .{ .bool = c.xmlTextWriterStartElementNS(writer, prefix_ptr, @ptrCast(name_z.ptr), ns_ptr) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterStartElementNS(writer, prefix_ptr, @ptrCast(name_z.ptr), ns_ptr) >= 0 });
 }
 
-fn xwEndElement(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterEndElement(writer) >= 0 };
+fn xwEndElement(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterEndElement(writer) >= 0 });
 }
 
-fn xwFullEndElement(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterFullEndElement(writer) >= 0 };
+fn xwFullEndElement(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterFullEndElement(writer) >= 0 });
 }
 
-fn xwWriteElement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwWriteElement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(name_z);
     const content_z: ?[:0]u8 = if (args.len > 1 and args[1] == .string) try dupZ(ctx, args[1].string.bytes()) else null;
     defer if (content_z) |z| ctx.allocator.free(z);
     const content_ptr: [*c]const u8 = if (content_z) |z| @ptrCast(z.ptr) else null;
-    return .{ .bool = c.xmlTextWriterWriteElement(writer, @ptrCast(name_z.ptr), content_ptr) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWriteElement(writer, @ptrCast(name_z.ptr), content_ptr) >= 0 });
 }
 
-fn xwWriteAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwWriteAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(name_z);
     const val_z = try dupZ(ctx, args[1].string.bytes());
     defer ctx.allocator.free(val_z);
-    return .{ .bool = c.xmlTextWriterWriteAttribute(writer, @ptrCast(name_z.ptr), @ptrCast(val_z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWriteAttribute(writer, @ptrCast(name_z.ptr), @ptrCast(val_z.ptr)) >= 0 });
 }
 
-fn xwWriteAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 4) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwWriteAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 4) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const prefix_z: ?[:0]u8 = if (args[0] == .string and args[0].string.bytes().len > 0)
         try dupZ(ctx, args[0].string.bytes())
     else
         null;
     defer if (prefix_z) |z| ctx.allocator.free(z);
     const prefix_ptr: [*c]const u8 = if (prefix_z) |z| @ptrCast(z.ptr) else null;
-    if (args[1] != .string or args[3] != .string) return .{ .bool = false };
+    if (args[1] != .string or args[3] != .string) return NativeResult.scalar(.{ .bool = false });
     const name_z = try dupZ(ctx, args[1].string.bytes());
     defer ctx.allocator.free(name_z);
     const ns_z: ?[:0]u8 = if (args[2] == .string and args[2].string.bytes().len > 0)
@@ -276,93 +277,93 @@ fn xwWriteAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!Val
     const ns_ptr: [*c]const u8 = if (ns_z) |z| @ptrCast(z.ptr) else null;
     const val_z = try dupZ(ctx, args[3].string.bytes());
     defer ctx.allocator.free(val_z);
-    return .{ .bool = c.xmlTextWriterWriteAttributeNS(writer, prefix_ptr, @ptrCast(name_z.ptr), ns_ptr, @ptrCast(val_z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWriteAttributeNS(writer, prefix_ptr, @ptrCast(name_z.ptr), ns_ptr, @ptrCast(val_z.ptr)) >= 0 });
 }
 
-fn xwStartAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwStartAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(z);
-    return .{ .bool = c.xmlTextWriterStartAttribute(writer, @ptrCast(z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterStartAttribute(writer, @ptrCast(z.ptr)) >= 0 });
 }
 
-fn xwEndAttribute(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterEndAttribute(writer) >= 0 };
+fn xwEndAttribute(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterEndAttribute(writer) >= 0 });
 }
 
-fn xwText(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwText(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(z);
-    return .{ .bool = c.xmlTextWriterWriteString(writer, @ptrCast(z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWriteString(writer, @ptrCast(z.ptr)) >= 0 });
 }
 
-fn xwWriteRaw(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwWriteRaw(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(z);
-    return .{ .bool = c.xmlTextWriterWriteRaw(writer, @ptrCast(z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWriteRaw(writer, @ptrCast(z.ptr)) >= 0 });
 }
 
-fn xwWriteCData(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwWriteCData(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(z);
-    return .{ .bool = c.xmlTextWriterWriteCDATA(writer, @ptrCast(z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWriteCDATA(writer, @ptrCast(z.ptr)) >= 0 });
 }
 
-fn xwStartCdata(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterStartCDATA(writer) >= 0 };
+fn xwStartCdata(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterStartCDATA(writer) >= 0 });
 }
 
-fn xwEndCdata(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterEndCDATA(writer) >= 0 };
+fn xwEndCdata(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterEndCDATA(writer) >= 0 });
 }
 
-fn xwWriteComment(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwWriteComment(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(z);
-    return .{ .bool = c.xmlTextWriterWriteComment(writer, @ptrCast(z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWriteComment(writer, @ptrCast(z.ptr)) >= 0 });
 }
 
-fn xwStartComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterStartComment(writer) >= 0 };
+fn xwStartComment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterStartComment(writer) >= 0 });
 }
 
-fn xwEndComment(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
-    return .{ .bool = c.xmlTextWriterEndComment(writer) >= 0 };
+fn xwEndComment(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterEndComment(writer) >= 0 });
 }
 
-fn xwWritePi(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
-    if (args.len < 2 or args[0] != .string or args[1] != .string) return .{ .bool = false };
-    const obj = getThis(ctx) orelse return .{ .bool = false };
-    const writer = getWriter(obj) orelse return .{ .bool = false };
+fn xwWritePi(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
+    const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const writer = getWriter(obj) orelse return NativeResult.scalar(.{ .bool = false });
     const t_z = try dupZ(ctx, args[0].string.bytes());
     defer ctx.allocator.free(t_z);
     const c_z = try dupZ(ctx, args[1].string.bytes());
     defer ctx.allocator.free(c_z);
-    return .{ .bool = c.xmlTextWriterWritePI(writer, @ptrCast(t_z.ptr), @ptrCast(c_z.ptr)) >= 0 };
+    return NativeResult.scalar(.{ .bool = c.xmlTextWriterWritePI(writer, @ptrCast(t_z.ptr), @ptrCast(c_z.ptr)) >= 0 });
 }
 
 // ---------------- registration ----------------
@@ -460,87 +461,87 @@ fn forwardOnObj(ctx: *NativeContext, args: []const Value, comptime instance_fn: 
 // for the procedural wrappers we directly invoke the instance fn by hand-rolling
 // the dispatch: copy the relevant args and present them with $this set. simplest
 // path: call the instance method through callMethod which sets up the frame
-fn procCall(ctx: *NativeContext, args: []const Value, comptime method: []const u8) RuntimeError!Value {
-    if (args.len < 1 or args[0] != .object) return .{ .bool = false };
-    return ctx.callMethod(args[0].object, method, args[1..]);
+fn procCall(ctx: *NativeContext, args: []const Value, comptime method: []const u8) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.share(try ctx.callMethod(args[0].object, method, args[1..]));
 }
 
-fn procOpenMemory(ctx: *NativeContext, _: []const Value) RuntimeError!Value {
+fn procOpenMemory(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     return xwToMemory(ctx, &.{});
 }
-fn procOpenURI(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procOpenURI(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return xwToUri(ctx, args);
 }
-fn procOutputMemory(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procOutputMemory(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "outputMemory");
 }
-fn procFlush(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procFlush(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "flush");
 }
-fn procSetIndent(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procSetIndent(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "setIndent");
 }
-fn procSetIndentString(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procSetIndentString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "setIndentString");
 }
-fn procStartDocument(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procStartDocument(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "startDocument");
 }
-fn procEndDocument(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procEndDocument(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "endDocument");
 }
-fn procStartElement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procStartElement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "startElement");
 }
-fn procStartElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procStartElementNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "startElementNS");
 }
-fn procEndElement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procEndElement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "endElement");
 }
-fn procFullEndElement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procFullEndElement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "fullEndElement");
 }
-fn procWriteElement(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procWriteElement(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "writeElement");
 }
-fn procWriteAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procWriteAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "writeAttribute");
 }
-fn procWriteAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procWriteAttributeNS(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "writeAttributeNS");
 }
-fn procStartAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procStartAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "startAttribute");
 }
-fn procEndAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procEndAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "endAttribute");
 }
-fn procText(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procText(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "text");
 }
-fn procWriteRaw(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procWriteRaw(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "writeRaw");
 }
-fn procWriteCData(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procWriteCData(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "writeCData");
 }
-fn procStartCdata(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procStartCdata(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "startCdata");
 }
-fn procEndCdata(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procEndCdata(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "endCdata");
 }
-fn procWriteComment(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procWriteComment(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "writeComment");
 }
-fn procStartComment(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procStartComment(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "startComment");
 }
-fn procEndComment(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procEndComment(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "endComment");
 }
-fn procWritePi(ctx: *NativeContext, args: []const Value) RuntimeError!Value {
+fn procWritePi(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     return procCall(ctx, args, "writePi");
 }
 

--- a/tests/native_result_ownership.php
+++ b/tests/native_result_ownership.php
@@ -1,0 +1,276 @@
+<?php
+// covers: native string results that share an argument, copy a literal,
+// transfer a fresh buffer, or forward a VM call result; results stored into
+// arrays and objects; direct native-to-native calls; __toString coercion;
+// PDO column values surviving statement teardown; file reads with offsets
+
+namespace Own\Deep {
+    /** the documented class */
+    class Doc
+    {
+        /** the documented method */
+        public function m(): string
+        {
+            return "m";
+        }
+    }
+}
+
+namespace {
+    function show($label, $v)
+    {
+        echo $label, ": ", var_export($v, true), "\n";
+    }
+
+    $s = "Hello, World";
+    show("substr-share", substr($s, 0));
+    show("substr-slice", substr($s, 7));
+    show("substr-copy", substr(strtoupper($s), 0, 5));
+    show("repeat-1", str_repeat($s, 1));
+    show("trim-noop", trim($s));
+    show("ucfirst-noop", ucfirst($s));
+    show("replace-nomatch", str_replace("zzz", "y", $s));
+    show("replace-match", str_replace("World", "PHP", $s));
+    show("shuffle-1", str_shuffle("a"));
+    show("implode", implode("-", explode(", ", $s)));
+    show("sprintf", sprintf("%s|%05d|%.2f", $s, 42, 3.14159));
+    show("lower-noop", strtolower("already"));
+
+    show("preg-nomatch", preg_replace('/zzz/', 'y', $s));
+    show("preg-match", preg_replace('/o/', '0', $s));
+    show("preg-array-subject", preg_replace('/l/', 'L', ["hello", "world", 7]));
+    show("preg-array-pattern", preg_replace(['/a/', '/b/'], ['1', '2'], "abcab"));
+    show("preg-limit", preg_replace('/a/', 'X', "banana", 2, $count));
+    show("preg-count", $count);
+    show("preg-callback", preg_replace_callback('/\d+/', fn($m) => $m[0] * 2, "a1b22c333"));
+    show("preg-callback-array", preg_replace_callback_array(['/a/' => fn($m) => 'A', '/b/' => fn($m) => 'B'], "aabb"));
+    show("preg-filter", preg_filter('/^a/', 'X', ["apple", "berry", "avocado"]));
+    show("preg-filter-scalar-nomatch", preg_filter('/^z/', 'X', "apple"));
+    show("preg-split", preg_split('/[\s,]+/', "a, b  c,d"));
+    show("preg-quote", preg_quote("a.b*c"));
+    show("preg-last-error-msg", preg_last_error_msg());
+
+    $arr = ["x" => 1, "y" => 2, 10 => 3];
+    show("array-search-key", array_search(2, $arr));
+    show("array-key-first", array_key_first($arr));
+    show("array-key-last", array_key_last($arr));
+    show("array-keys", array_keys($arr));
+    show("array-flip", array_flip(["a" => "b", "c" => "d"]));
+
+    $stored = [];
+    for ($i = 0; $i < 50; $i++) {
+        $stored[] = substr("prefix-" . $i, 7);
+        $stored[] = str_pad((string) $i, 3, "0", STR_PAD_LEFT);
+    }
+    show("stored-count", count($stored));
+    show("stored-tail", array_slice($stored, -4));
+
+    $obj = new stdClass();
+    $obj->name = strtoupper("counted");
+    $obj->copy = substr($obj->name, 0);
+    $obj->name = trim(" replaced ");
+    show("object-props", [$obj->name, $obj->copy]);
+
+    show("eval-string", eval('return "ev" . "al";'));
+    show("eval-int", eval('return 40 + 2;'));
+    show("eval-array", eval('return ["k" => strrev("abc")];'));
+
+    class Stringy
+    {
+        public function __toString(): string
+        {
+            return "stringy-" . str_repeat("x", 3);
+        }
+    }
+    $st = new Stringy();
+    show("tostring-concat", "<" . $st . ">");
+    show("tostring-strlen", strlen($st));
+    show("tostring-pad", str_pad($st, 12, "."));
+    show("tostring-in-array", in_array("stringy-xxx", [$st]));
+    show("tostring-strval", strval($st));
+
+    class Holder
+    {
+        public $v = 1;
+    }
+    $closure = function () {
+        return $this->v;
+    };
+    $h = new Holder();
+    $h->v = 7;
+    $bound = Closure::bind($closure, $h, Holder::class);
+    show("closure-bind", $bound());
+    $bound2 = $closure->bindTo($h);
+    show("closure-bindto", $bound2());
+    show("closure-call", $closure->call($h));
+    $fc = Closure::fromCallable('strtoupper');
+    show("closure-from-callable", $fc("abc"));
+
+    $rc = new ReflectionClass(\Own\Deep\Doc::class);
+    show("refl-short", $rc->getShortName());
+    show("refl-ns", $rc->getNamespaceName());
+    show("refl-doc", $rc->getDocComment());
+    show("refl-file", basename($rc->getFileName()));
+    $rm = $rc->getMethod("m");
+    show("refl-method-doc", $rm->getDocComment());
+    show("refl-method-file", basename($rm->getFileName()));
+    $rf = new ReflectionFunction('show');
+    show("refl-fn-short", $rf->getShortName());
+    show("refl-fn-ns", $rf->getNamespaceName());
+    $rp = new ReflectionProperty(Holder::class, "v");
+    show("refl-prop-value", $rp->getValue($h));
+    show("refl-prop-has-type", $rp->hasType());
+    show("refl-invoke", $rm->invoke(new \Own\Deep\Doc()));
+    show("refl-invoke-args", $rm->invokeArgs(new \Own\Deep\Doc(), []));
+
+    $pdo = new PDO("sqlite::memory:");
+    $pdo->exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, grp TEXT, price REAL)");
+    $ins = $pdo->prepare("INSERT INTO t (name, grp, price) VALUES (?, ?, ?)");
+    foreach ([["apple", "fruit", 1.5], ["pear", "fruit", 2.25], ["kale", "veg", 0.75], ["", "veg", 0]] as $row) {
+        $ins->execute($row);
+    }
+    $rows = [];
+    $st = $pdo->query("SELECT id, name, grp FROM t ORDER BY id");
+    $rows["assoc"] = $st->fetchAll(PDO::FETCH_ASSOC);
+    $st = $pdo->query("SELECT id, name FROM t ORDER BY id");
+    $rows["num"] = $st->fetchAll(PDO::FETCH_NUM);
+    $st = $pdo->query("SELECT id, name FROM t ORDER BY id");
+    $rows["both"] = $st->fetch(PDO::FETCH_BOTH);
+    $st = $pdo->query("SELECT name FROM t ORDER BY id");
+    $rows["column"] = $st->fetchAll(PDO::FETCH_COLUMN);
+    $st = $pdo->query("SELECT name, price FROM t ORDER BY id");
+    $rows["keypair"] = $st->fetchAll(PDO::FETCH_KEY_PAIR);
+    $st = $pdo->query("SELECT grp, name, price FROM t ORDER BY id");
+    $rows["group"] = $st->fetchAll(PDO::FETCH_GROUP | PDO::FETCH_ASSOC);
+    $st = $pdo->query("SELECT grp, name FROM t ORDER BY id");
+    $rows["unique"] = $st->fetchAll(PDO::FETCH_UNIQUE | PDO::FETCH_ASSOC);
+    $st = $pdo->query("SELECT name, price FROM t ORDER BY id");
+    $rows["func"] = $st->fetchAll(PDO::FETCH_FUNC, fn($n, $p) => $n . "=" . $p);
+    $st = $pdo->query("SELECT name, grp FROM t ORDER BY id");
+    $rows["obj"] = $st->fetch(PDO::FETCH_OBJ);
+    $st = $pdo->query("SELECT name, grp FROM t ORDER BY id");
+    $rows["named"] = $st->fetch(PDO::FETCH_NAMED);
+    $st = $pdo->query("SELECT name FROM t WHERE id = 2");
+    $rows["fetchcolumn"] = $st->fetchColumn();
+    $st = $pdo->query("SELECT name FROM t WHERE id = 4");
+    $rows["fetchcolumn-empty"] = $st->fetchColumn();
+    class Row
+    {
+        public $name;
+        public $grp;
+    }
+    $st = $pdo->query("SELECT name, grp FROM t ORDER BY id");
+    $st->setFetchMode(PDO::FETCH_CLASS, Row::class);
+    $rows["class"] = $st->fetch();
+    $st = null;
+    $pdo = null;
+    show("pdo-rows", $rows);
+    show("pdo-driver", "sqlite");
+
+    $tmp = tempnam(sys_get_temp_dir(), "own");
+    file_put_contents($tmp, "0123456789\nline two\nline three\n");
+    show("fgc-all", file_get_contents($tmp));
+    show("fgc-offset", file_get_contents($tmp, false, null, 4));
+    show("fgc-offset-length", file_get_contents($tmp, false, null, 2, 5));
+    show("fgc-negative-offset", file_get_contents($tmp, false, null, -6));
+    show("file-lines", file($tmp, FILE_IGNORE_NEW_LINES));
+    show("filetype", filetype($tmp));
+    show("readlink-basename", basename(realpath($tmp)) === basename($tmp));
+    show("pathinfo-ext", pathinfo("/a/b/c.tar.gz", PATHINFO_EXTENSION));
+    show("pathinfo-file", pathinfo("/a/b/c.tar.gz", PATHINFO_FILENAME));
+    show("pathinfo-dir", pathinfo("/a/b/c.tar.gz", PATHINFO_DIRNAME));
+    show("pathinfo-base", pathinfo("/a/b/c.tar.gz", PATHINFO_BASENAME));
+    $gz = $tmp . ".gz";
+    file_put_contents($gz, gzencode("alpha\nbeta\ngamma"));
+    show("gzfile", gzfile($gz));
+    show("gz-roundtrip", gzdecode(file_get_contents($gz)));
+    $fh = fopen($tmp, "r");
+    show("fgets", fgets($fh));
+    show("fread", fread($fh, 4));
+    fclose($fh);
+    $tf = tmpfile();
+    fwrite($tf, "temp data");
+    rewind($tf);
+    show("tmpfile", fread($tf, 100));
+    fclose($tf);
+    unlink($gz);
+    unlink($tmp);
+    show("stream-resolve", stream_resolve_include_path("/definitely/missing/path"));
+    show("sys-temp-dir-string", is_string(sys_get_temp_dir()));
+    show("uname-mode", in_array(php_uname("s"), ["Darwin", "Linux"], true));
+
+    $json = json_encode(["k" => ["nested" => "v", "n" => [1, 2, 3]], "s" => "str"]);
+    show("json", $json);
+    $decoded = json_decode($json, true);
+    $decoded["k"]["nested"] = strtoupper($decoded["k"]["nested"]);
+    show("json-decoded", $decoded);
+    $ser = serialize(["a" => "b", "o" => $h]);
+    show("serialize", $ser);
+    show("unserialize", unserialize($ser));
+    show("var-export-nul", var_export("a\0b", true));
+
+    $doc = new DOMDocument();
+    $doc->loadXML('<root a="1"><child>text</child><child>more</child></root>');
+    $root = $doc->documentElement;
+    show("dom-node-name", $root->nodeName);
+    show("dom-attr", $root->getAttribute("a"));
+    show("dom-first-child", $root->firstChild->textContent);
+    show("dom-item", $doc->getElementsByTagName("child")->item(1)->nodeValue);
+    show("dom-save", trim($doc->saveXML($root)));
+
+    $sx = simplexml_load_string('<r><i n="1">one</i><i n="2">two</i></r>');
+    show("sxml-string", (string) $sx->i[1]);
+    show("sxml-attr", (string) $sx->i[0]["n"]);
+    show("sxml-asxml", trim($sx->asXML()));
+
+    $w = new XMLWriter();
+    $w->openMemory();
+    $w->startElement("e");
+    $w->writeAttribute("k", "v");
+    $w->text("body");
+    $w->endElement();
+    show("xmlwriter", $w->outputMemory());
+    show("xmlwriter-flush-after", $w->outputMemory());
+
+    show("sodium-hex", sodium_bin2hex("\x01\xab"));
+    show("sodium-hash", sodium_bin2hex(sodium_crypto_generichash("abc", "", 16)));
+    show("hash", hash("sha256", "abc"));
+    show("md5", md5("abc"));
+    show("base64", base64_encode("abc"));
+    show("preg-scalar-subject", preg_replace('/l/', 'L', 7));
+    show("preg-callback-scalar-subject", preg_replace_callback('/7/', fn($m) => "x", 7));
+    show("preg-callback-array-scalar-subject", preg_replace_callback_array(['/7/' => fn($m) => "y"], 7));
+
+    date_default_timezone_set("UTC");
+    show("tz-get", date_default_timezone_get());
+    $dt = new DateTime("2024-02-29 12:34:56", new DateTimeZone("UTC"));
+    show("date-format", $dt->format("Y-m-d H:i:s T"));
+    show("tz-name", $dt->getTimezone()->getName());
+    show("date-fn", date("D, d M Y", 86400 * 365));
+    show("strtotime", strtotime("2024-01-01 00:00:00 UTC"));
+    show("date-parse", date_parse("2024-02-29 12:34:56")["year"]);
+
+    $ini = parse_ini_string("a=1\nb=two\n[sec]\nc=3", true);
+    show("ini", $ini);
+    show("version-compare", version_compare("8.4.0", "8.5.0"));
+    show("uniqid-len", strlen(uniqid()) >= 13);
+    show("escapeshellarg", escapeshellarg("it's"));
+    show("shell-exec", trim(shell_exec("echo shell-ok")));
+
+    $it = new ArrayIterator(["p" => "q", "r" => "s"]);
+    $out = [];
+    foreach (new RegexIterator($it, '/^[qs]$/') as $k => $v) {
+        $out[$k] = strtoupper($v);
+    }
+    show("regex-iterator", $out);
+    $heap = new SplPriorityQueue();
+    $heap->insert("low", 1);
+    $heap->insert("high", 9);
+    show("pq-extract", $heap->extract());
+    $heap->next();
+    show("pq-valid", $heap->valid());
+    show("mb-convert", mb_convert_encoding("caf\xc3\xa9", "ISO-8859-1", "UTF-8") === "caf\xe9");
+    show("filter-var", filter_var("42", FILTER_VALIDATE_INT));
+    show("filter-var-array", filter_var_array(["n" => "7", "e" => "a@b.c"], ["n" => FILTER_VALIDATE_INT, "e" => FILTER_VALIDATE_EMAIL]));
+    show("done", true);
+}


### PR DESCRIPTION
Every native function now returns RuntimeError!NativeResult, which names the ownership of a string result at the return site: scalar, borrowed, literal, copyString, takeString, share, or transfer. VM.invokeNative unwraps the value and the registry rejects any native with the wrong return type at compile time, so the contract is enforced for every registered native and method native.

Strings that natives used to leave in the request arena are now counted and released by their last holder. PDO column values, intl conversions, file reads, and the reflection, dom, sodium, system, gmp, gd, curl, mysqli, xml, and pcre modules were converted, along with the helpers behind them. The Debug allocator run of the compat suite found a double free and a leak in file_get_contents and a leak in every __toString coercion, all fixed here.

preg_replace, preg_replace_callback, and preg_replace_callback_array now coerce scalar subjects to strings as PHP does. tests/native_result_ownership.php exercises the contract end to end.
