### PR TITLE
Harden releases: pinned runners, checksums, attestations, packaged-binary smoke tests

### DIFF
--- a/.github/scripts/release_smoke.php
+++ b/.github/scripts/release_smoke.php
@@ -1,0 +1,22 @@
+<?php
+// executed against every packaged release binary: touches each linked
+// native library once so a missing or mislinked dependency fails the release
+$checks = [
+    "pcre" => preg_match('/^v(\d+)/', "v42") === 1,
+    "sqlite" => (new PDO("sqlite::memory:"))->query("select 42 as n")->fetchColumn() == 42,
+    "zlib" => gzdecode(gzencode("zphp")) === "zphp",
+    "openssl" => strlen(openssl_random_pseudo_bytes(8)) === 8,
+    "curl" => is_string(curl_version()["version"]),
+    "libxml" => (new DOMDocument())->loadXML("<a>b</a>") === true,
+    "json" => json_decode('{"ok":true}', true)["ok"] === true,
+    "gmp" => gmp_strval(gmp_add("1", "2")) === "3",
+    "gd" => imagecreatetruecolor(2, 2) !== false,
+    "sodium" => strlen(sodium_crypto_generichash("x")) === 32,
+    "intl" => class_exists("NumberFormatter"),
+    "bcmath" => bcadd("0.1", "0.2", 1) === "0.3",
+    "mbstring" => mb_strlen("h\u{e9}") === 2,
+    "datetime" => (new DateTime("2024-01-01 00:00:00 UTC"))->format("U") === "1704067200",
+];
+$failed = array_keys(array_filter($checks, fn($ok) => !$ok));
+echo "smoke: " . count($checks) . " checks, " . count($failed) . " failed", $failed ? " (" . implode(", ", $failed) . ")" : "", "\n";
+exit($failed ? 1 : 0);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-24.04
@@ -56,12 +57,13 @@ jobs:
         uses: jirutka/setup-alpine@v1
         with:
           arch: ${{ matrix.alpine }}
-          branch: latest-stable
+          # pinned: a new alpine release changes library packaging under our feet
+          branch: v3.22
           apk-tools-url: https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.10/${{ matrix.alpine }}/apk.static#!sha256!${{ matrix.apk_sha }}
           packages: >
             build-base linux-headers curl xz
             pcre2-dev sqlite-dev sqlite-static zlib-dev zlib-static
-            mariadb-connector-c-dev libpq-dev
+            mariadb-connector-c-dev mariadb-static libpq-dev
             openssl-dev openssl-libs-static
             nghttp2-dev nghttp2-static curl-dev curl-static
             libxml2-dev libxml2-static

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -17,14 +19,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             name: linux-x86_64
           - os: ubuntu-24.04-arm
             name: linux-aarch64
           # pinned to 15: macos-latest = macOS 26 whose SDK zig 0.15.1 can't link
           - os: macos-15
             name: macos-aarch64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             name: linux-x86_64-musl
             alpine: x86_64
             apk_sha: 34bb1a96f0258982377a289392d4ea9f3f4b767a4bb5806b1b87179b79ad8a1c
@@ -107,20 +109,78 @@ jobs:
           cp zig-out/bin/zphp zphp-${{ matrix.name }}
           chmod +x zphp-${{ matrix.name }}
 
+      # the packaged file is what ships, so that is what gets executed here,
+      # not the zig-out build it was copied from
+      - name: smoke test packaged binary (glibc/macos)
+        if: ${{ !matrix.alpine }}
+        run: |
+          ./zphp-${{ matrix.name }} version
+          ./zphp-${{ matrix.name }} run .github/scripts/release_smoke.php
+
+      - name: smoke test packaged binary (musl)
+        if: matrix.alpine
+        shell: alpine.sh {0}
+        run: |
+          ./zphp-${{ matrix.name }} version
+          ./zphp-${{ matrix.name }} run .github/scripts/release_smoke.php
+
+      # which native libraries the binary loads at runtime, with the versions
+      # the build host had. glibc and macos builds link them dynamically and
+      # need the same sonames on the target machine; musl builds are static
+      - name: record linked libraries
+        run: |
+          {
+            echo "zphp-${{ matrix.name }} built on ${{ matrix.os }} with zig 0.15.1"
+            echo
+            if [ "${{ runner.os }}" = "macOS" ]; then
+              otool -L zphp-${{ matrix.name }}
+              echo
+              brew list --versions mysql-client libpq openssl@3 nghttp2 curl libxml2 icu4c gmp gd libsodium openldap pcre2 sqlite 2>/dev/null || true
+            elif [ -n "${{ matrix.alpine }}" ]; then
+              echo "static musl build (no runtime library dependencies beyond the kernel)"
+              file zphp-${{ matrix.name }} || true
+            else
+              ldd zphp-${{ matrix.name }}
+              echo
+              dpkg-query -W libpcre2-8-0 libsqlite3-0 zlib1g libmysqlclient21 libpq5 libssl3t64 libnghttp2-14 libcurl4t64 libxml2 libicu74 libgmp10 libgd3 libsodium23 libldap2 2>/dev/null || dpkg-query -W 'libpcre2*' 'libsqlite3*' 'zlib1g' 'libmysqlclient*' 'libpq5' 'libssl3*' 'libnghttp2*' 'libcurl4*' 'libxml2' 'libicu*' 'libgmp10' 'libgd3' 'libsodium*' 'libldap*' 2>/dev/null || true
+            fi
+          } > zphp-${{ matrix.name }}.libs.txt
+          cat zphp-${{ matrix.name }}.libs.txt
+
+      - uses: actions/attest-build-provenance@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          subject-path: zphp-${{ matrix.name }}
+
       - uses: actions/upload-artifact@v4
         with:
           name: zphp-${{ matrix.name }}
