### PR TITLE
PHP 8.4 gaps: Deprecated, lazy reset, BcMath\Number, ReflectionConstant

### DIFF
--- a/src/fast_loop.zig
+++ b/src/fast_loop.zig
@@ -109,6 +109,11 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                 .add => {
                     const b = self.stack[sp - 1];
                     const a = self.stack[sp - 2];
+                    if (a == .object or b == .object) {
+                        frame.ip = ip - 1;
+                        self.sp = sp;
+                        return;
+                    }
                     sp -= 2;
                     self.stackRelease(a);
                     self.stackRelease(b);
@@ -121,6 +126,11 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                 .subtract => {
                     const b = self.stack[sp - 1];
                     const a = self.stack[sp - 2];
+                    if (a == .object or b == .object) {
+                        frame.ip = ip - 1;
+                        self.sp = sp;
+                        return;
+                    }
                     sp -= 2;
                     self.stackRelease(a);
                     self.stackRelease(b);
@@ -133,6 +143,11 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                 .multiply => {
                     const b = self.stack[sp - 1];
                     const a = self.stack[sp - 2];
+                    if (a == .object or b == .object) {
+                        frame.ip = ip - 1;
+                        self.sp = sp;
+                        return;
+                    }
                     sp -= 2;
                     self.stackRelease(a);
                     self.stackRelease(b);
@@ -227,6 +242,11 @@ fn fastLoopImpl(self: *VM) RuntimeError!void {
                 .modulo => {
                     const b_mod = self.stack[sp - 1];
                     const a_mod = self.stack[sp - 2];
+                    if (a_mod == .object or b_mod == .object) {
+                        frame.ip = ip - 1;
+                        self.sp = sp;
+                        return;
+                    }
                     sp -= 2;
                     self.stackRelease(a_mod);
                     self.stackRelease(b_mod);

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -224,6 +224,7 @@ pub const NativeContext = struct {
 
 pub const NativeResult = @import("native_result.zig").NativeResult;
 const NativeFn = *const fn (*NativeContext, []const Value) RuntimeError!NativeResult;
+pub const NativeBinop = enum { add, sub, mul, div, mod, pow, compare, negate };
 
 pub const CaptureEntry = struct {
     closure_name: []const u8,
@@ -280,6 +281,10 @@ pub const ClassDef = struct {
     is_final: bool = false,
     is_readonly: bool = false,
     native_cleanup: ?*const fn (*PhpObject) bool = null,
+    // arithmetic and comparison on instances of a native class (BcMath\Number).
+    // null result means the operand pair is not supported and the ordinary
+    // TypeError path runs
+    native_binop: ?*const fn (*NativeContext, NativeBinop, Value, Value) RuntimeError!?Value = null,
     // set when any property-hook method ($hook_get/$hook_set) is registered on
     // this class. lets hasPropHook skip the per-access bufPrint + method lookup
     // for the >99% of classes that declare no hooks (PHP 8.4 feature). does not
@@ -1410,6 +1415,7 @@ pub const VM = struct {
         try @import("../stdlib/xml_parser.zig").register(vm, allocator);
         try @import("../stdlib/intl.zig").register(vm, allocator);
         try @import("../stdlib/gmp.zig").register(vm, allocator);
+        try @import("../stdlib/bcmath.zig").register(vm, allocator);
         try @import("../stdlib/gd.zig").register(vm, allocator);
         try @import("../stdlib/soap.zig").register(vm, allocator);
         try @import("../stdlib/mysqli.zig").register(vm, allocator);
@@ -1880,6 +1886,9 @@ pub const VM = struct {
         try c.put(a, "E_USER_WARNING", .{ .int = 512 });
         try c.put(a, "E_USER_NOTICE", .{ .int = 1024 });
         try c.put(a, "E_STRICT", .{ .int = 2048 });
+        inline for (.{ .{ "PHP_OUTPUT_HANDLER_START", 1 }, .{ "PHP_OUTPUT_HANDLER_WRITE", 0 }, .{ "PHP_OUTPUT_HANDLER_FLUSH", 4 }, .{ "PHP_OUTPUT_HANDLER_CLEAN", 2 }, .{ "PHP_OUTPUT_HANDLER_FINAL", 8 }, .{ "PHP_OUTPUT_HANDLER_CONT", 0 }, .{ "PHP_OUTPUT_HANDLER_END", 8 }, .{ "PHP_OUTPUT_HANDLER_CLEANABLE", 16 }, .{ "PHP_OUTPUT_HANDLER_FLUSHABLE", 32 }, .{ "PHP_OUTPUT_HANDLER_REMOVABLE", 64 }, .{ "PHP_OUTPUT_HANDLER_STDFLAGS", 112 }, .{ "PHP_OUTPUT_HANDLER_STARTED", 4096 }, .{ "PHP_OUTPUT_HANDLER_DISABLED", 8192 }, .{ "PHP_OUTPUT_HANDLER_PROCESSED", 16384 } }) |k| {
+            try c.put(a, k[0], .{ .int = k[1] });
+        }
         try c.put(a, "E_RECOVERABLE_ERROR", .{ .int = 4096 });
         try c.put(a, "E_DEPRECATED", .{ .int = 8192 });
         try c.put(a, "E_USER_DEPRECATED", .{ .int = 16384 });
@@ -3415,6 +3424,10 @@ pub const VM = struct {
                     if (a == .array and b == .array) {
                         self.push(.{ .array = try self.arrayUnion(a.array, b.array) });
                     } else {
+                        if (try self.objectBinop(.add, a, b)) |r| {
+                            self.push(r);
+                            continue;
+                        }
                         if (try self.checkArithOperands(a, b, "+")) continue;
                         self.push(Value.add(a, b));
                     }
@@ -3422,12 +3435,20 @@ pub const VM = struct {
                 .subtract => {
                     const b = self.pop();
                     const a = self.pop();
+                    if (try self.objectBinop(.sub, a, b)) |r| {
+                        self.push(r);
+                        continue;
+                    }
                     if (try self.checkArithOperands(a, b, "-")) continue;
                     self.push(Value.subtract(a, b));
                 },
                 .multiply => {
                     const b = self.pop();
                     const a = self.pop();
+                    if (try self.objectBinop(.mul, a, b)) |r| {
+                        self.push(r);
+                        continue;
+                    }
                     if (try self.checkArithOperands(a, b, "*")) continue;
                     self.push(Value.multiply(a, b));
                 },
@@ -3444,6 +3465,10 @@ pub const VM = struct {
                 .divide => {
                     const b = self.pop();
                     const a = self.pop();
+                    if (try self.objectBinop(.div, a, b)) |r| {
+                        self.push(r);
+                        continue;
+                    }
                     if (try self.checkArithOperands(a, b, "/")) continue;
                     const bv = Value.toFloat(b);
                     if (bv == 0.0) {
@@ -3455,6 +3480,10 @@ pub const VM = struct {
                 .modulo => {
                     const b = self.pop();
                     const a = self.pop();
+                    if (try self.objectBinop(.mod, a, b)) |r| {
+                        self.push(r);
+                        continue;
+                    }
                     if (try self.checkArithOperands(a, b, "%")) continue;
                     const bi = Value.toInt(b);
                     if (bi == 0) {
@@ -3466,11 +3495,19 @@ pub const VM = struct {
                 .power => {
                     const b = self.pop();
                     const a = self.pop();
+                    if (try self.objectBinop(.pow, a, b)) |r| {
+                        self.push(r);
+                        continue;
+                    }
                     if (try self.checkArithOperands(a, b, "**")) continue;
                     self.push(Value.power(a, b));
                 },
                 .negate => {
                     const v = self.pop();
+                    if (try self.objectBinop(.negate, v, .null)) |r| {
+                        self.push(r);
+                        continue;
+                    }
                     if (!isArithOperand(v)) {
                         const tn = arithTypeName(v);
                         const msg = try std.fmt.allocPrint(self.allocator, "Cannot negate {s}", .{tn});
@@ -10778,24 +10815,42 @@ pub const VM = struct {
     pub fn getStaticProp(self: *VM, class_name: []const u8, prop_name: []const u8) ?Value {
         var current: ?[]const u8 = class_name;
         while (current) |cn| {
-            if (self.classes.getPtr(cn)) |cls| {
-                if (cls.static_props.get(prop_name)) |val| return val;
-                for (cls.interfaces.items) |iface| {
-                    if (self.getStaticProp(iface, prop_name)) |val| return val;
-                }
-                current = cls.parent;
+            if (self.classes.contains(cn)) {
+                if (self.staticPropStep(cn, prop_name)) |step| {
+                    if (step.found) |val| return val;
+                    current = step.parent;
+                } else break;
             } else {
                 self.tryAutoload(cn) catch {};
-                if (self.classes.getPtr(cn)) |cls| {
-                    if (cls.static_props.get(prop_name)) |val| return val;
-                    for (cls.interfaces.items) |iface| {
-                        if (self.getStaticProp(iface, prop_name)) |val| return val;
-                    }
-                    current = cls.parent;
+                if (self.staticPropStep(cn, prop_name)) |step| {
+                    if (step.found) |val| return val;
+                    current = step.parent;
                 } else break;
             }
         }
         return null;
+    }
+
+    const StaticPropStep = struct { found: ?Value, parent: ?[]const u8 };
+
+    // one class of the lookup chain. the interface walk can autoload, which
+    // rehashes `classes`, so the class entry is never held across that
+    // recursion: names are copied out first and only they are used after
+    fn staticPropStep(self: *VM, cn: []const u8, prop_name: []const u8) ?StaticPropStep {
+        var ifaces: [64][]const u8 = undefined;
+        var n: usize = 0;
+        var parent: ?[]const u8 = null;
+        {
+            const cls = self.classes.getPtr(cn) orelse return null;
+            if (cls.static_props.get(prop_name)) |val| return .{ .found = val, .parent = null };
+            n = @min(cls.interfaces.items.len, ifaces.len);
+            @memcpy(ifaces[0..n], cls.interfaces.items[0..n]);
+            parent = cls.parent;
+        }
+        for (ifaces[0..n]) |iface| {
+            if (self.getStaticProp(iface, prop_name)) |val| return .{ .found = val, .parent = null };
+        }
+        return .{ .found = null, .parent = parent };
     }
 
     // like getStaticProp but returns a pointer to the storage slot (walking the
@@ -11147,6 +11202,17 @@ pub const VM = struct {
     /// PHP 8 rejects non-numeric strings, arrays (except for +), and objects
     /// without __toString as arithmetic operands with TypeError. returns true
     /// when the throw was caught in-frame and the caller should `continue`
+    fn objectBinop(self: *VM, op: NativeBinop, a: Value, b: Value) RuntimeError!?Value {
+        if (a != .object and b != .object) return null;
+        const hook = blk: {
+            if (a == .object) if (self.classes.get(a.object.class_name)) |cls| if (cls.native_binop) |h| break :blk h;
+            if (b == .object) if (self.classes.get(b.object.class_name)) |cls| if (cls.native_binop) |h| break :blk h;
+            return null;
+        };
+        var ctx = self.makeContext(null);
+        return hook(&ctx, op, a, b);
+    }
+
     pub fn checkArithOperands(self: *VM, a: Value, b: Value, comptime op: []const u8) RuntimeError!bool {
         if (isArithOperand(a) and isArithOperand(b)) {
             if (a == .string and isPartialNumericString(a.string.bytes())) self.emitNonNumericWarning();
@@ -14842,6 +14908,7 @@ pub const VM = struct {
 
     // mirror of looseEqualWithStringable for ordered comparisons
     pub fn compareWithStringable(self: *VM, a: Value, b: Value) RuntimeError!i64 {
+        if (try self.objectBinop(.compare, a, b)) |r| return r.int;
         if (a == .object and b == .string) {
             if (self.hasMethod(a.object.class_name, "__toString")) {
                 const s = try self.callMethod(a.object, "__toString", &.{});
@@ -14860,6 +14927,7 @@ pub const VM = struct {
     // __toString and compares as strings. Value.equal can't reach into the VM
     // to call methods, so this wrapper does that coercion before delegating
     pub fn looseEqualWithStringable(self: *VM, a: Value, b: Value) RuntimeError!bool {
+        if (try self.objectBinop(.compare, a, b)) |r| return r.int == 0;
         if (a == .object and b == .string) {
             if (self.hasMethod(a.object.class_name, "__toString")) {
                 const s = try self.callMethod(a.object, "__toString", &.{});

--- a/src/stdlib/bcmath.zig
+++ b/src/stdlib/bcmath.zig
@@ -326,14 +326,24 @@ fn bcDivInternal(allocator: Allocator, a: BcNum, b: BcNum, target_scale: usize) 
     // we can truncate. simpler approach: convert both to integer reps with extra
     // zeros to control the scale.
 
-    // make a' = a * 10^(target_scale + b.scale - a.scale) (integer), b' = b (integer)
-    const extra_a: usize = target_scale + b.scale - a.scale + 1;
+    // make a' = a * 10^(target_scale + b.scale - a.scale) (integer), b' = b (integer).
+    // a dividend more precise than the target needs its low digits dropped
+    // instead: truncating before an integer division truncates the quotient
+    // at the same place
+    const shift: i64 = @as(i64, @intCast(target_scale + b.scale + 1)) - @as(i64, @intCast(a.scale));
 
     var num_digits = std.ArrayListUnmanaged(u8){};
     defer num_digits.deinit(allocator);
-    try num_digits.appendSlice(allocator, a.digits.items);
-    var i: usize = 0;
-    while (i < extra_a) : (i += 1) try num_digits.append(allocator, 0);
+    if (shift >= 0) {
+        try num_digits.appendSlice(allocator, a.digits.items);
+        var i: usize = 0;
+        while (i < @as(usize, @intCast(shift))) : (i += 1) try num_digits.append(allocator, 0);
+    } else {
+        const drop: usize = @intCast(-shift);
+        const keep = if (drop >= a.digits.items.len) 0 else a.digits.items.len - drop;
+        try num_digits.appendSlice(allocator, a.digits.items[0..keep]);
+        if (num_digits.items.len == 0) try num_digits.append(allocator, 0);
+    }
 
     var div_digits = std.ArrayListUnmanaged(u8){};
     defer div_digits.deinit(allocator);
@@ -1059,3 +1069,535 @@ pub const entries = .{
     .{ "bcfloor", bcFloor },
     .{ "bcround", bcRound },
 };
+
+// ---------------- BcMath\Number (PHP 8.4) ----------------
+//
+// an immutable arbitrary-precision decimal: `value` is the canonical digit
+// string, `scale` its count of fractional digits. every operation is routed
+// through the procedural natives above with the scale PHP picks: add/sub/mod
+// use the larger operand scale, mul the sum, div/sqrt/negative pow compute
+// ten extra digits and drop trailing zeros back down to the left operand's
+// scale, positive pow multiplies the scale by the exponent
+
+const number_class = "BcMath\\Number";
+
+pub fn register(vm: *VM, a: Allocator) !void {
+    var def = ClassDef{ .name = number_class, .is_final = true, .is_readonly = true, .native_binop = numberBinop };
+    try def.properties.append(a, .{ .name = "value", .default = .{ .string = Value.String.borrowed("0") }, .has_default = true, .is_readonly = true, .type_str = "string" });
+    try def.properties.append(a, .{ .name = "scale", .default = .{ .int = 0 }, .has_default = true, .is_readonly = true, .type_str = "int" });
+    const methods = .{
+        .{ "__construct", 1 }, .{ "add", 2 },     .{ "sub", 2 },        .{ "mul", 2 },         .{ "div", 2 },           .{ "mod", 2 },
+        .{ "divmod", 2 },      .{ "powmod", 3 },  .{ "pow", 2 },        .{ "sqrt", 1 },        .{ "floor", 0 },         .{ "ceil", 0 },
+        .{ "round", 2 },       .{ "compare", 2 }, .{ "__toString", 0 }, .{ "__serialize", 0 }, .{ "__unserialize", 1 },
+    };
+    inline for (methods) |m| try def.methods.put(a, m[0], .{ .name = m[0], .arity = m[1] });
+    try vm.classes.put(a, number_class, def);
+    const natives = .{
+        .{ "__construct", numberConstruct },     .{ "add", numberAdd },         .{ "sub", numberSub },             .{ "mul", numberMul },
+        .{ "div", numberDiv },                   .{ "mod", numberMod },         .{ "divmod", numberDivmod },       .{ "powmod", numberPowmod },
+        .{ "pow", numberPow },                   .{ "sqrt", numberSqrt },       .{ "floor", numberFloor },         .{ "ceil", numberCeil },
+        .{ "round", numberRound },               .{ "compare", numberCompare }, .{ "__toString", numberToString }, .{ "__serialize", numberSerialize },
+        .{ "__unserialize", numberUnserialize },
+    };
+    inline for (natives) |n| try vm.native_fns.put(a, number_class ++ "::" ++ n[0], n[1]);
+}
+
+fn isNumberObject(v: Value) bool {
+    return v == .object and std.mem.eql(u8, v.object.class_name, number_class);
+}
+
+fn numberThis(ctx: *NativeContext) ?*PhpObject {
+    const this_v = ctx.vm.currentFrame().vars.get("$this") orelse return null;
+    if (!isNumberObject(this_v)) return null;
+    return this_v.object;
+}
+
+fn wellFormed(s: []const u8) bool {
+    var i: usize = 0;
+    if (i < s.len and (s[i] == '+' or s[i] == '-')) i += 1;
+    var digits: usize = 0;
+    while (i < s.len and std.ascii.isDigit(s[i])) : (i += 1) digits += 1;
+    if (i < s.len and s[i] == '.') {
+        i += 1;
+        while (i < s.len and std.ascii.isDigit(s[i])) : (i += 1) digits += 1;
+    }
+    return i == s.len and digits > 0;
+}
+
+fn scaleOf(s: []const u8) usize {
+    const dot = std.mem.indexOfScalar(u8, s, '.') orelse return 0;
+    return s.len - dot - 1;
+}
+
+// canonical form: no plus sign, no leading zeros in the integer part, the
+// fractional digits exactly as given, and no sign on zero
+fn canonical(allocator: Allocator, raw: []const u8) ![]u8 {
+    var s = raw;
+    var neg = false;
+    if (s.len > 0 and (s[0] == '+' or s[0] == '-')) {
+        neg = s[0] == '-';
+        s = s[1..];
+    }
+    const dot = std.mem.indexOfScalar(u8, s, '.');
+    var int_part = if (dot) |d| s[0..d] else s;
+    const frac_part = if (dot) |d| s[d + 1 ..] else "";
+    while (int_part.len > 1 and int_part[0] == '0') int_part = int_part[1..];
+    if (int_part.len == 0) int_part = "0";
+    var nonzero = false;
+    for (int_part) |c| if (c != '0') {
+        nonzero = true;
+    };
+    for (frac_part) |c| if (c != '0') {
+        nonzero = true;
+    };
+    var out = std.ArrayListUnmanaged(u8){};
+    errdefer out.deinit(allocator);
+    if (neg and nonzero) try out.append(allocator, '-');
+    try out.appendSlice(allocator, int_part);
+    if (frac_part.len > 0) {
+        try out.append(allocator, '.');
+        try out.appendSlice(allocator, frac_part);
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+// drops trailing fractional zeros, never below `min_scale` digits
+fn stripToScale(s: []const u8, min_scale: usize) []const u8 {
+    const dot = std.mem.indexOfScalar(u8, s, '.') orelse return s;
+    var end = s.len;
+    while (end > dot + 1 + min_scale and s[end - 1] == '0') end -= 1;
+    if (end == dot + 1) end = dot;
+    return s[0..end];
+}
+
+fn throwNotWellFormed(ctx: *NativeContext, comptime method: []const u8, comptime arg: []const u8) RuntimeError {
+    _ = ctx.vm.throwBuiltinException("ValueError", number_class ++ "::" ++ method ++ "(): Argument #1 ($" ++ arg ++ ") is not well-formed") catch {};
+    return error.RuntimeError;
+}
+
+// the decimal string an operand contributes; owned by the caller
+fn operandString(ctx: *NativeContext, v: Value, comptime method: []const u8, comptime arg: []const u8) RuntimeError![]u8 {
+    switch (v) {
+        .object => |obj| {
+            if (!isNumberObject(v)) return throwNotWellFormed(ctx, method, arg);
+            const val = obj.get("value");
+            return try ctx.allocator.dupe(u8, if (val == .string) val.string.bytes() else "0");
+        },
+        .int => |i| return try std.fmt.allocPrint(ctx.allocator, "{d}", .{i}),
+        .float => |f| return try std.fmt.allocPrint(ctx.allocator, "{d}", .{@as(i64, @intFromFloat(f))}),
+        .bool => |b| return try ctx.allocator.dupe(u8, if (b) "1" else "0"),
+        .string => |str| {
+            if (str.len == 0) return try ctx.allocator.dupe(u8, "0");
+            if (!wellFormed(str.bytes())) return throwNotWellFormed(ctx, method, arg);
+            return try canonical(ctx.allocator, str.bytes());
+        },
+        else => return throwNotWellFormed(ctx, method, arg),
+    }
+}
+
+fn makeNumber(ctx: *NativeContext, raw: []const u8) RuntimeError!*PhpObject {
+    const obj = try ctx.createObject(number_class);
+    try setNumber(ctx, obj, raw);
+    return obj;
+}
+
+fn setNumber(ctx: *NativeContext, obj: *PhpObject, raw: []const u8) RuntimeError!void {
+    const canon = try canonical(ctx.allocator, raw);
+    defer ctx.allocator.free(canon);
+    const owned = try Value.String.create(ctx.allocator, canon);
+    defer owned.release();
+    try obj.set(ctx.allocator, "value", .{ .string = owned });
+    try obj.set(ctx.allocator, "scale", .{ .int = @intCast(scaleOf(canon)) });
+}
+
+fn explicitScale(args: []const Value, idx: usize) ?usize {
+    if (args.len > idx and args[idx] == .int and args[idx].int >= 0) return @intCast(args[idx].int);
+    return null;
+}
+
+// runs a procedural native on two decimal strings at a fixed scale and hands
+// back the result string; released by the caller
+fn runNative(ctx: *NativeContext, comptime native: anytype, a: []const u8, b: ?[]const u8, scale: usize) RuntimeError!Value.String {
+    var args: [3]Value = .{ .{ .string = Value.String.borrowed(a) }, .{ .int = @intCast(scale) }, .null };
+    var n: usize = 2;
+    if (b) |bs| {
+        args[1] = .{ .string = Value.String.borrowed(bs) };
+        args[2] = .{ .int = @intCast(scale) };
+        n = 3;
+    }
+    const result = try native(ctx, args[0..n]);
+    if (result.value != .string) {
+        if (result.value == .array) {
+            // divmod hands back its pair through the array path
+        }
+        return error.RuntimeError;
+    }
+    return result.value.string;
+}
+
+const BinaryScale = enum { larger, sum, expand };
+
+fn numberBinary(ctx: *NativeContext, this: *PhpObject, other: Value, args: []const Value, comptime method: []const u8, comptime native: anytype, comptime rule: BinaryScale) RuntimeError!NativeResult {
+    const a = try operandString(ctx, .{ .object = this }, method, "num");
+    defer ctx.allocator.free(a);
+    const b = try operandString(ctx, other, method, "num");
+    defer ctx.allocator.free(b);
+    return NativeResult.borrowed(.{ .object = try binaryResult(ctx, a, b, explicitScale(args, 1), native, rule) });
+}
+
+fn binaryResult(ctx: *NativeContext, a: []const u8, b: []const u8, explicit: ?usize, comptime native: anytype, comptime rule: BinaryScale) RuntimeError!*PhpObject {
+    const sa = scaleOf(a);
+    const sb = scaleOf(b);
+    const natural: usize = switch (rule) {
+        .larger => @max(sa, sb),
+        .sum => sa + sb,
+        .expand => sa + 10,
+    };
+    const scale = explicit orelse natural;
+    const result = try runNative(ctx, native, a, b, scale);
+    defer result.release();
+    const bytes = if (explicit == null and rule == .expand) stripToScale(result.bytes(), sa) else result.bytes();
+    return makeNumber(ctx, bytes);
+}
+
+fn numberConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const s = try operandString(ctx, args[0], "__construct", "num");
+    defer ctx.allocator.free(s);
+    try setNumber(ctx, this, s);
+    return NativeResult.scalar(.null);
+}
+
+fn numberAdd(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    return numberBinary(ctx, this, args[0], args, "add", bcAdd, .larger);
+}
+
+fn numberSub(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    return numberBinary(ctx, this, args[0], args, "sub", bcSub, .larger);
+}
+
+fn numberMul(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    return numberBinary(ctx, this, args[0], args, "mul", bcMul, .sum);
+}
+
+fn numberDiv(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    return numberBinary(ctx, this, args[0], args, "div", bcDiv, .expand);
+}
+
+fn numberMod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    return numberBinary(ctx, this, args[0], args, "mod", bcMod, .larger);
+}
+
+fn numberDivmod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const a = try operandString(ctx, .{ .object = this }, "divmod", "num");
+    defer ctx.allocator.free(a);
+    const b = try operandString(ctx, args[0], "divmod", "num");
+    defer ctx.allocator.free(b);
+    const scale = explicitScale(args, 1) orelse @max(scaleOf(a), scaleOf(b));
+    var call_args: [3]Value = .{ .{ .string = Value.String.borrowed(a) }, .{ .string = Value.String.borrowed(b) }, .{ .int = @intCast(scale) } };
+    const pair = try bcDivmod(ctx, &call_args);
+    if (pair.value != .array) return error.RuntimeError;
+    const out = try ctx.createArray();
+    for (pair.value.array.entries.items) |entry| {
+        if (entry.value != .string) continue;
+        try out.append(ctx.allocator, .{ .object = try makeNumber(ctx, entry.value.string.bytes()) });
+    }
+    return NativeResult.borrowed(.{ .array = out });
+}
+
+fn integralString(s: []const u8) bool {
+    return scaleOf(stripToScale(s, 0)) == 0;
+}
+
+fn numberPow(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const a = try operandString(ctx, .{ .object = this }, "pow", "exponent");
+    defer ctx.allocator.free(a);
+    const e = try operandString(ctx, args[0], "pow", "exponent");
+    defer ctx.allocator.free(e);
+    if (!integralString(e)) {
+        _ = ctx.vm.throwBuiltinException("ValueError", number_class ++ "::pow(): Argument #1 ($exponent) exponent cannot have a fractional part") catch {};
+        return error.RuntimeError;
+    }
+    const exp = std.fmt.parseInt(i64, stripToScale(e, 0), 10) catch return error.RuntimeError;
+    return NativeResult.borrowed(.{ .object = try powResult(ctx, a, exp, explicitScale(args, 1)) });
+}
+
+fn powResult(ctx: *NativeContext, a: []const u8, exp: i64, explicit: ?usize) RuntimeError!*PhpObject {
+    const sa = scaleOf(a);
+    const natural: usize = if (exp > 0) sa * @as(usize, @intCast(exp)) else sa + 10;
+    const scale = explicit orelse natural;
+    var exp_buf: [24]u8 = undefined;
+    const e = std.fmt.bufPrint(&exp_buf, "{d}", .{exp}) catch return error.RuntimeError;
+    const result = try runNative(ctx, bcPow, a, e, scale);
+    defer result.release();
+    const bytes = if (explicit == null and exp <= 0) stripToScale(result.bytes(), 0) else result.bytes();
+    return makeNumber(ctx, bytes);
+}
+
+fn numberPowmod(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 2) return NativeResult.scalar(.null);
+    const a = try operandString(ctx, .{ .object = this }, "powmod", "exponent");
+    defer ctx.allocator.free(a);
+    const e = try operandString(ctx, args[0], "powmod", "exponent");
+    defer ctx.allocator.free(e);
+    const m = try operandString(ctx, args[1], "powmod", "modulus");
+    defer ctx.allocator.free(m);
+    if (!integralString(a)) {
+        _ = ctx.vm.throwBuiltinException("ValueError", "Base number cannot have a fractional part") catch {};
+        return error.RuntimeError;
+    }
+    const scale = explicitScale(args, 2) orelse 0;
+    var call_args: [4]Value = .{ .{ .string = Value.String.borrowed(a) }, .{ .string = Value.String.borrowed(e) }, .{ .string = Value.String.borrowed(m) }, .{ .int = @intCast(scale) } };
+    const result = try bcPowmod(ctx, &call_args);
+    if (result.value != .string) return error.RuntimeError;
+    defer result.value.string.release();
+    return NativeResult.borrowed(.{ .object = try makeNumber(ctx, result.value.string.bytes()) });
+}
+
+fn numberSqrt(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    const a = try operandString(ctx, .{ .object = this }, "sqrt", "scale");
+    defer ctx.allocator.free(a);
+    const explicit = explicitScale(args, 0);
+    const sa = scaleOf(a);
+    const result = try runNative(ctx, bcSqrt, a, null, explicit orelse sa + 10);
+    defer result.release();
+    const bytes = if (explicit == null) stripToScale(result.bytes(), sa) else result.bytes();
+    return NativeResult.borrowed(.{ .object = try makeNumber(ctx, bytes) });
+}
+
+fn numberFloor(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return numberUnary(ctx, bcFloor);
+}
+
+fn numberCeil(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    return numberUnary(ctx, bcCeil);
+}
+
+fn numberUnary(ctx: *NativeContext, comptime native: anytype) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    const a = try operandString(ctx, .{ .object = this }, "floor", "num");
+    defer ctx.allocator.free(a);
+    var call_args: [1]Value = .{.{ .string = Value.String.borrowed(a) }};
+    const result = try native(ctx, &call_args);
+    if (result.value != .string) return error.RuntimeError;
+    defer result.value.string.release();
+    return NativeResult.borrowed(.{ .object = try makeNumber(ctx, result.value.string.bytes()) });
+}
+
+const RoundMode = enum { half_away, half_towards, half_even, half_odd, towards_zero, away_from_zero, negative_inf, positive_inf };
+
+fn roundModeOf(v: Value) RoundMode {
+    if (v == .object and std.mem.eql(u8, v.object.class_name, "RoundingMode")) {
+        const name = v.object.get("name");
+        if (name == .string) {
+            const n = name.string.bytes();
+            const table = .{ .{ "HalfAwayFromZero", RoundMode.half_away }, .{ "HalfTowardsZero", RoundMode.half_towards }, .{ "HalfEven", RoundMode.half_even }, .{ "HalfOdd", RoundMode.half_odd }, .{ "TowardsZero", RoundMode.towards_zero }, .{ "AwayFromZero", RoundMode.away_from_zero }, .{ "NegativeInfinity", RoundMode.negative_inf }, .{ "PositiveInfinity", RoundMode.positive_inf } };
+            inline for (table) |entry| if (std.mem.eql(u8, n, entry[0])) return entry[1];
+        }
+    }
+    if (v == .int) return switch (v.int) {
+        2 => .half_towards,
+        3 => .half_even,
+        4 => .half_odd,
+        else => .half_away,
+    };
+    return .half_away;
+}
+
+// rounds the canonical decimal `s` to `precision` fractional digits (negative
+// precision rounds integer positions) by inspecting the digits past the cut
+fn roundDecimal(allocator: Allocator, s: []const u8, precision: i64, mode: RoundMode) ![]u8 {
+    const neg = s.len > 0 and s[0] == '-';
+    const body = if (neg) s[1..] else s;
+    const dot = std.mem.indexOfScalar(u8, body, '.');
+    const int_part = if (dot) |d| body[0..d] else body;
+    const frac_part = if (dot) |d| body[d + 1 ..] else "";
+    var digits = std.ArrayListUnmanaged(u8){};
+    defer digits.deinit(allocator);
+    try digits.appendSlice(allocator, int_part);
+    try digits.appendSlice(allocator, frac_part);
+    // cut is the count of digits kept from the front; it may run past either end
+    const cut_signed: i64 = @as(i64, @intCast(int_part.len)) + precision;
+    const cut: usize = @intCast(@max(cut_signed, 0));
+    var kept = std.ArrayListUnmanaged(u8){};
+    defer kept.deinit(allocator);
+    if (cut <= digits.items.len) {
+        try kept.appendSlice(allocator, digits.items[0..cut]);
+    } else {
+        try kept.appendSlice(allocator, digits.items);
+        try kept.appendNTimes(allocator, '0', cut - digits.items.len);
+    }
+    const rest = if (cut < digits.items.len) digits.items[cut..] else "";
+    var rest_nonzero = false;
+    for (rest) |c| if (c != '0') {
+        rest_nonzero = true;
+    };
+    const first: u8 = if (rest.len > 0) rest[0] else '0';
+    var tail_nonzero = false;
+    if (rest.len > 1) for (rest[1..]) |c| if (c != '0') {
+        tail_nonzero = true;
+    };
+    const above_half = first > '5' or (first == '5' and tail_nonzero);
+    const exactly_half = first == '5' and !tail_nonzero;
+    const last_digit: u8 = if (kept.items.len > 0) kept.items[kept.items.len - 1] else '0';
+    const last_odd = (last_digit - '0') % 2 == 1;
+    const bump = switch (mode) {
+        .half_away => above_half or exactly_half,
+        .half_towards => above_half,
+        .half_even => above_half or (exactly_half and last_odd),
+        .half_odd => above_half or (exactly_half and !last_odd),
+        .towards_zero => false,
+        .away_from_zero => rest_nonzero,
+        .negative_inf => neg and rest_nonzero,
+        .positive_inf => !neg and rest_nonzero,
+    };
+    if (bump) {
+        var i: usize = kept.items.len;
+        var carry = true;
+        while (carry and i > 0) {
+            i -= 1;
+            if (kept.items[i] == '9') {
+                kept.items[i] = '0';
+            } else {
+                kept.items[i] += 1;
+                carry = false;
+            }
+        }
+        if (carry) try kept.insert(allocator, 0, '1');
+    }
+    // kept digits end `precision` places after the point; rebuild the string
+    var out = std.ArrayListUnmanaged(u8){};
+    errdefer out.deinit(allocator);
+    if (neg) try out.append(allocator, '-');
+    if (precision <= 0) {
+        try out.appendSlice(allocator, if (kept.items.len == 0) "0" else kept.items);
+        try out.appendNTimes(allocator, '0', @intCast(-precision));
+    } else {
+        const frac_len: usize = @intCast(precision);
+        if (kept.items.len <= frac_len) {
+            try out.append(allocator, '0');
+            try out.append(allocator, '.');
+            try out.appendNTimes(allocator, '0', frac_len - kept.items.len);
+            try out.appendSlice(allocator, kept.items);
+        } else {
+            try out.appendSlice(allocator, kept.items[0 .. kept.items.len - frac_len]);
+            try out.append(allocator, '.');
+            try out.appendSlice(allocator, kept.items[kept.items.len - frac_len ..]);
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn numberRound(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    const a = try operandString(ctx, .{ .object = this }, "round", "precision");
+    defer ctx.allocator.free(a);
+    const precision: i64 = if (args.len > 0 and args[0] == .int) args[0].int else 0;
+    const mode = if (args.len > 1) roundModeOf(args[1]) else RoundMode.half_away;
+    const rounded = try roundDecimal(ctx.allocator, a, precision, mode);
+    defer ctx.allocator.free(rounded);
+    return NativeResult.borrowed(.{ .object = try makeNumber(ctx, rounded) });
+}
+
+fn numberCompare(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1) return NativeResult.scalar(.null);
+    const a = try operandString(ctx, .{ .object = this }, "compare", "num");
+    defer ctx.allocator.free(a);
+    const b = try operandString(ctx, args[0], "compare", "num");
+    defer ctx.allocator.free(b);
+    return NativeResult.scalar(.{ .int = try compareStrings(ctx, a, b, explicitScale(args, 1)) });
+}
+
+fn compareStrings(ctx: *NativeContext, a: []const u8, b: []const u8, explicit: ?usize) RuntimeError!i64 {
+    const scale = explicit orelse @max(scaleOf(a), scaleOf(b));
+    var call_args: [3]Value = .{ .{ .string = Value.String.borrowed(a) }, .{ .string = Value.String.borrowed(b) }, .{ .int = @intCast(scale) } };
+    const result = try bcComp(ctx, &call_args);
+    return if (result.value == .int) result.value.int else 0;
+}
+
+fn numberToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.literal("");
+    return NativeResult.share(this.get("value"));
+}
+
+fn numberSerialize(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    const arr = try ctx.createArray();
+    try arr.set(ctx.allocator, .{ .string = Value.String.borrowed("value") }, this.get("value"));
+    return NativeResult.borrowed(.{ .array = arr });
+}
+
+fn numberUnserialize(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = numberThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .array) return NativeResult.scalar(.null);
+    const v = args[0].array.get(.{ .string = Value.String.borrowed("value") });
+    if (v == .string and wellFormed(v.string.bytes())) try setNumber(ctx, this, v.string.bytes());
+    return NativeResult.scalar(.null);
+}
+
+// operator overloading: the Number side supplies the semantics, the other
+// operand may be a Number, an int, or a numeric string. anything else is
+// left to the VM's ordinary TypeError
+fn numberBinop(ctx: *NativeContext, op: vm_mod.NativeBinop, a: Value, b: Value) RuntimeError!?Value {
+    const supported = struct {
+        fn ok(v: Value) bool {
+            return isNumberObject(v) or v == .int or v == .string or v == .float or v == .bool;
+        }
+    };
+    if (!supported.ok(a)) return null;
+    if (op != .negate and !supported.ok(b)) return null;
+    const sa = try operandString(ctx, a, "add", "num");
+    defer ctx.allocator.free(sa);
+    switch (op) {
+        .negate => {
+            const result = try binaryResult(ctx, "0", sa, null, bcSub, .larger);
+            return .{ .object = result };
+        },
+        .compare => {
+            const sb = try operandString(ctx, b, "compare", "num");
+            defer ctx.allocator.free(sb);
+            return .{ .int = try compareStrings(ctx, sa, sb, null) };
+        },
+        .pow => {
+            const sb = try operandString(ctx, b, "pow", "exponent");
+            defer ctx.allocator.free(sb);
+            if (!integralString(sb)) {
+                _ = ctx.vm.throwBuiltinException("ValueError", number_class ++ "::pow(): Argument #1 ($exponent) exponent cannot have a fractional part") catch {};
+                return error.RuntimeError;
+            }
+            const exp = std.fmt.parseInt(i64, stripToScale(sb, 0), 10) catch return error.RuntimeError;
+            return .{ .object = try powResult(ctx, sa, exp, null) };
+        },
+        else => {
+            const sb = try operandString(ctx, b, "add", "num");
+            defer ctx.allocator.free(sb);
+            const result = switch (op) {
+                .add => try binaryResult(ctx, sa, sb, null, bcAdd, .larger),
+                .sub => try binaryResult(ctx, sa, sb, null, bcSub, .larger),
+                .mul => try binaryResult(ctx, sa, sb, null, bcMul, .sum),
+                .div => try binaryResult(ctx, sa, sb, null, bcDiv, .expand),
+                .mod => try binaryResult(ctx, sa, sb, null, bcMod, .larger),
+                else => unreachable,
+            };
+            return .{ .object = result };
+        },
+    }
+}

--- a/src/stdlib/datetime.zig
+++ b/src/stdlib/datetime.zig
@@ -1255,10 +1255,22 @@ fn dtiSetTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!Native
     return NativeResult.borrowed(.{ .object = new_obj });
 }
 
+// a float timestamp keeps its sub-second part as microseconds
+fn setTimestampWithFraction(ctx: *NativeContext, obj: *PhpObject, ts: Value) !void {
+    if (ts == .float) {
+        const whole = @floor(ts.float);
+        try obj.set(ctx.allocator, "timestamp", .{ .int = @intFromFloat(whole) });
+        const micros: i64 = @intFromFloat(@round((ts.float - whole) * 1_000_000.0));
+        if (micros != 0) try obj.set(ctx.allocator, "__microseconds", .{ .int = micros });
+        return;
+    }
+    try obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(ts) });
+}
+
 fn dtCreateFromTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("DateTime");
-    try obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(args[0]) });
+    try setTimestampWithFraction(ctx, obj, args[0]);
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -1826,7 +1838,7 @@ fn weekdayNameLen(s: []const u8) ?usize {
 fn dtiCreateFromTimestamp(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("DateTimeImmutable");
-    try obj.set(ctx.allocator, "timestamp", .{ .int = Value.toInt(args[0]) });
+    try setTimestampWithFraction(ctx, obj, args[0]);
     return NativeResult.borrowed(.{ .object = obj });
 }
 

--- a/src/stdlib/native_params.zig
+++ b/src/stdlib/native_params.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 // names include the $ prefix to match php convention and user-defined function param format.
 
 pub const map = std.StaticStringMap([]const []const u8).initComptime(.{
+    .{ "Deprecated::__construct", &.{ "$message", "$since" } },
     .{ "substr", &.{ "$string", "$offset", "$length" } },
     .{ "str_replace", &.{ "$search", "$replace", "$subject", "$count" } },
     .{ "str_ireplace", &.{ "$search", "$replace", "$subject", "$count" } },

--- a/src/stdlib/reflection.zig
+++ b/src/stdlib/reflection.zig
@@ -79,6 +79,32 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try sp_def.attributes.append(a, .{ .name = "Attribute", .args = &.{} });
     try vm.classes.put(a, "SensitiveParameter", sp_def);
 
+    // PHP 8.4 #[Deprecated]: reflection reports it through isDeprecated();
+    // the runtime does not reproduce the E_DEPRECATED message
+    var dep_def = ClassDef{ .name = "Deprecated", .is_final = true };
+    try dep_def.properties.append(a, .{ .name = "message", .default = .null, .has_default = true, .is_readonly = true, .type_str = "?string" });
+    try dep_def.properties.append(a, .{ .name = "since", .default = .null, .has_default = true, .is_readonly = true, .type_str = "?string" });
+    try dep_def.methods.put(a, "__construct", .{ .name = "__construct", .arity = 2 });
+    try dep_def.attributes.append(a, .{ .name = "Attribute", .args = &.{} });
+    try vm.classes.put(a, "Deprecated", dep_def);
+    try vm.native_fns.put(a, "Deprecated::__construct", deprecatedConstruct);
+
+    var rconst_def = ClassDef{ .name = "ReflectionConstant" };
+    try rconst_def.properties.append(a, .{ .name = "name", .default = .{ .string = Value.String.borrowed("") } });
+    inline for (.{ .{ "__construct", 1 }, .{ "getName", 0 }, .{ "getValue", 0 }, .{ "getShortName", 0 }, .{ "getNamespaceName", 0 }, .{ "isDeprecated", 0 }, .{ "getAttributes", 2 }, .{ "getFileName", 0 }, .{ "__toString", 0 } }) |m| {
+        try rconst_def.methods.put(a, m[0], .{ .name = m[0], .arity = m[1] });
+    }
+    try vm.classes.put(a, "ReflectionConstant", rconst_def);
+    try vm.native_fns.put(a, "ReflectionConstant::__construct", rconstConstruct);
+    try vm.native_fns.put(a, "ReflectionConstant::getName", rconstGetName);
+    try vm.native_fns.put(a, "ReflectionConstant::getValue", rconstGetValue);
+    try vm.native_fns.put(a, "ReflectionConstant::getShortName", rconstGetShortName);
+    try vm.native_fns.put(a, "ReflectionConstant::getNamespaceName", rconstGetNamespaceName);
+    try vm.native_fns.put(a, "ReflectionConstant::isDeprecated", reflectionFalse);
+    try vm.native_fns.put(a, "ReflectionConstant::getAttributes", reflectionEmptyArray);
+    try vm.native_fns.put(a, "ReflectionConstant::getFileName", reflectionFalse);
+    try vm.native_fns.put(a, "ReflectionConstant::__toString", rconstToString);
+
     // SensitiveParameterValue (PHP 8.2) - returned by debug_backtrace for
     // redacted sensitive params. simple value wrapper
     var spv_def = ClassDef{ .name = "SensitiveParameterValue" };
@@ -137,6 +163,9 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try rc_def.methods.put(a, "initializeLazyObject", .{ .name = "initializeLazyObject", .arity = 1 });
     try rc_def.methods.put(a, "isUninitializedLazyObject", .{ .name = "isUninitializedLazyObject", .arity = 1 });
     try rc_def.methods.put(a, "markLazyObjectAsInitialized", .{ .name = "markLazyObjectAsInitialized", .arity = 1 });
+    try rc_def.methods.put(a, "resetAsLazyGhost", .{ .name = "resetAsLazyGhost", .arity = 2 });
+    try rc_def.methods.put(a, "resetAsLazyProxy", .{ .name = "resetAsLazyProxy", .arity = 2 });
+    try rc_def.methods.put(a, "getLazyInitializer", .{ .name = "getLazyInitializer", .arity = 1 });
     try rc_def.methods.put(a, "getShortName", .{ .name = "getShortName", .arity = 0 });
     try rc_def.methods.put(a, "getNamespaceName", .{ .name = "getNamespaceName", .arity = 0 });
     try rc_def.methods.put(a, "inNamespace", .{ .name = "inNamespace", .arity = 0 });
@@ -190,6 +219,9 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionClass::initializeLazyObject", rcInitializeLazyObject);
     try vm.native_fns.put(a, "ReflectionClass::isUninitializedLazyObject", rcIsUninitializedLazyObject);
     try vm.native_fns.put(a, "ReflectionClass::markLazyObjectAsInitialized", rcMarkLazyObjectAsInitialized);
+    try vm.native_fns.put(a, "ReflectionClass::resetAsLazyGhost", rcResetAsLazyGhost);
+    try vm.native_fns.put(a, "ReflectionClass::resetAsLazyProxy", rcResetAsLazyProxy);
+    try vm.native_fns.put(a, "ReflectionClass::getLazyInitializer", rcGetLazyInitializer);
     try vm.native_fns.put(a, "ReflectionClass::getShortName", rcGetShortName);
     try vm.native_fns.put(a, "ReflectionClass::getNamespaceName", rcGetNamespaceName);
     try vm.native_fns.put(a, "ReflectionClass::inNamespace", rcInNamespace);
@@ -316,7 +348,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionMethod::inNamespace", reflectionFalse);
     try vm.native_fns.put(a, "ReflectionMethod::isInternal", rmIsInternal);
     try vm.native_fns.put(a, "ReflectionMethod::isUserDefined", rmIsUserDefined);
-    try vm.native_fns.put(a, "ReflectionMethod::isDeprecated", reflectionFalse);
+    try vm.native_fns.put(a, "ReflectionMethod::isDeprecated", rmIsDeprecated);
 
     var rp_def = ClassDef{ .name = "ReflectionParameter" };
     try rp_def.properties.append(a, .{ .name = "name", .default = .{ .string = Value.String.borrowed("") } });
@@ -506,7 +538,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionFunction::inNamespace", rfInNamespace);
     try vm.native_fns.put(a, "ReflectionFunction::getExtension", reflectionFalse);
     try vm.native_fns.put(a, "ReflectionFunction::getExtensionName", reflectionFalse);
-    try vm.native_fns.put(a, "ReflectionFunction::isDeprecated", reflectionFalse);
+    try vm.native_fns.put(a, "ReflectionFunction::isDeprecated", rfIsDeprecated);
     try vm.native_fns.put(a, "ReflectionFunction::isDisabled", reflectionFalse);
 
     var rprop_def = ClassDef{ .name = "ReflectionProperty" };
@@ -517,6 +549,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try rprop_def.methods.put(a, "getValue", .{ .name = "getValue", .arity = 1 });
     try rprop_def.methods.put(a, "getName", .{ .name = "getName", .arity = 0 });
     try rprop_def.methods.put(a, "getType", .{ .name = "getType", .arity = 0 });
+    try rprop_def.methods.put(a, "getSettableType", .{ .name = "getSettableType", .arity = 0 });
     try rprop_def.methods.put(a, "isPublic", .{ .name = "isPublic", .arity = 0 });
     try rprop_def.methods.put(a, "isProtected", .{ .name = "isProtected", .arity = 0 });
     try rprop_def.methods.put(a, "isPrivate", .{ .name = "isPrivate", .arity = 0 });
@@ -581,6 +614,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "ReflectionProperty::setRawValueWithoutLazyInitialization", rpSetWithoutLazy);
     try vm.native_fns.put(a, "ReflectionProperty::getName", rpropGetName);
     try vm.native_fns.put(a, "ReflectionProperty::getType", rpropGetType);
+    try vm.native_fns.put(a, "ReflectionProperty::getSettableType", rpropGetType);
     try vm.native_fns.put(a, "ReflectionProperty::isPublic", rpropIsPublic);
     try vm.native_fns.put(a, "ReflectionProperty::isProtected", rpropIsProtected);
     try vm.native_fns.put(a, "ReflectionProperty::isPrivate", rpropIsPrivate);
@@ -641,12 +675,14 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try rcc_def.methods.put(a, "isPrivate", .{ .name = "isPrivate", .arity = 0 });
     try rcc_def.methods.put(a, "isFinal", .{ .name = "isFinal", .arity = 0 });
     try rcc_def.methods.put(a, "isEnumCase", .{ .name = "isEnumCase", .arity = 0 });
+    try rcc_def.methods.put(a, "isDeprecated", .{ .name = "isDeprecated", .arity = 0 });
     try rcc_def.methods.put(a, "getType", .{ .name = "getType", .arity = 0 });
     try rcc_def.methods.put(a, "hasType", .{ .name = "hasType", .arity = 0 });
     try rcc_def.methods.put(a, "getModifiers", .{ .name = "getModifiers", .arity = 0 });
     try rcc_def.methods.put(a, "getDocComment", .{ .name = "getDocComment", .arity = 0 });
     try vm.classes.put(a, "ReflectionClassConstant", rcc_def);
     try vm.native_fns.put(a, "ReflectionClassConstant::getDocComment", rccGetDocComment);
+    try vm.native_fns.put(a, "ReflectionClassConstant::isDeprecated", rccIsDeprecated);
 
     try vm.native_fns.put(a, "ReflectionClassConstant::__construct", rccConstruct);
     try vm.native_fns.put(a, "ReflectionClassConstant::getName", rccGetName);
@@ -4253,6 +4289,26 @@ fn raNewInstance(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResul
                     }
                 }
                 if (count > 0) _ = try ctx.callMethod(obj, "__construct", resolved[0..count]);
+            } else if (@import("native_params.zig").map.get(ctor_key)) |params| {
+                // a native attribute constructor (#[Deprecated]) resolves its
+                // names from the same table named calls use
+                var resolved: [16]Value = .{.null} ** 16;
+                var pos: usize = 0;
+                for (arr.entries.items) |entry| {
+                    if (entry.key == .string) {
+                        for (params, 0..) |p, pi| {
+                            if (pi < resolved.len and std.mem.eql(u8, p[1..], entry.key.string.bytes())) {
+                                resolved[pi] = entry.value;
+                                if (pi >= pos) pos = pi + 1;
+                                break;
+                            }
+                        }
+                    } else if (pos < resolved.len) {
+                        resolved[pos] = entry.value;
+                        pos += 1;
+                    }
+                }
+                _ = try ctx.callMethod(obj, "__construct", resolved[0..pos]);
             } else {
                 var call_args: [16]Value = undefined;
                 const count = @min(arr.entries.items.len, 16);
@@ -4544,4 +4600,154 @@ fn rfibGetTrace(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult
         try arr.append(ctx.allocator, .{ .array = frame });
     }
     return NativeResult.borrowed(.{ .array = arr });
+}
+
+fn hasDeprecatedAttribute(attrs: []const AttributeDef) bool {
+    for (attrs) |attr| {
+        const name = std.mem.trimLeft(u8, attr.name, "\\");
+        if (std.ascii.eqlIgnoreCase(name, "Deprecated")) return true;
+    }
+    return false;
+}
+
+fn deprecatedConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len > 0 and args[0] == .string) try this.set(ctx.allocator, "message", args[0]);
+    if (args.len > 1 and args[1] == .string) try this.set(ctx.allocator, "since", args[1]);
+    return NativeResult.scalar(.null);
+}
+
+fn rfIsDeprecated(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const func_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const attrs = ctx.vm.function_attributes.get(ctx.vm.getOrigClosureName(func_name)) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = hasDeprecatedAttribute(attrs) });
+}
+
+fn rmIsDeprecated(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const method_name = methodLookupName(this) orelse return NativeResult.scalar(.{ .bool = false });
+    const declaring = if (this.get("_declaring_class") == .string) this.get("_declaring_class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(declaring) orelse return NativeResult.scalar(.{ .bool = false });
+    const attrs = cls.method_attributes.get(method_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = hasDeprecatedAttribute(attrs) });
+}
+
+fn rccIsDeprecated(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
+    const class_name = if (this.get("class") == .string) this.get("class").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const const_name = if (this.get("name") == .string) this.get("name").string.bytes() else return NativeResult.scalar(.{ .bool = false });
+    const cls = ctx.vm.classes.get(class_name) orelse return NativeResult.scalar(.{ .bool = false });
+    const attrs = cls.constant_attributes.get(const_name) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = hasDeprecatedAttribute(attrs) });
+}
+
+fn rconstConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    if (args.len < 1 or args[0] != .string) return throwReflection(ctx, "ReflectionConstant::__construct() expects a constant name");
+    const name = std.mem.trimLeft(u8, args[0].string.bytes(), "\\");
+    if (!ctx.vm.php_constants.contains(name)) {
+        const msg = std.fmt.allocPrint(ctx.allocator, "Constant \"{s}\" does not exist", .{name}) catch return throwReflection(ctx, "Constant does not exist");
+        try ctx.strings.append(ctx.allocator, msg);
+        return throwReflection(ctx, msg);
+    }
+    const owned = try Value.String.create(ctx.allocator, name);
+    defer owned.release();
+    try this.set(ctx.allocator, "name", .{ .string = owned });
+    return NativeResult.scalar(.null);
+}
+
+fn rconstGetName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    return NativeResult.share(this.get("name"));
+}
+
+fn rconstGetValue(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const name_v = this.get("name");
+    if (name_v != .string) return NativeResult.scalar(.null);
+    return NativeResult.share(ctx.vm.php_constants.get(name_v.string.bytes()) orelse .null);
+}
+
+fn rconstGetShortName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.scalar(.null);
+    const name_v = this.get("name");
+    if (name_v != .string) return NativeResult.scalar(.null);
+    const name = name_v.string.bytes();
+    const pos = std.mem.lastIndexOfScalar(u8, name, '\\') orelse return NativeResult.shareString(name_v.string);
+    return try NativeResult.copyString(ctx.allocator, name[pos + 1 ..]);
+}
+
+fn rconstGetNamespaceName(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.literal("");
+    const name_v = this.get("name");
+    if (name_v != .string) return NativeResult.literal("");
+    const name = name_v.string.bytes();
+    const pos = std.mem.lastIndexOfScalar(u8, name, '\\') orelse return NativeResult.literal("");
+    return try NativeResult.copyString(ctx.allocator, name[0..pos]);
+}
+
+fn rconstToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const this = getThis(ctx) orelse return NativeResult.literal("");
+    const name_v = this.get("name");
+    if (name_v != .string) return NativeResult.literal("");
+    const value = ctx.vm.php_constants.get(name_v.string.bytes()) orelse Value.null;
+    var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(ctx.allocator);
+    try buf.appendSlice(ctx.allocator, "Constant [ ");
+    try buf.appendSlice(ctx.allocator, @tagName(value));
+    try buf.append(ctx.allocator, ' ');
+    try buf.appendSlice(ctx.allocator, name_v.string.bytes());
+    try buf.appendSlice(ctx.allocator, " ] { ");
+    try value.format(&buf, ctx.allocator);
+    try buf.appendSlice(ctx.allocator, " }\n");
+    return try NativeResult.copyString(ctx.allocator, buf.items);
+}
+
+// resetAsLazyGhost / resetAsLazyProxy: an existing instance drops every
+// property value it holds and becomes lazy again around the new initializer
+fn rcResetAsLazy(ctx: *NativeContext, args: []const Value, proxy: bool) RuntimeError!NativeResult {
+    if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.null);
+    const obj = args[0].object;
+    if (obj.lazy) |state| {
+        if (state.initializer != .null) ctx.vm.releaseValue(state.initializer);
+        ctx.allocator.free(state.pending);
+        ctx.allocator.destroy(state);
+        obj.lazy = null;
+    }
+    if (obj.slots) |slots| {
+        for (slots) |v| ctx.vm.releaseValue(v);
+        ctx.allocator.free(slots);
+        obj.slots = null;
+    }
+    for (obj.properties.values()) |v| ctx.vm.releaseValue(v);
+    obj.properties.clearRetainingCapacity();
+    obj.unset_slots.clearRetainingCapacity();
+    try ctx.vm.initObjectProperties(obj, obj.class_name);
+    VM.retainValue(args[1]);
+    const state = try ctx.allocator.create(PhpObject.LazyState);
+    const count = if (obj.slots) |slots| slots.len else 0;
+    state.* = .{ .initializer = args[1], .proxy = proxy, .pending = try ctx.allocator.alloc(bool, count), .skip_serialize = args.len > 2 and args[2] == .int and (args[2].int & 8) != 0 };
+    @memset(state.pending, true);
+    obj.lazy = state;
+    if (count == 0) {
+        ctx.vm.releaseValue(state.initializer);
+        state.initializer = .null;
+    }
+    return NativeResult.borrowed(.{ .object = obj });
+}
+
+fn rcResetAsLazyGhost(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return rcResetAsLazy(ctx, args, false);
+}
+
+fn rcResetAsLazyProxy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    return rcResetAsLazy(ctx, args, true);
+}
+
+fn rcGetLazyInitializer(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
+    const state = args[0].object.lazy orelse return NativeResult.scalar(.null);
+    if (state.initializer == .null) return NativeResult.scalar(.null);
+    return NativeResult.share(state.initializer);
 }

--- a/tests/php84_features.php
+++ b/tests/php84_features.php
@@ -1,0 +1,167 @@
+<?php
+// covers: #[\Deprecated] reflection, lazy object reset APIs, BcMath\Number,
+// ReflectionConstant, ReflectionProperty::getSettableType, fractional
+// createFromTimestamp, PHP_OUTPUT_HANDLER_* constants
+
+namespace App\Config {
+    const LIMIT = 42;
+}
+
+namespace {
+    use BcMath\Number;
+
+    function show($label, $v)
+    {
+        echo $label, ": ", var_export($v, true), "\n";
+    }
+
+    #[\Deprecated("use fresh()", since: "2.0")]
+    function stale()
+    {
+        return 1;
+    }
+    function fresh()
+    {
+        return 2;
+    }
+    class Legacy
+    {
+        #[\Deprecated]
+        const OLD = 1;
+        const CURRENT = 2;
+        #[\Deprecated(since: "1.5")]
+        public function old() { return "old"; }
+        public function current() { return "current"; }
+    }
+    show("deprecated-class", class_exists('Deprecated'));
+    show("fn-deprecated", (new ReflectionFunction('stale'))->isDeprecated());
+    show("fn-fresh", (new ReflectionFunction('fresh'))->isDeprecated());
+    $attr = (new ReflectionFunction('stale'))->getAttributes()[0];
+    show("attr-name", $attr->getName());
+    $inst = $attr->newInstance();
+    show("attr-message", $inst->message);
+    show("attr-since", $inst->since);
+    show("method-deprecated", (new ReflectionMethod('Legacy', 'old'))->isDeprecated());
+    show("method-current", (new ReflectionMethod('Legacy', 'current'))->isDeprecated());
+    show("method-since", (new ReflectionMethod('Legacy', 'old'))->getAttributes()[0]->newInstance()->since);
+    show("const-deprecated", (new ReflectionClassConstant('Legacy', 'OLD'))->isDeprecated());
+    show("const-current", (new ReflectionClassConstant('Legacy', 'CURRENT'))->isDeprecated());
+    show("calls", [@stale(), fresh(), @Legacy::OLD, @(new Legacy)->old()]);
+
+    class User
+    {
+        public function __construct(public int $id = 0, public string $name = "")
+        {
+            echo "ctor {$this->id}\n";
+        }
+        public function greet() { return "hi {$this->name}"; }
+    }
+    $rc = new ReflectionClass(User::class);
+    $real = new User(1, "real");
+    $rc->resetAsLazyGhost($real, function (User $u) { $u->__construct(2, "ghost"); });
+    show("reset-ghost-uninit", $rc->isUninitializedLazyObject($real));
+    show("reset-ghost-init", $rc->getLazyInitializer($real) instanceof Closure);
+    show("reset-ghost-greet", $real->greet());
+    show("reset-ghost-after", $rc->isUninitializedLazyObject($real));
+    show("reset-ghost-init-after", $rc->getLazyInitializer($real));
+    $proxied = new User(3, "orig");
+    $rc->resetAsLazyProxy($proxied, function (User $u) { return new User(4, "proxy"); });
+    show("reset-proxy-uninit", $rc->isUninitializedLazyObject($proxied));
+    show("reset-proxy-name", $proxied->name);
+    show("reset-proxy-after", $rc->isUninitializedLazyObject($proxied));
+    $marked = $rc->newLazyGhost(fn(User $u) => $u->__construct(5, "never"));
+    $rc->markLazyObjectAsInitialized($marked);
+    show("marked", [$rc->isUninitializedLazyObject($marked), $rc->getLazyInitializer($marked)]);
+    show("plain-init", $rc->getLazyInitializer(new User(6, "plain")));
+
+    $p = fn(Number $n) => $n->value . "/" . $n->scale;
+    show("number-parse", array_map(fn($s) => $p(new Number($s)), ["1.50", "007", "-0.50", "-0", "+3.25", "", 12]));
+    show("number-add", [$p((new Number("1.5"))->add(new Number(2))), $p((new Number("1"))->add("2.25")), $p((new Number("1"))->add("2.25", 1))]);
+    show("number-sub", $p((new Number(5))->sub(new Number("0.125"))));
+    show("number-mul", [$p((new Number("1.5"))->mul(new Number("2.25"))), $p((new Number("3"))->mul("2.5"))]);
+    $divs = [];
+    foreach ([["1", "3"], ["1", "4"], ["10", "4"], ["1.5", "0.5"], ["2", "1.5"], ["1.25", "0.5"], ["1.1", "3"], ["2", "1.000000000000"]] as [$x, $y]) {
+        $divs["$x/$y"] = $p((new Number($x))->div(new Number($y)));
+    }
+    show("number-div", $divs);
+    show("number-div-scale", $p((new Number("1"))->div(3, 5)));
+    show("number-mod", [$p((new Number("10"))->mod(new Number("3"))), $p((new Number("10.5"))->mod(new Number("3"))), $p((new Number("-7"))->mod(2))]);
+    show("number-divmod", array_map($p, (new Number("1.5"))->divmod(new Number("0.4"))));
+    show("number-powmod", $p((new Number("10"))->powmod(new Number(3), new Number(7))));
+    show("number-pow", [$p((new Number("1.5"))->pow(3)), $p((new Number("2"))->pow(-2)), $p((new Number("2.5"))->pow(-1)), $p((new Number("2.5"))->pow(0)), $p((new Number("1.5"))->pow(2, 4))]);
+    show("number-sqrt", [$p((new Number("2"))->sqrt()), $p((new Number("2.25"))->sqrt()), $p((new Number("2"))->sqrt(4)), $p((new Number("1.0000000000001"))->sqrt())]);
+    show("number-floor-ceil", [$p((new Number("-1.5"))->floor()), $p((new Number("-1.5"))->ceil()), $p((new Number("1.5"))->floor()), $p((new Number("1.5"))->ceil())]);
+    show("number-round", [
+        $p((new Number("2.5"))->round()), $p((new Number("-2.5"))->round()), $p((new Number("2.55"))->round(1)), $p((new Number("25"))->round(-1)),
+        $p((new Number("0.05"))->round(1)), $p((new Number("9.99"))->round(1)), $p((new Number("1.55"))->round(1, RoundingMode::HalfEven)),
+        $p((new Number("1.65"))->round(1, RoundingMode::HalfEven)), $p((new Number("1.55"))->round(1, RoundingMode::TowardsZero)),
+        $p((new Number("-1.55"))->round(1, RoundingMode::NegativeInfinity)), $p((new Number("1.51"))->round(1, RoundingMode::AwayFromZero)),
+        $p((new Number("1.55"))->round(1, RoundingMode::HalfTowardsZero)), $p((new Number("1.45"))->round(1, RoundingMode::HalfOdd)),
+    ]);
+    show("number-compare", [(new Number("1.5"))->compare(new Number("1.50")), (new Number("1.5"))->compare(2), (new Number("3"))->compare("2.9")]);
+    show("number-operators", [
+        new Number("1.5") <=> new Number("2"), new Number("1.5") == "1.5", new Number("1.5") < 2, new Number("1.5") >= new Number("1.50"), new Number("2") != new Number("3"),
+        (new Number("3") + 1)->value, (1 + new Number("3"))->value, (new Number("3") * "2.5")->value, (-(new Number("3")))->value,
+        (new Number("2") ** 3)->value, (new Number("7") % 4)->value, (new Number("1") / 4)->value, (new Number("5") - new Number("0.5"))->value,
+    ]);
+    show("number-string", [(string) new Number("3.25"), "n=" . new Number("1.5"), json_encode(new Number("1.5")), serialize(new Number("1.5")), unserialize(serialize(new Number("2.50")))->value]);
+    $n = new Number("1.5");
+    show("number-props", [$n->value, $n->scale]);
+    $rn = new ReflectionClass(Number::class);
+    show("number-class", [$rn->isFinal(), $rn->isReadOnly()]);
+    foreach (["abc", " 1", "1e5", "1.2.3"] as $bad) {
+        try {
+            new Number($bad);
+            show("number-bad", $bad);
+        } catch (ValueError $e) {
+            show("number-bad", $e->getMessage());
+        }
+    }
+    try {
+        (new Number("1"))->div(new Number(0));
+    } catch (DivisionByZeroError $e) {
+        show("number-div-zero", $e->getMessage());
+    }
+    try {
+        (new Number("1.5"))->pow(new Number("0.5"));
+    } catch (ValueError $e) {
+        show("number-pow-frac", $e->getMessage());
+    }
+    try {
+        new Number("1") + [];
+    } catch (TypeError $e) {
+        show("number-type", $e->getMessage());
+    }
+    show("bcmod", [bcmod("10.5", "3", 1), bcmod("10.5", "3"), bcmod("1.5", "0.4", 1), bcmod("-7", "2"), bcmod("2.5", "1", 2)]);
+
+    $c = new ReflectionConstant('App\Config\LIMIT');
+    show("rconst", [$c->getName(), $c->getValue(), $c->getShortName(), $c->getNamespaceName(), $c->isDeprecated()]);
+    show("rconst-global", [(new ReflectionConstant('PHP_INT_SIZE'))->getValue(), (new ReflectionConstant('PHP_EOL'))->getShortName()]);
+    try {
+        new ReflectionConstant('NOPE_MISSING');
+    } catch (ReflectionException $e) {
+        show("rconst-missing", $e->getMessage());
+    }
+
+    class Typed
+    {
+        public int $plain = 1;
+        public private(set) string $asym = "a";
+        public ?array $maybe = null;
+        public $untyped;
+    }
+    show("settable", [
+        (string) (new ReflectionProperty(Typed::class, 'plain'))->getSettableType(),
+        (string) (new ReflectionProperty(Typed::class, 'asym'))->getSettableType(),
+        (string) (new ReflectionProperty(Typed::class, 'maybe'))->getSettableType(),
+        (new ReflectionProperty(Typed::class, 'untyped'))->getSettableType(),
+    ]);
+
+    show("ts-float", DateTimeImmutable::createFromTimestamp(1.5)->format("U.u"));
+    show("ts-float-mutable", DateTime::createFromTimestamp(1700000000.25)->format("U.u"));
+    show("ts-int", DateTimeImmutable::createFromTimestamp(1700000000)->format("U.u"));
+    show("ts-micro", DateTime::createFromTimestamp(1.5)->getMicrosecond());
+
+    show("output-handler", [PHP_OUTPUT_HANDLER_START, PHP_OUTPUT_HANDLER_WRITE, PHP_OUTPUT_HANDLER_FLUSH, PHP_OUTPUT_HANDLER_CLEAN, PHP_OUTPUT_HANDLER_FINAL, PHP_OUTPUT_HANDLER_CONT, PHP_OUTPUT_HANDLER_END, PHP_OUTPUT_HANDLER_CLEANABLE, PHP_OUTPUT_HANDLER_FLUSHABLE, PHP_OUTPUT_HANDLER_REMOVABLE, PHP_OUTPUT_HANDLER_STDFLAGS, PHP_OUTPUT_HANDLER_STARTED, PHP_OUTPUT_HANDLER_DISABLED, PHP_OUTPUT_HANDLER_PROCESSED]);
+    show("done", true);
+}


### PR DESCRIPTION
Adds the PHP 8.4 features still missing after auditing #14 against PHP 8.5: the #[\Deprecated] attribute with isDeprecated() on functions, methods, and class constants; ReflectionClass::resetAsLazyGhost, resetAsLazyProxy, and getLazyInitializer; the BcMath\Number class including operator overloading; ReflectionConstant; ReflectionProperty::getSettableType; fractional timestamps in createFromTimestamp; and the PHP_OUTPUT_HANDLER_* constants.

Operator overloading comes from a native_binop hook on ClassDef that the VM consults before its usual operand checks. Two bugs fixed along the way: bcmod() overflowed when the dividend had more digits than the target scale, and getStaticProp kept a pointer into the class map across an autoload.

tests/php84_features.php pins all of it against PHP. The new Dom\HTMLDocument API is not included. Deprecation messages are out of scope.

Closes #14.
