### PR TITLE
Canonicalize directories once and cache zone files

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -173,9 +173,62 @@ fn compileCachePath(allocator: std.mem.Allocator, path: []const u8, stat: std.fs
     hasher.update(std.mem.asBytes(&closure_counter));
     hasher.final(&digest);
     const hex = std.fmt.bytesToHex(digest, .lower);
-    const cache_root = try std.fs.getAppDataDir(allocator, "zphp");
-    defer allocator.free(cache_root);
+    const cache_root = try compileCacheRoot(allocator);
     return std.fmt.allocPrint(allocator, "{s}/{s}/{s}.zphpc", .{ cache_root, compile_cache_dir, hex });
+}
+
+// resolved once per process from the page allocator so the Debug allocator
+// does not report a deliberate process-lifetime allocation at exit
+var compile_cache_root: ?[]const u8 = null;
+
+fn compileCacheRoot(allocator: std.mem.Allocator) ![]const u8 {
+    if (compile_cache_root) |root| return root;
+    _ = allocator;
+    const root = try std.fs.getAppDataDir(std.heap.page_allocator, "zphp");
+    compile_cache_root = root;
+    return root;
+}
+
+const ResolvedSource = struct { abs_path: []const u8, stat: std.fs.File.Stat };
+
+// a file load used to cost a realpath (open + fcntl + close on macOS) plus
+// open + fstat before the bytecode cache was even consulted. directories
+// are canonicalized once per process and the file itself gets one lstat;
+// a file that is itself a symlink takes the full realpath route
+fn resolveSource(allocator: std.mem.Allocator, vm: *VM, path: []const u8) ?ResolvedSource {
+    const base = std.fs.path.basename(path);
+    if (base.len > 0 and !std.mem.eql(u8, base, ".") and !std.mem.eql(u8, base, "..")) {
+        if (realDir(vm, std.fs.path.dirname(path) orelse ".")) |real_dir| {
+            const sep: []const u8 = if (std.mem.endsWith(u8, real_dir, "/")) "" else "/";
+            const abs = std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ real_dir, sep, base }) catch return null;
+            if (std.posix.fstatat(std.posix.AT.FDCWD, abs, std.posix.AT.SYMLINK_NOFOLLOW)) |st| {
+                const mode: u32 = @intCast(st.mode);
+                if (std.posix.S.ISREG(mode)) return .{ .abs_path = abs, .stat = std.fs.File.Stat.fromPosix(st) };
+            } else |_| {}
+            allocator.free(abs);
+        }
+    }
+    const abs = std.fs.cwd().realpathAlloc(allocator, path) catch allocator.dupe(u8, path) catch return null;
+    const stat = std.fs.cwd().statFile(abs) catch {
+        allocator.free(abs);
+        return null;
+    };
+    return .{ .abs_path = abs, .stat = stat };
+}
+
+fn realDir(vm: *VM, dir: []const u8) ?[]const u8 {
+    if (vm.realdir_cache.get(dir)) |real| return real;
+    const real = std.fs.cwd().realpathAlloc(vm.allocator, dir) catch return null;
+    const key = vm.allocator.dupe(u8, dir) catch {
+        vm.allocator.free(real);
+        return null;
+    };
+    vm.realdir_cache.put(vm.allocator, key, real) catch {
+        vm.allocator.free(key);
+        vm.allocator.free(real);
+        return null;
+    };
+    return real;
 }
 
 fn loadCompileCache(allocator: std.mem.Allocator, path: []const u8, stat: std.fs.File.Stat, closure_counter: u32) ?*CompileResult {
@@ -292,20 +345,18 @@ fn loadFile(path: []const u8, allocator: std.mem.Allocator, vm: *@import("runtim
             return null;
         };
     } else {
-        abs_path = std.fs.cwd().realpathAlloc(allocator, path) catch allocator.dupe(u8, path) catch return null;
+        const resolved = resolveSource(allocator, vm, path) orelse return null;
+        abs_path = resolved.abs_path;
+        const stat = resolved.stat;
+        if (loadCompileCache(allocator, abs_path, stat, closure_counter)) |cached| {
+            allocator.free(abs_path);
+            return cached;
+        }
         const file = std.fs.cwd().openFile(abs_path, .{}) catch {
             allocator.free(abs_path);
             return null;
         };
         defer file.close();
-        const stat = file.stat() catch {
-            allocator.free(abs_path);
-            return null;
-        };
-        if (loadCompileCache(allocator, abs_path, stat, closure_counter)) |cached| {
-            allocator.free(abs_path);
-            return cached;
-        }
         source = file.readToEndAlloc(allocator, max_source_size) catch {
             allocator.free(abs_path);
             return null;

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -597,6 +597,9 @@ pub const VM = struct {
     global_vars: std.ArrayListUnmanaged(StaticEntry) = .{},
     file_loader: ?*const FileLoader = null,
     loaded_files: std.StringHashMapUnmanaged(void) = .{},
+    // canonical directory paths keyed by the spelling a require used, so a
+    // file load costs one lstat instead of a realpath per file
+    realdir_cache: std.StringHashMapUnmanaged([]const u8) = .{},
     // protocols whose builtin stream wrapper has been disabled via stream_wrapper_unregister
     stream_wrappers_unregistered: std.StringHashMapUnmanaged(void) = .{},
     // protocol -> user class name registered via stream_wrapper_register
@@ -2646,6 +2649,8 @@ pub const VM = struct {
         self.static_vars.deinit(self.allocator);
         self.global_vars.deinit(self.allocator);
         self.loaded_files.deinit(self.allocator);
+        self.clearRealDirCache();
+        self.realdir_cache.deinit(self.allocator);
         self.stream_wrappers_unregistered.deinit(self.allocator);
         self.stream_wrappers_user.deinit(self.allocator);
         if (self.serve_mode) {
@@ -2665,6 +2670,15 @@ pub const VM = struct {
         for (self.serve_cache_keys.items) |k| self.allocator.free(k);
         self.serve_cache_keys.deinit(self.allocator);
         self.serve_compile_cache.deinit(self.allocator);
+    }
+
+    pub fn clearRealDirCache(self: *VM) void {
+        var it = self.realdir_cache.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.realdir_cache.clearRetainingCapacity();
     }
 
     pub fn reset(self: *VM) void {
@@ -2770,6 +2784,7 @@ pub const VM = struct {
         self.static_vars.clearRetainingCapacity();
         self.global_vars.clearRetainingCapacity();
         self.loaded_files.clearRetainingCapacity();
+        self.clearRealDirCache();
         self.stream_wrappers_unregistered.clearRetainingCapacity();
         self.stream_wrappers_user.clearRetainingCapacity();
         self.magic_get_guard.clearRetainingCapacity();

--- a/src/stdlib/datetime.zig
+++ b/src/stdlib/datetime.zig
@@ -3792,10 +3792,22 @@ const TzBytes = struct {
     }
 };
 
+// zone files are read once per process: tzdata does not change while zphp
+// runs and every date() call in a timezone-aware app would otherwise reopen
+// /usr/share/zoneinfo/<name>. entries are keyed by the requested name and
+// never freed (a few KB per distinct zone); the mutex covers threaded serve
+var zone_cache: std.StringHashMapUnmanaged([]const u8) = .{};
+var zone_cache_mutex: std.Thread.Mutex = .{};
+
 fn resolveTzif(allocator: Allocator, name: []const u8) ?TzBytes {
-    if (readZoneInfo(allocator, name)) |b| return .{ .bytes = b, .owned = true };
-    if (embeddedZoneInfo(name)) |b| return .{ .bytes = b, .owned = false };
-    return null;
+    zone_cache_mutex.lock();
+    defer zone_cache_mutex.unlock();
+    if (zone_cache.get(name)) |b| return .{ .bytes = b, .owned = false };
+    const bytes: []const u8 = readZoneInfo(std.heap.page_allocator, name) orelse embeddedZoneInfo(name) orelse return null;
+    const key = std.heap.page_allocator.dupe(u8, name) catch return .{ .bytes = bytes, .owned = false };
+    zone_cache.put(std.heap.page_allocator, key, bytes) catch {};
+    _ = allocator;
+    return .{ .bytes = bytes, .owned = false };
 }
 
 test "embedded tzdata resolves non-table zones without system zoneinfo" {


### PR DESCRIPTION
Loading a PHP file cost a realpath (open, fcntl, close on macOS) plus an open and fstat before the bytecode cache was consulted, nine syscalls per cached file. resolveSource canonicalizes each directory once per process and does a single lstat on the file; a file that is itself a symlink takes the full realpath route. The cache miss path opens and re-stats the file as before. The bytecode cache root is resolved once per process.

Zone files are now read once per process instead of on every date() call in a timezone-aware application.

Laravel and WordPress harnesses run 2 to 6% faster; nothing regressed.