-          path: zphp-${{ matrix.name }}
+          path: |
+            zphp-${{ matrix.name }}
+            zphp-${{ matrix.name }}.libs.txt
 
   release:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
+      - name: checksums
+        run: |
+          cd artifacts
+          sha256sum zphp-* | grep -v '\.libs\.txt' > SHA256SUMS
+          cat SHA256SUMS
+      # the x86_64 artifacts run on this runner: one last execution of exactly
+      # the bytes that are about to be published
+      - name: execute published binaries
+        run: |
+          cd artifacts
+          chmod +x zphp-linux-x86_64 zphp-linux-x86_64-musl
+          ./zphp-linux-x86_64-musl version
+          ./zphp-linux-x86_64 version
       - name: create release
         uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ zphp install
 
 Download builds from [GitHub Releases](https://github.com/nvms/zphp/releases).
 
+| Asset | Platform | Notes |
+|---|---|---|
+| `zphp-linux-x86_64-musl` | Linux x86_64 | Static. Runs on any distribution. |
+| `zphp-linux-aarch64-musl` | Linux aarch64 | Static. Runs on any distribution. |
+| `zphp-linux-x86_64` | Ubuntu 24.04 x86_64 | Links the system libraries listed in the matching `.libs.txt`. |
+| `zphp-linux-aarch64` | Ubuntu 24.04 aarch64 | Links the system libraries listed in the matching `.libs.txt`. |
+| `zphp-macos-aarch64` | macOS 15 or newer, Apple Silicon | Links Homebrew libraries listed in the matching `.libs.txt`. |
+
+Pick a musl build unless you are on the exact platform a glibc build was made on. Every release ships a `SHA256SUMS` file, a `.libs.txt` per binary naming the native libraries it was linked against, and a build provenance attestation you can check with `gh attestation verify zphp-<platform> --repo nvms/zphp`.
+
 See the [documentation](https://nvms.github.io/zphp/) for build instructions and usage guides.
 
 ## Project Status

--- a/build.zig
+++ b/build.zig
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
     exe_mod.linkSystemLibrary("pcre2-8", .{ .preferred_link_mode = .static });
     exe_mod.linkSystemLibrary("sqlite3", .{ .preferred_link_mode = .static });
     exe_mod.linkSystemLibrary("z", .{ .preferred_link_mode = .static });
-    exe_mod.linkSystemLibrary("mysqlclient", .{});
+    addMysqlClient(b, exe_mod);
     exe_mod.linkSystemLibrary("pq", .{});
     addOpenSsl(b, exe_mod);
     exe_mod.linkSystemLibrary("nghttp2", .{ .preferred_link_mode = .static });
@@ -77,7 +77,7 @@ pub fn build(b: *std.Build) void {
     test_mod.linkSystemLibrary("pcre2-8", .{ .preferred_link_mode = .static });
     test_mod.linkSystemLibrary("sqlite3", .{ .preferred_link_mode = .static });
     test_mod.linkSystemLibrary("z", .{ .preferred_link_mode = .static });
-    test_mod.linkSystemLibrary("mysqlclient", .{});
+    addMysqlClient(b, test_mod);
     test_mod.linkSystemLibrary("pq", .{});
     addOpenSsl(b, test_mod);
     test_mod.linkSystemLibrary("nghttp2", .{ .preferred_link_mode = .static });
@@ -131,6 +131,22 @@ fn addOpenSsl(b: *std.Build, mod: *std.Build.Module) void {
     if (pkgConfigVariable(b, "openssl", "libdir")) |lib| {
         mod.addLibraryPath(.{ .cwd_relative = lib });
     }
+}
+
+// ubuntu and homebrew ship mysqlclient.pc. alpine ships the same API as
+// libmariadb.pc (mariadb-connector-c-dev) with headers under /usr/include/mysql
+// and the static archive in mariadb-static
+fn addMysqlClient(b: *std.Build, mod: *std.Build.Module) void {
+    if (pkgConfigVariable(b, "mysqlclient", "libdir") != null) {
+        mod.linkSystemLibrary("mysqlclient", .{});
+        return;
+    }
+    if (pkgConfigVariable(b, "libmariadb", "includedir")) |inc| {
+        mod.addIncludePath(.{ .cwd_relative = inc });
+        mod.linkSystemLibrary("mariadb", .{ .preferred_link_mode = .static });
+        return;
+    }
+    mod.linkSystemLibrary("mysqlclient", .{});
 }
 
 fn pkgConfigVariable(b: *std.Build, pkg: []const u8, name: []const u8) ?[]const u8 {


### PR DESCRIPTION
The release workflow now pins every runner and the Alpine branch, executes each packaged binary against a smoke script that touches every linked native library, records the libraries each binary was linked against as a .libs.txt asset, publishes SHA256SUMS, and attaches a build provenance attestation (verify with gh attestation verify). The README gains a platform table that says which builds are static and which need the build host's libraries.

Running the workflow on this branch showed the musl builds had been broken since Alpine dropped mysqlclient.pc; build.zig now falls back to libmariadb, which ships the same API.

No SBOM: for a Zig binary linking system libraries it would list nothing the .libs.txt does not.

Closes #20.
