### PR TITLE
add a frame-pointer build option for profiling

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -66,6 +66,13 @@ pub fn build(b: *std.Build) void {
         pinStaticArchives(b, exe_mod);
     }
 
+    // -Dframe-pointers keeps frame pointers in release builds so `sample`
+    // and perf can unwind the stack when profiling by time
+    if (b.option(bool, "frame-pointers", "keep frame pointers for profiling") orelse false) {
+        exe_mod.omit_frame_pointer = false;
+        fast_loop_mod.omit_frame_pointer = false;
+    }
+
     const exe = b.addExecutable(.{
         .name = "zphp",
         .root_module = exe_mod,


### PR DESCRIPTION
`zig build -Dframe-pointers` (or `make release ZIG_FLAGS=-Dframe-pointers`) keeps frame pointers in a release build so `sample` on macOS can unwind it and produce a flat profile. Without it a ReleaseFast binary shows a single `start` frame and nothing else.

This came out of profiling native call overhead. A prototype that ran natives in place from the fast loop cut `abs()` in a loop from 72ns to 30ns per call, but no real-application harness moved, and it needed a carve-out for the top-level frame and careful placement to avoid perturbing unrelated handlers. It was not merged; the profile and its conclusions are recorded for the next attempt.
