### PR TITLE
Keep extension resource pointers out of PHP properties

### DIFF
--- a/src/extension.zig
+++ b/src/extension.zig
@@ -21,8 +21,6 @@ const static_extensions = @import("static_extensions");
 
 pub const abi_version: u32 = 1;
 const max_functions = 2048;
-const ptr_property = "__ext_ptr";
-const type_property = "__ext_type";
 
 pub const Descriptor = extern struct {
     abi: u32,
@@ -358,23 +356,19 @@ pub fn vmDeinit(vm: *VM) void {
     vm.ic.?.ext_slots = &.{};
 }
 
-// resource objects: the native pointer and its type live in two hidden
-// properties; the destructor runs once, then the pointer is zeroed
+// the destructor runs once, then the pointer is zeroed
 fn resourceCleanup(obj: *PhpObject) bool {
-    const ptr = obj.get(ptr_property);
-    const kind = obj.get(type_property);
-    if (ptr != .int or ptr.int == 0 or kind != .int) return true;
-    const index: usize = @intCast(kind.int - 1);
-    if (index < resource_types.items.len) resource_types.items[index].dtor(@ptrFromInt(@as(usize, @intCast(ptr.int))));
-    if (obj.properties.getPtr(ptr_property)) |slot| slot.* = .{ .int = 0 };
+    if (obj.native_ptr == 0 or obj.native_kind == 0) return true;
+    const index: usize = obj.native_kind - 1;
+    if (index < resource_types.items.len) resource_types.items[index].dtor(@ptrFromInt(obj.native_ptr));
+    obj.native_ptr = 0;
     return true;
 }
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     if (resource_types.items.len == 0) return;
     for (objects.items) |obj| {
-        if (obj.pooled) continue;
-        if (obj.get(type_property) != .int) continue;
+        if (obj.pooled or obj.native_kind == 0) continue;
         _ = resourceCleanup(obj);
     }
 }
@@ -543,8 +537,6 @@ fn apiRegisterResource(ext: *Extension, class_name: CStr, dtor: ?ResourceDtor) c
     resource_types.append(persistent(), reg) catch return 0;
     ext.resources.append(persistent(), reg) catch return 0;
     cls.resource_type = @intCast(resource_types.items.len);
-    cls.properties.append(persistent(), .{ .name = ptr_property, .default = .{ .int = 0 } }) catch return 0;
-    cls.properties.append(persistent(), .{ .name = type_property, .default = .{ .int = @intCast(resource_types.items.len) } }) catch return 0;
     return cls.resource_type.?;
 }
 
@@ -744,8 +736,8 @@ fn apiMakeResource(call: *Call, kind: u32, ptr: ?*anyopaque) callconv(.c) ?*Valu
     if (kind == 0 or kind > resource_types.items.len) return null;
     const class_name = resource_types.items[kind - 1].class_name;
     const obj = call.ctx.createObject(class_name) catch return null;
-    obj.set(call.ctx.allocator, ptr_property, .{ .int = @intCast(@intFromPtr(ptr)) }) catch return null;
-    obj.set(call.ctx.allocator, type_property, .{ .int = kind }) catch return null;
+    obj.native_ptr = @intFromPtr(ptr);
+    obj.native_kind = kind;
     return cell(call, .{ .object = obj });
 }
 
@@ -753,11 +745,9 @@ fn apiResourcePtr(call: *Call, v: ?*const Value, kind: u32) callconv(.c) ?*anyop
     _ = call;
     const value = v orelse return null;
     if (value.* != .object) return null;
-    const stored_kind = value.object.get(type_property);
-    if (stored_kind != .int or stored_kind.int != kind) return null;
-    const ptr = value.object.get(ptr_property);
-    if (ptr != .int or ptr.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(ptr.int)));
+    const obj = value.object;
+    if (obj.native_kind != kind or obj.native_ptr == 0) return null;
+    return @ptrFromInt(obj.native_ptr);
 }
 
 fn collectArgs(buf: []Value, args: ?[*]const ?*const Value, count: usize) ?[]Value {

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -799,6 +799,11 @@ pub const PhpObject = struct {
     // a reference cell has targeted one of this object's properties; the
     // release path must detach those weak mirrors before the address is reused
     ref_mirrored: bool = false,
+    // a native handle owned by an extension resource: the pointer and the
+    // registered type id live here, not in properties, so php code cannot
+    // read or forge them
+    native_ptr: usize = 0,
+    native_kind: u32 = 0,
 
     pub const LazyState = struct {
         initializer: Value,

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -6675,6 +6675,12 @@ pub const VM = struct {
                             return error.RuntimeError;
                         };
                         src = src.storage();
+                        if (src.native_kind != 0) {
+                            const msg = try std.fmt.allocPrint(self.allocator, "Trying to clone an uncloneable object of class {s}", .{src.class_name});
+                            try self.strings.append(self.allocator, msg);
+                            if (try self.throwBuiltinException("Error", msg)) continue;
+                            return error.RuntimeError;
+                        }
                         const copy = try self.allocator.create(PhpObject);
                         self.next_object_id += 1;
                         copy.* = .{ .class_name = src.class_name, .id = self.next_object_id };

--- a/tests/extensions/demo.expected
+++ b/tests/extensions/demo.expected
@@ -73,5 +73,13 @@ int(2)
 unwound
 int(3)
 demo_read(): Argument #1 ($buffer) must be an open DemoBuffer
+array(0) {
+}
+array(0) {
+}
+int(4)
+string(4) "stil"
+Trying to clone an uncloneable object of class DemoBuffer
+int(4)
 done
 shutdown sees 2

--- a/tests/extensions/demo.php
+++ b/tests/extensions/demo.php
@@ -38,6 +38,14 @@ function throws() { $x = demo_open(4); throw new RuntimeException("mid"); }
 try { throws(); } catch (RuntimeException $e) { echo "unwound\n"; }
 var_dump(demo_freed());
 try { demo_read("not a buffer"); } catch (TypeError $e) { echo $e->getMessage(), "\n"; }
+$probe = demo_open(4);
+var_dump(get_object_vars($probe), (new ReflectionClass($probe))->getProperties());
+$probe->__ext_ptr = 0x41414141;
+$probe->__ext_type = 99;
+var_dump(demo_write($probe, "still mine"), demo_read($probe));
+try { $copy = clone $probe; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+unset($probe);
+var_dump(demo_freed());
 $keep = demo_open(2);
 register_shutdown_function(function () { echo "shutdown sees ", demo_add(1, 1), "\n"; });
 echo "done\n";


### PR DESCRIPTION
Fixes #62.

`zphp_resource` stored the native pointer and type id in two public properties, so a script could read them, overwrite them, and steer the destructor to an arbitrary address or another type's destructor. They now live in fields on the object itself, which PHP code cannot see or write. `get_object_vars` and reflection report no properties on a resource object, and `clone` on one throws `Error: Trying to clone an uncloneable object of class X`, as PHP does for its own handle classes.

The demo extension test covers the reproductions from the issue.