### PR TITLE
Reset every request-scoped setting between serve requests

### DIFF
--- a/src/env.zig
+++ b/src/env.zig
@@ -121,7 +121,12 @@ pub const EnvSnapshot = struct {
 
 pub fn populateEnvSuperglobal(vm: *VM, a: std.mem.Allocator, snapshot: ?*const EnvSnapshot) !void {
     if (snapshot) |snap| {
-        try vm.putRequestVar("$_ENV", .{ .array = snap.env_arr });
+        // the request gets its own array over the snapshot's bytes: a script
+        // writing $_ENV must not change what the next request sees, and the
+        // per-request copy dies with the request heap
+        const env_arr = try vm.allocArray();
+        for (snap.env_arr.entries.items) |entry| try env_arr.set(a, entry.key, entry.value);
+        try vm.putRequestVar("$_ENV", .{ .array = env_arr });
         return;
     }
 

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -2791,6 +2791,25 @@ pub const VM = struct {
         self.headers_sent = false;
         self.default_tz_name = "UTC";
         self.default_tz_offset = 0;
+        // per-request runtime settings and last-error state; the strings
+        // below live in the request arena that this reset frees
+        self.error_reporting_level = 30719;
+        // ini_set stores keys and values in the request arena freed below;
+        // a stale entry would compare freed bytes on the next put
+        self.ini_settings.clearRetainingCapacity();
+        self.rng_seeded = false;
+        self.strtok_state = null;
+        self.strtok_pos = 0;
+        self.last_error_type = 0;
+        self.last_error_message = "";
+        self.last_error_file = "";
+        self.last_error_line = 0;
+        self.last_dt_error_count = 0;
+        self.last_dt_error_text = "";
+        self.last_dt_error_pos = 0;
+        self.last_dt_parse_failed = false;
+        self.last_intl_error_code = 0;
+        self.exit_code = 0;
         self.statics.clearRetainingCapacity();
         self.statics_cells.clearRetainingCapacity();
         self.globals_cells.clearRetainingCapacity();
@@ -13423,7 +13442,7 @@ pub const VM = struct {
                 self.saveFrameArgs(arg_count);
                 self.dropN(ac);
                 try self.fillDefaults(&new_vars, func, bind_count);
-                const inherit_cc = self.closureScopeByName(name) orelse self.currentFrame().called_class;
+                const inherit_cc = self.closureScopeByName(name) orelse self.callerCalledClass();
                 self.frames[self.frame_count] = .{ .chunk = &func.chunk, .ip = 0, .vars = new_vars, .locals = try self.allocLocals(func, &new_vars), .func = func, .ref_slots = closure_refs, .called_class = inherit_cc, .call_name = name };
                 self.frames[self.frame_count].entry_sp = self.sp;
                 self.setFrameArgCount(arg_count);
@@ -13471,7 +13490,7 @@ pub const VM = struct {
             }
         }
 
-        self.frames[self.frame_count] = .{ .chunk = &func.chunk, .ip = 0, .vars = .{}, .locals = locals, .func = func, .called_class = self.closureScopeByName(name) orelse self.currentFrame().called_class, .call_name = name };
+        self.frames[self.frame_count] = .{ .chunk = &func.chunk, .ip = 0, .vars = .{}, .locals = locals, .func = func, .called_class = self.closureScopeByName(name) orelse self.callerCalledClass(), .call_name = name };
         self.frames[self.frame_count].entry_sp = self.sp;
         self.setFrameArgCount(arg_count);
         self.frame_count += 1;
@@ -17158,7 +17177,7 @@ pub const VM = struct {
                     return error.RuntimeError;
                 }
                 const inherit_cc = if (std.mem.startsWith(u8, name, "__closure_"))
-                    self.closureScopeByName(name) orelse self.currentFrame().called_class
+                    self.closureScopeByName(name) orelse self.callerCalledClass()
                 else
                     null;
                 self.frames[self.frame_count] = .{ .chunk = &func.chunk, .ip = 0, .vars = new_vars, .locals = try self.allocLocals(func, &new_vars), .func = func, .ref_slots = callee_refs, .ref_owner = callee_owner, .called_class = inherit_cc, .call_name = name };
@@ -17486,6 +17505,13 @@ pub const VM = struct {
         return self.capture_index.get(name);
     }
 
+    // a closure invoked with no frame on the stack (a shutdown callback after
+    // a serve request) has no caller scope to inherit
+    fn callerCalledClass(self: *VM) ?[]const u8 {
+        if (self.frame_count == 0) return null;
+        return self.currentFrame().called_class;
+    }
+
     fn executeClosureLocalsOnly(self: *VM, func: *const ObjFunction, name: []const u8, args: []const Value) RuntimeError!Value {
         const base_frame = self.frame_count;
         const lc: usize = func.local_count;
@@ -17525,7 +17551,7 @@ pub const VM = struct {
         const base_handler = self.handler_count;
         const prev_floor = self.handler_floor;
         self.handler_floor = self.handler_count;
-        self.frames[self.frame_count] = .{ .chunk = &func.chunk, .ip = 0, .vars = .{}, .locals = locals, .func = func, .called_class = self.closureScopeByName(name) orelse self.currentFrame().called_class, .call_name = name };
+        self.frames[self.frame_count] = .{ .chunk = &func.chunk, .ip = 0, .vars = .{}, .locals = locals, .func = func, .called_class = self.closureScopeByName(name) orelse self.callerCalledClass(), .call_name = name };
         self.frames[self.frame_count].entry_sp = self.sp;
         self.consumePendingArgCount();
         self.saveFrameArgsSlice(args);

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -209,6 +209,9 @@ const Worker = struct {
     // instead of the front-controller entry. compiled bytecode is cached here
     // per worker, keyed by absolute path, so each such script compiles once
     script_cache: std.StringHashMapUnmanaged(*CompileResult),
+    // the process umask a request may change with umask(); restored before
+    // the next request runs, as php_request_shutdown does
+    umask: std.c.mode_t,
 };
 
 // what to run for a request, and how to shape $_SERVER for it
@@ -296,7 +299,14 @@ fn initWorker(allocator: Allocator, result: *const CompileResult, doc_root: []co
         .conns = [_]?Connection{null} ** (MAX_CONNS + 1),
         .n_fds = 1,
         .script_cache = .{},
+        .umask = currentUmask(),
     };
+}
+
+fn currentUmask() std.c.mode_t {
+    const current = std.c.umask(0);
+    _ = std.c.umask(current);
+    return current;
 }
 
 // workers come up one at a time into the leading slots. a worker whose VM,
@@ -897,6 +907,7 @@ fn processHttpRead(w: *Worker, c: *Connection) void {
     // PHP execution - php-fpm dispatch: an existing .php file runs directly,
     // anything else routes to the front-controller entry
     const dispatch = resolveDispatch(w, &req);
+    _ = std.c.umask(w.umask);
     w.vm.reset();
     const mock_conn = std.net.Server.Connection{
         .stream = c.stream,
@@ -1028,6 +1039,7 @@ fn handleH2Request(w: *Worker, conn: *Connection, session: *h2.H2Session, stream
 
     // PHP execution - php-fpm dispatch (see HTTP/1.1 path)
     const dispatch = resolveDispatch(w, &req);
+    _ = std.c.umask(w.umask);
     w.vm.reset();
     const mock_conn = std.net.Server.Connection{
         .stream = conn.stream,
@@ -1103,6 +1115,7 @@ fn handleWsUpgrade(w: *Worker, c: *Connection, ws_key: []const u8) void {
     };
 
     if (!w.ws_initialized) {
+        _ = std.c.umask(w.umask);
         w.vm.reset();
         w.vm.interpret(w.result) catch {
             c.state = .closing;

--- a/tests/serve/app.php
+++ b/tests/serve/app.php
@@ -100,6 +100,64 @@ if ($path === "/health") {
 } elseif ($path === "/redirect") {
     header("Location: /headers", true, 302);
     echo "redirecting";
+} elseif ($path === "/isolation/dirty") {
+    // touch every kind of request-scoped state; /isolation/probe must not see any of it
+    function isolation_counter() { static $n = 0; return ++$n; }
+    $GLOBALS["leak"] = "leaked-global";
+    $_ENV["LEAK"] = "x";
+    isolation_counter();
+    header("X-Leak: yes");
+    http_response_code(201);
+    ob_start();
+    echo "buffered";
+    set_error_handler(fn() => true);
+    set_exception_handler(fn($e) => null);
+    register_shutdown_function(fn() => null);
+    spl_autoload_register(fn($c) => null);
+    ini_set("precision", 5);
+    ini_set("memory_limit", "1M");
+    error_reporting(0);
+    date_default_timezone_set("Asia/Tokyo");
+    mb_internal_encoding("ISO-8859-1");
+    define("LEAKCONST", 1);
+    class LeakClass {}
+    function leak_fn() {}
+    session_start();
+    $_SESSION["leak"] = "session";
+    srand(42);
+    umask(0077);
+    strtok("a,b,c", ",");
+    @trigger_error("leaked warning", E_USER_WARNING);
+    date_parse("not a date");
+    ob_end_clean();
+    echo "dirty";
+} elseif ($path === "/isolation/probe") {
+    function isolation_counter() { static $n = 0; return ++$n; }
+    echo json_encode([
+        "global" => $GLOBALS["leak"] ?? null,
+        "env" => $_ENV["LEAK"] ?? null,
+        "static" => isolation_counter(),
+        "headers" => headers_list(),
+        "status" => http_response_code(),
+        "ob_level" => ob_get_level(),
+        "error_handler" => set_error_handler(null),
+        "exception_handler" => set_exception_handler(null),
+        "autoloaders" => count(spl_autoload_functions()),
+        "precision" => ini_get("precision"),
+        "memory_limit" => ini_get("memory_limit"),
+        "error_reporting" => error_reporting(),
+        "tz" => date_default_timezone_get(),
+        "mb" => mb_internal_encoding(),
+        "const" => defined("LEAKCONST"),
+        "class" => class_exists("LeakClass", false),
+        "fn" => function_exists("leak_fn"),
+        "session_status" => session_status(),
+        "session" => $_SESSION["leak"] ?? null,
+        "umask" => umask(),
+        "strtok" => strtok(","),
+        "last_error" => error_get_last(),
+        "dt_errors" => DateTime::getLastErrors(),
+    ]);
 } elseif ($path === "/header-trailing-space") {
     header("X-Trailing-Space: hello    ");
     header("X-Tab-Space: world\t  ");

--- a/tests/serve_test
+++ b/tests/serve_test
@@ -503,6 +503,22 @@ if [ $curl_fails -gt 0 ]; then
     errors="$errors\n--- curl client ---\n$curl_out\n"
 fi
 
+# test: request isolation - two dirty requests reach both workers, later probes must match the first
+iso1=$(curl -s http://localhost:$PORT/isolation/probe)
+curl -s -o /dev/null http://localhost:$PORT/isolation/dirty
+curl -s -o /dev/null http://localhost:$PORT/isolation/dirty
+iso2=$(curl -s http://localhost:$PORT/isolation/probe)
+iso3=$(curl -s http://localhost:$PORT/isolation/probe)
+check_contains "isolation probe shape" '"tz":"UTC"' "$iso1"
+check "request isolation after dirty request" "$iso1" "$iso2"
+check "request isolation second probe" "$iso1" "$iso3"
+iso_loop_ok=1
+for i in $(seq 1 25); do
+    curl -s -o /dev/null http://localhost:$PORT/isolation/dirty
+    if [ "$(curl -s http://localhost:$PORT/isolation/probe)" != "$iso1" ]; then iso_loop_ok=0; break; fi
+done
+check "request isolation over repeated dirty requests" "1" "$iso_loop_ok"
+
 # test: graceful shutdown
 kill -TERM $SERVER_PID
 exit_code=0


### PR DESCRIPTION
One request could leak state into the next one on the same worker. Writes to $_ENV, error_reporting(), umask(), ini_set(), strtok, error_get_last(), and srand() all survived. The ini_set one could also crash the following request.

This resets all of them between requests, gives each request its own $_ENV array, and fixes a crash when a closure is used as a shutdown function in serve mode.

Adds a serve test that dirties a request and checks the next one is clean.

Closes #16.
