### PR TITLE
Add bench-compare for paired perf runs against the merge base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ bench: ## Run runtime benchmarks (ReleaseFast)
 	zig build -Doptimize=ReleaseFast
 	./benchmarks/runtime/run
 
+.PHONY: bench-compare
+bench-compare: ## Time this tree against its merge base with main on this machine (ReleaseFast, interleaved); pass BASE=<ref> to pick the base
+	python3 ./benchmarks/compare $(if $(BASE),--base $(BASE),)
+
 .PHONY: soak
 soak: ## Run the memory soak (ReleaseFast): a string-heavy loop must hold a flat RSS
 	zig build -Doptimize=ReleaseFast

--- a/benchmarks/compare
+++ b/benchmarks/compare
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Compare this tree's performance against a base commit on this machine.
+
+Both binaries are built in ReleaseFast (the base in a temporary git worktree,
+cached by commit) and every benchmark is timed for both, interleaved, in the
+same session. Ratios below 1.0 mean this tree is faster. Nothing is stored and
+nothing is compared against numbers from another machine: run it wherever you
+are, and read the ratios, not the milliseconds.
+
+    benchmarks/compare                 # against the merge base with main
+    benchmarks/compare --base v0.6.0   # against any ref
+    benchmarks/compare --runs 9        # more samples (default 5, min wins)
+    benchmarks/compare --micro         # runtime micros only (no real apps)
+"""
+import argparse
+import glob
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CACHE = os.path.join(os.environ.get("TMPDIR", "/tmp"), "zphp-compare")
+MICROS = sorted(glob.glob(os.path.join(ROOT, "benchmarks", "runtime", "*.php")))
+MACROS = sorted(glob.glob(os.path.join(ROOT, "tests", "laravel", "harness", "*.php")) + glob.glob(os.path.join(ROOT, "tests", "wordpress", "harness", "*.php")))
+
+
+def git(*args, cwd=ROOT):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True).stdout.strip()
+
+
+# `make release` carries the pkg-config and SDK setup the build needs; the
+# produced binary is copied out so zig-out can be rebuilt freely afterwards
+def build(src_dir, prefix):
+    env = dict(os.environ)
+    if sys.platform == "darwin" and "DEVELOPER_DIR" not in env and os.path.isdir("/Library/Developer/CommandLineTools"):
+        env["DEVELOPER_DIR"] = "/Library/Developer/CommandLineTools"
+    subprocess.run(["make", "-C", src_dir, "release"], env=env, check=True, stdout=subprocess.DEVNULL)
+    os.makedirs(os.path.join(prefix, "bin"), exist_ok=True)
+    binary = os.path.join(prefix, "bin", "zphp")
+    shutil.copy(os.path.join(src_dir, "zig-out", "bin", "zphp"), binary)
+    return binary
+
+
+def base_binary(ref):
+    sha = git("rev-parse", ref)
+    prefix = os.path.join(CACHE, "base-" + sha)
+    binary = os.path.join(prefix, "bin", "zphp")
+    if os.path.exists(binary):
+        return binary, sha
+    worktree = os.path.join(CACHE, "wt-" + sha)
+    if os.path.exists(worktree):
+        shutil.rmtree(worktree, ignore_errors=True)
+        subprocess.run(["git", "worktree", "prune"], cwd=ROOT)
+    print(f"building base {sha[:8]} in a worktree", flush=True)
+    git("worktree", "add", "--detach", worktree, sha)
+    try:
+        build(worktree, prefix)
+    finally:
+        git("worktree", "remove", "--force", worktree)
+    return binary, sha
+
+
+def head_binary():
+    prefix = os.path.join(CACHE, "head")
+    print("building this tree", flush=True)
+    return build(ROOT, prefix)
+
+
+def time_run(binary, script):
+    start = time.perf_counter()
+    subprocess.run([binary, "run", script], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=120)
+    return (time.perf_counter() - start) * 1000
+
+
+def measure(scripts, base, head, runs):
+    best = {(which, s): float("inf") for which in ("base", "head") for s in scripts}
+    for _ in range(runs):
+        for s in scripts:
+            for which, binary in (("base", base), ("head", head)):
+                best[(which, s)] = min(best[(which, s)], time_run(binary, s))
+    return best
+
+
+def report(title, scripts, best):
+    if not scripts:
+        return []
+    print(f"\n{title}")
+    print(f"{'benchmark':32s} {'base':>8s} {'head':>8s}   ratio")
+    ratios = []
+    for s in scripts:
+        b = best[("base", s)]
+        h = best[("head", s)]
+        ratio = h / b if b else float("nan")
+        ratios.append(ratio)
+        flag = "  slower" if ratio > 1.05 else ("  faster" if ratio < 0.95 else "")
+        print(f"{os.path.basename(s)[:32]:32s} {b:8.1f} {h:8.1f}   {ratio:.3f}{flag}")
+    geomean = 1.0
+    for r in ratios:
+        geomean *= r
+    geomean **= 1.0 / len(ratios)
+    print(f"{'geomean':32s} {'':>8s} {'':>8s}   {geomean:.3f}")
+    return ratios
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", help="ref to compare against (default: merge base with main)")
+    ap.add_argument("--runs", type=int, default=5, help="samples per benchmark per binary, min wins")
+    ap.add_argument("--micro", action="store_true", help="skip the real-app harnesses")
+    args = ap.parse_args()
+    os.makedirs(CACHE, exist_ok=True)
+    ref = args.base or git("merge-base", "HEAD", "main")
+    base, sha = base_binary(ref)
+    head = head_binary()
+    dirty = " (uncommitted changes)" if git("status", "--porcelain", "--untracked-files=no") else ""
+    print(f"\nbase {sha[:8]}  vs  head {git('rev-parse', '--short', 'HEAD')}{dirty}, min of {args.runs} interleaved runs, ms")
+    micro = measure(MICROS, base, head, args.runs)
+    report("runtime micros", MICROS, micro)
+    if not args.micro:
+        macros = [s for s in MACROS if os.path.exists(s)]
+        if macros:
+            macro = measure(macros, base, head, args.runs)
+            report("real-app harnesses (needs tests/laravel/setup and tests/wordpress/setup)", macros, macro)
+        else:
+            print("\nno real-app harnesses found; run tests/laravel/setup and tests/wordpress/setup")
+    print("\nratios under 1.0 are wins for this tree. treat anything within 5% as noise and rerun with --runs 9 before believing it.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
make bench-compare builds the merge base with main in a temporary worktree (cached per commit) and this tree, both ReleaseFast, then times every runtime micro and real-app harness for both binaries interleaved in one session and prints the ratios. Nothing is stored and nothing is compared across machines, so it gives the same answer on any box: ratios under 1.0 are wins, anything within 5% is noise.

BASE=<ref> picks a different base, --runs raises the sample count, --micro skips the real apps.

Closes #22.
