### PR TITLE
Keep every native pointer in the object's native handle

### DIFF
--- a/src/extension.zig
+++ b/src/extension.zig
@@ -16,6 +16,7 @@ const InterfaceDef = vm_mod.InterfaceDef;
 const value_mod = @import("runtime/value.zig");
 const Value = value_mod.Value;
 const PhpArray = value_mod.PhpArray;
+const NativeHandle = value_mod.NativeHandle;
 const PhpObject = value_mod.PhpObject;
 const static_extensions = @import("static_extensions");
 
@@ -358,17 +359,18 @@ pub fn vmDeinit(vm: *VM) void {
 
 // the destructor runs once, then the pointer is zeroed
 fn resourceCleanup(obj: *PhpObject) bool {
-    if (obj.native_ptr == 0 or obj.native_kind == 0) return true;
-    const index: usize = obj.native_kind - 1;
-    if (index < resource_types.items.len) resource_types.items[index].dtor(@ptrFromInt(obj.native_ptr));
-    obj.native_ptr = 0;
+    const id = obj.native.extensionId() orelse return true;
+    if (obj.native.ptr == 0 or id == 0) return true;
+    const index: usize = id - 1;
+    if (index < resource_types.items.len) resource_types.items[index].dtor(@ptrFromInt(obj.native.ptr));
+    obj.native.ptr = 0;
     return true;
 }
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     if (resource_types.items.len == 0) return;
     for (objects.items) |obj| {
-        if (obj.pooled or obj.native_kind == 0) continue;
+        if (obj.pooled or obj.native.extensionId() == null) continue;
         _ = resourceCleanup(obj);
     }
 }
@@ -736,8 +738,7 @@ fn apiMakeResource(call: *Call, kind: u32, ptr: ?*anyopaque) callconv(.c) ?*Valu
     if (kind == 0 or kind > resource_types.items.len) return null;
     const class_name = resource_types.items[kind - 1].class_name;
     const obj = call.ctx.createObject(class_name) catch return null;
-    obj.native_ptr = @intFromPtr(ptr);
-    obj.native_kind = kind;
+    obj.native = .{ .kind = NativeHandle.extensionKind(kind), .ptr = @intFromPtr(ptr) };
     return cell(call, .{ .object = obj });
 }
 
@@ -745,9 +746,7 @@ fn apiResourcePtr(call: *Call, v: ?*const Value, kind: u32) callconv(.c) ?*anyop
     _ = call;
     const value = v orelse return null;
     if (value.* != .object) return null;
-    const obj = value.object;
-    if (obj.native_kind != kind or obj.native_ptr == 0) return null;
-    return @ptrFromInt(obj.native_ptr);
+    return value.object.native.get(anyopaque, NativeHandle.extensionKind(kind));
 }
 
 fn collectArgs(buf: []Value, args: ?[*]const ?*const Value, count: usize) ?[]Value {

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -761,6 +761,80 @@ pub const Fiber = struct {
     }
 };
 
+// the raw pointers a native class keeps on an instance, tagged with the
+// binding that owns them so one binding's pointer never reaches another's
+// code. up to three addresses: a libxml node with its document and an
+// iteration cursor, a curl easy handle with its header list and share
+pub const NativeHandle = struct {
+    kind: Kind = .none,
+    owns: bool = false,
+    owns_aux: bool = false,
+    ptr: usize = 0,
+    aux: usize = 0,
+    extra: usize = 0,
+
+    pub const Kind = enum(u32) {
+        none = 0,
+        curl,
+        curl_share,
+        curl_multi,
+        dom,
+        gd,
+        gmp,
+        collator,
+        number_formatter,
+        date_formatter,
+        calendar,
+        break_iterator,
+        transliterator,
+        ldap,
+        ldap_result,
+        mysqli,
+        mysqli_result,
+        pdo_sqlite,
+        pdo_sqlite_stmt,
+        pdo_mysql,
+        pdo_mysql_stmt,
+        pdo_pgsql,
+        pdo_pgsql_stmt,
+        simplexml,
+        websocket,
+        xml_reader,
+        xml_writer,
+        _,
+    };
+
+    const extension_base: u32 = 0x10000;
+
+    pub fn extensionKind(id: u32) Kind {
+        return @enumFromInt(extension_base + id);
+    }
+
+    pub fn extensionId(self: NativeHandle) ?u32 {
+        const raw = @intFromEnum(self.kind);
+        return if (raw >= extension_base) raw - extension_base else null;
+    }
+
+    pub fn addr(p: anytype) usize {
+        return if (p) |q| @intFromPtr(q) else 0;
+    }
+
+    pub fn get(self: NativeHandle, comptime T: type, kind: Kind) ?*T {
+        if (self.kind != kind or self.ptr == 0) return null;
+        return @ptrFromInt(self.ptr);
+    }
+
+    pub fn getAux(self: NativeHandle, comptime T: type, kind: Kind) ?*T {
+        if (self.kind != kind or self.aux == 0) return null;
+        return @ptrFromInt(self.aux);
+    }
+
+    pub fn getExtra(self: NativeHandle, comptime T: type, kind: Kind) ?*T {
+        if (self.kind != kind or self.extra == 0) return null;
+        return @ptrFromInt(self.extra);
+    }
+};
+
 pub const PhpObject = struct {
     class_name: []const u8,
     properties: std.StringArrayHashMapUnmanaged(Value) = .{},
@@ -799,11 +873,9 @@ pub const PhpObject = struct {
     // a reference cell has targeted one of this object's properties; the
     // release path must detach those weak mirrors before the address is reused
     ref_mirrored: bool = false,
-    // a native handle owned by an extension resource: the pointer and the
-    // registered type id live here, not in properties, so php code cannot
-    // read or forge them
-    native_ptr: usize = 0,
-    native_kind: u32 = 0,
+    // native pointers behind a builtin or extension class live here, never
+    // in properties, so php code cannot read or forge them
+    native: NativeHandle = .{},
 
     pub const LazyState = struct {
         initializer: Value,

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -283,6 +283,9 @@ pub const ClassDef = struct {
     is_final: bool = false,
     is_readonly: bool = false,
     native_cleanup: ?*const fn (*PhpObject) bool = null,
+    // copies the native handle for `clone`; a class with a handle and no
+    // hook is uncloneable, like php's handle classes
+    native_clone: ?*const fn (*VM, *PhpObject, *PhpObject) bool = null,
     // arithmetic and comparison on instances of a native class (BcMath\Number).
     // null result means the operand pair is not supported and the ordinary
     // TypeError path runs
@@ -6678,10 +6681,9 @@ pub const VM = struct {
                             return error.RuntimeError;
                         };
                         src = src.storage();
-                        if (src.native_kind != 0) {
-                            const msg = try std.fmt.allocPrint(self.allocator, "Trying to clone an uncloneable object of class {s}", .{src.class_name});
-                            try self.strings.append(self.allocator, msg);
-                            if (try self.throwBuiltinException("Error", msg)) continue;
+                        const native_clone = if (src.native.kind == .none) null else self.nativeCloneHook(src.class_name);
+                        if (src.native.kind != .none and native_clone == null) {
+                            if (try self.throwUncloneable(src.class_name)) continue;
                             return error.RuntimeError;
                         }
                         const copy = try self.allocator.create(PhpObject);
@@ -6700,6 +6702,10 @@ pub const VM = struct {
                             try copy.properties.put(self.allocator, entry.key_ptr.*, try self.copyObjectCloneValue(entry.value_ptr.*));
                         }
                         try self.objects.append(self.allocator, copy);
+                        if (native_clone) |hook| if (!hook(self, src, copy)) {
+                            if (try self.throwUncloneable(src.class_name)) continue;
+                            return error.RuntimeError;
+                        };
                         if (src.ref_mirrored) {
                             if (src.slot_layout) |layout| {
                                 for (layout.names) |name| {
@@ -11422,6 +11428,23 @@ pub const VM = struct {
             .generator => "Generator",
             .fiber => "Fiber",
         };
+    }
+
+    // the hook sits on the builtin class; a user subclass inherits it
+    fn nativeCloneHook(self: *VM, class_name: []const u8) ?*const fn (*VM, *PhpObject, *PhpObject) bool {
+        var name: ?[]const u8 = class_name;
+        while (name) |n| {
+            const def = self.classes.get(n) orelse return null;
+            if (def.native_clone) |hook| return hook;
+            name = def.parent;
+        }
+        return null;
+    }
+
+    pub fn throwUncloneable(self: *VM, class_name: []const u8) !bool {
+        const msg = try std.fmt.allocPrint(self.allocator, "Trying to clone an uncloneable object of class {s}", .{class_name});
+        try self.strings.append(self.allocator, msg);
+        return self.throwBuiltinException("Error", msg);
     }
 
     pub fn throwBuiltinException(self: *VM, class_name: []const u8, message: []const u8) !bool {

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -6,6 +6,8 @@ const VM = @import("runtime/vm.zig").VM;
 const Value = @import("runtime/value.zig").Value;
 const PhpArray = @import("runtime/value.zig").PhpArray;
 const PhpObject = @import("runtime/value.zig").PhpObject;
+const NativeHandle = @import("runtime/value.zig").NativeHandle;
+const platform = @import("platform.zig");
 
 const tls = @import("tls.zig");
 const h2 = @import("h2.zig");
@@ -764,7 +766,7 @@ fn compactConnections(w: *Worker) void {
             if (c.state == .closing) {
                 if (c.ws_obj) |ws_obj| {
                     ws_obj.set(w.allocator, "__ws_closed", .{ .bool = true }) catch {};
-                    ws_obj.set(w.allocator, "__ws_ssl", .{ .int = 0 }) catch {};
+                    ws_obj.native.ptr = 0;
                     if (w.vm.functions.contains("ws_onClose")) {
                         _ = w.vm.callByName("ws_onClose", &.{Value{ .object = ws_obj }}) catch {};
                     }
@@ -1193,14 +1195,9 @@ fn handleWsUpgrade(w: *Worker, c: *Connection, ws_key: []const u8) void {
         c.state = .closing;
         return;
     };
-    ws_obj.* = .{ .class_name = "WebSocketConnection" };
-    ws_obj.set(w.allocator, "__ws_fd", .{ .int = @intCast(c.fd) }) catch {
-        c.state = .closing;
-        return;
-    };
-    ws_obj.set(w.allocator, "__ws_ssl", .{ .int = if (c.ssl) |s| @intCast(@intFromPtr(s)) else @as(i64, 0) }) catch {
-        c.state = .closing;
-        return;
+    ws_obj.* = .{
+        .class_name = "WebSocketConnection",
+        .native = .{ .kind = .websocket, .ptr = NativeHandle.addr(c.ssl), .aux = @intCast(platform.socketToInt(c.fd)) },
     };
     ws_obj.set(w.allocator, "__ws_closed", .{ .bool = false }) catch {
         c.state = .closing;

--- a/src/stdlib/curl.zig
+++ b/src/stdlib/curl.zig
@@ -57,9 +57,29 @@ fn ensureGlobalInit() void {
 }
 
 fn getHandle(obj: *PhpObject) ?*c.CURL {
-    const v = obj.get("__curl_ptr");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.CURL, .curl);
+}
+
+fn getSlist(obj: *PhpObject) ?*c.struct_curl_slist {
+    return obj.native.getAux(c.struct_curl_slist, .curl);
+}
+
+fn getEasyShare(obj: *PhpObject) ?*ShareState {
+    return obj.native.getExtra(ShareState, .curl);
+}
+
+fn freeSlist(obj: *PhpObject) void {
+    if (getSlist(obj)) |sl| {
+        c.curl_slist_free_all(sl);
+        obj.native.aux = 0;
+    }
+}
+
+fn cloneHandle(_: *VM, src: *PhpObject, copy: *PhpObject) bool {
+    const handle = getHandle(src) orelse return false;
+    const dup = c.curl_easy_duphandle(handle) orelse return false;
+    copy.native = .{ .kind = .curl, .ptr = @intFromPtr(dup) };
+    return true;
 }
 
 fn getThis(ctx: *NativeContext) ?*PhpObject {
@@ -89,17 +109,12 @@ fn curlInit(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult 
     const handle = c.curl_easy_init() orelse return NativeResult.scalar(.{ .bool = false });
 
     const obj = try ctx.createObject("CurlHandle");
-    try obj.set(ctx.allocator, "__curl_ptr", .{ .int = @intCast(@intFromPtr(handle)) });
+    obj.native = .{ .kind = .curl, .ptr = @intFromPtr(handle) };
     try obj.set(ctx.allocator, "__error", .{ .string = Value.String.borrowed("") });
     try obj.set(ctx.allocator, "__errno", .{ .int = 0 });
     try obj.set(ctx.allocator, "__return_transfer", .{ .bool = false });
     try obj.set(ctx.allocator, "__header_out", .{ .bool = false });
     try obj.set(ctx.allocator, "__http_code", .{ .int = 0 });
-
-    try obj.set(ctx.allocator, "__share_state", .{ .int = 0 });
-
-    // store slist pointers for cleanup
-    try obj.set(ctx.allocator, "__slist_ptr", .{ .int = 0 });
 
     if (args.len > 0 and args[0] == .string) {
         const url_z = try dupeZ(ctx, args[0].string.bytes());
@@ -129,7 +144,7 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
             // in allocation order. reset preserves libcurl's share association.
             share.refs += 1;
             releaseEasyShare(obj);
-            obj.properties.getPtr("__share_state").?.* = .{ .int = @intCast(@intFromPtr(share)) };
+            obj.native.extra = @intFromPtr(share);
         }
         try obj.set(ctx.allocator, "__errno", .{ .int = @intCast(code) });
         return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
@@ -245,12 +260,7 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
     if (option == c.CURLOPT_HTTPHEADER) {
         if (value != .array) return NativeResult.scalar(.{ .bool = false });
 
-        // free previous slist if any
-        const prev_v = obj.get("__slist_ptr");
-        if (prev_v == .int and prev_v.int != 0) {
-            const prev: *c.struct_curl_slist = @ptrFromInt(@as(usize, @intCast(prev_v.int)));
-            c.curl_slist_free_all(prev);
-        }
+        freeSlist(obj);
 
         var slist: ?*c.struct_curl_slist = null;
         for (value.array.entries.items) |entry| {
@@ -260,7 +270,7 @@ fn applySetopt(ctx: *NativeContext, handle: *c.CURL, obj: *PhpObject, option: i6
             }
         }
         if (slist) |sl| {
-            try obj.set(ctx.allocator, "__slist_ptr", .{ .int = @intCast(@intFromPtr(sl)) });
+            obj.native.aux = @intFromPtr(sl);
             const code: c_uint = @intCast(c.curl_easy_setopt(handle, c.CURLOPT_HTTPHEADER, sl));
             return NativeResult.scalar(.{ .bool = code == c.CURLE_OK });
         }
@@ -404,22 +414,11 @@ fn curlClose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult
 
 pub fn cleanupHandle(obj: *PhpObject) void {
     if (obj.pooled) return;
-    // The property map belongs to the VM allocator (also used by native
-    // contexts). Cleanup only clears existing pointer slots: even put of an
-    // existing key can grow a full map, so it must not use page_allocator.
-    // free slist
-    const slist_v = obj.get("__slist_ptr");
-    if (slist_v == .int and slist_v.int != 0) {
-        const sl: *c.struct_curl_slist = @ptrFromInt(@as(usize, @intCast(slist_v.int)));
-        c.curl_slist_free_all(sl);
-        obj.properties.getPtr("__slist_ptr").?.* = .{ .int = 0 };
-    }
-
-    // free curl handle
+    freeSlist(obj);
     if (getHandle(obj)) |handle| {
         c.curl_easy_cleanup(handle);
         releaseEasyShare(obj);
-        obj.properties.getPtr("__curl_ptr").?.* = .{ .int = 0 };
+        obj.native.ptr = 0;
     }
 }
 
@@ -709,15 +708,7 @@ fn curlReset(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult
     try obj.set(ctx.allocator, "__error", .{ .string = Value.String.borrowed("") });
     try obj.set(ctx.allocator, "__errno", .{ .int = 0 });
     try obj.set(ctx.allocator, "__http_code", .{ .int = 0 });
-
-    // free slist
-    const slist_v = obj.get("__slist_ptr");
-    if (slist_v == .int and slist_v.int != 0) {
-        const sl: *c.struct_curl_slist = @ptrFromInt(@as(usize, @intCast(slist_v.int)));
-        c.curl_slist_free_all(sl);
-        try obj.set(ctx.allocator, "__slist_ptr", .{ .int = 0 });
-    }
-
+    freeSlist(obj);
     return NativeResult.scalar(.null);
 }
 
@@ -740,9 +731,7 @@ const ShareState = struct {
 };
 
 fn getShareState(obj: *PhpObject) ?*ShareState {
-    const v = obj.get("__share_state");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(ShareState, .curl_share);
 }
 
 fn releaseShare(state: *ShareState) void {
@@ -754,14 +743,18 @@ fn releaseShare(state: *ShareState) void {
 }
 
 fn releaseEasyShare(obj: *PhpObject) void {
-    if (getShareState(obj)) |state| {
-        obj.properties.getPtr("__share_state").?.* = .{ .int = 0 };
+    if (getEasyShare(obj)) |state| {
+        obj.native.extra = 0;
         releaseShare(state);
     }
 }
 
 fn cleanupShare(obj: *PhpObject) bool {
-    if (!obj.pooled) releaseEasyShare(obj);
+    if (obj.pooled) return true;
+    if (getShareState(obj)) |state| {
+        obj.native.ptr = 0;
+        releaseShare(state);
+    }
     return true;
 }
 
@@ -779,16 +772,6 @@ fn curlShareConstruct(ctx: *NativeContext, _: []const Value) RuntimeError!Native
     return error.RuntimeError;
 }
 
-fn curlShareClone(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
-    // The VM copies properties before invoking __clone. Remove the borrowed
-    // native pointer so failed-clone teardown cannot release the original state.
-    if (getThis(ctx)) |obj| {
-        if (obj.properties.getPtr("__share_state")) |ptr| ptr.* = .{ .int = 0 };
-    }
-    try ctx.vm.setPendingException("Error", "Trying to clone an uncloneable object of class CurlShareHandle");
-    return error.RuntimeError;
-}
-
 fn curlShareInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureGlobalInit();
     const handle = c.curl_share_init() orelse return NativeResult.scalar(.{ .bool = false });
@@ -797,7 +780,7 @@ fn curlShareInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResul
     errdefer std.heap.page_allocator.destroy(state);
     const obj = try ctx.createObject("CurlShareHandle");
     state.* = .{ .handle = handle };
-    try obj.set(ctx.allocator, "__share_state", .{ .int = @intCast(@intFromPtr(state)) });
+    obj.native = .{ .kind = .curl_share, .ptr = @intFromPtr(state) };
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -843,16 +826,14 @@ fn curlShareStrerror(ctx: *NativeContext, args: []const Value) RuntimeError!Nati
 var multi_wcb_table: std.AutoHashMapUnmanaged(usize, *WriteCallbackData) = .{};
 
 fn getMultiHandle(obj: *PhpObject) ?*c.CURLM {
-    const v = obj.get("__multi_ptr");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.CURLM, .curl_multi);
 }
 
 fn curlMultiInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     ensureGlobalInit();
     const mh = c.curl_multi_init() orelse return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("CurlMultiHandle");
-    try obj.set(ctx.allocator, "__multi_ptr", .{ .int = @intCast(@intFromPtr(mh)) });
+    obj.native = .{ .kind = .curl_multi, .ptr = @intFromPtr(mh) };
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -952,7 +933,7 @@ fn curlMultiClose(_: *NativeContext, args: []const Value) RuntimeError!NativeRes
     if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
     const mh = getMultiHandle(args[0].object) orelse return NativeResult.scalar(.null);
     _ = c.curl_multi_cleanup(mh);
-    args[0].object.properties.getPtr("__multi_ptr").?.* = .{ .int = 0 };
+    args[0].object.native.ptr = 0;
     return NativeResult.scalar(.null);
 }
 
@@ -1115,7 +1096,7 @@ fn cleanupPoolable(obj: *PhpObject) bool {
 }
 
 pub fn register(vm: *VM, a: std.mem.Allocator) !void {
-    var curl_def = ClassDef{ .name = "CurlHandle", .native_cleanup = cleanupPoolable };
+    var curl_def = ClassDef{ .name = "CurlHandle", .native_cleanup = cleanupPoolable, .native_clone = cloneHandle };
     try vm.classes.put(a, "CurlHandle", curl_def);
     _ = &curl_def;
 
@@ -1123,7 +1104,6 @@ pub fn register(vm: *VM, a: std.mem.Allocator) !void {
     try vm.classes.put(a, "CurlShareHandle", share_def);
     _ = &share_def;
     try vm.native_fns.put(a, "CurlShareHandle::__construct", curlShareConstruct);
-    try vm.native_fns.put(a, "CurlShareHandle::__clone", curlShareClone);
 
     var mh_def = ClassDef{ .name = "CurlMultiHandle" };
     try vm.classes.put(a, "CurlMultiHandle", mh_def);
@@ -1261,10 +1241,10 @@ pub fn register(vm: *VM, a: std.mem.Allocator) !void {
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
-        if (std.mem.eql(u8, obj.class_name, "CurlHandle")) {
-            cleanupHandle(obj);
-        } else if (std.mem.eql(u8, obj.class_name, "CurlShareHandle")) {
-            _ = cleanupShare(obj);
+        switch (obj.native.kind) {
+            .curl => cleanupHandle(obj),
+            .curl_share => _ = cleanupShare(obj),
+            else => {},
         }
     }
 }
@@ -1294,7 +1274,7 @@ test "curl property growth across native contexts and allocation-free cleanup" {
     const capacity = easy.object.properties.capacity();
     _ = try curlClose(&later_ctx, &.{easy});
     try std.testing.expectEqual(capacity, easy.object.properties.capacity());
-    try std.testing.expectEqual(@as(i64, 0), easy.object.get("__curl_ptr").int);
+    try std.testing.expectEqual(@as(usize, 0), easy.object.native.ptr);
     cleanupHandle(easy.object);
 
     const multi = (try curlMultiInit(&init_ctx, &.{})).value;

--- a/src/stdlib/dom.zig
+++ b/src/stdlib/dom.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const vm_mod = @import("../runtime/vm.zig");
 const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
@@ -103,29 +104,61 @@ fn freeCapturedError(e: *const CapturedError) void {
 }
 
 // ---------------- pointer storage on PhpObject ----------------
-// every wrapper stores its underlying xmlNodePtr as the "__node" property.
-// for DOMDocument the pointer is actually an xmlDocPtr (cast-compatible with
+// every wrapper keeps its xmlNodePtr in the object's native handle (kind
+// .dom). for DOMDocument the pointer is an xmlDocPtr (cast-compatible with
 // xmlNodePtr - libxml2 itself uses this dual identity throughout tree.c).
 //
 // the document wrapper owns the xmlDoc lifecycle: cleanupResources frees it.
 // child wrappers reference nodes inside the doc and free nothing themselves -
-// xmlFreeDoc walks the tree and frees everything.
+// xmlFreeDoc walks the tree and frees everything. the one exception is a
+// wrapper made by `clone`: its node is a detached copy nothing else reaches,
+// so it carries `owns` and the sweep frees it while it is still unattached
 
-fn getNodePtr(obj: *const PhpObject) ?*c.xmlNode {
-    const v = obj.get("__node");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+pub fn getNodePtr(obj: *const PhpObject) ?*c.xmlNode {
+    return obj.native.get(c.xmlNode, .dom);
 }
 
 fn getDocPtr(obj: *const PhpObject) ?*c.xmlDoc {
-    const v = obj.get("__node");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.xmlDoc, .dom);
 }
 
-fn setNodePtr(obj: *PhpObject, allocator: Allocator, node: ?*c.xmlNode) !void {
-    const p: i64 = if (node) |n| @intCast(@intFromPtr(n)) else 0;
-    try obj.set(allocator, "__node", .{ .int = p });
+pub fn setNodePtr(obj: *PhpObject, node: ?*c.xmlNode) void {
+    obj.native = .{ .kind = .dom, .ptr = NativeHandle.addr(node) };
+}
+
+fn setDocPtr(obj: *PhpObject, doc: ?*c.xmlDoc) void {
+    obj.native = .{ .kind = .dom, .ptr = NativeHandle.addr(doc) };
+}
+
+// ---------------- clone ----------------
+
+fn cloneDocHandle(_: *VM, src: *PhpObject, copy: *PhpObject) bool {
+    const doc = getDocPtr(src) orelse {
+        setDocPtr(copy, null);
+        return true;
+    };
+    const dup = c.xmlCopyDoc(doc, 1) orelse return false;
+    setDocPtr(copy, dup);
+    pointOwnerAtSelf(copy);
+    return true;
+}
+
+// the property copy left the clone's __owner on the original document
+fn pointOwnerAtSelf(copy: *PhpObject) void {
+    const slot = copy.properties.getPtr("__owner") orelse return;
+    slot.* = .{ .object = copy };
+    copy.retain();
+}
+
+fn cloneNodeHandle(_: *VM, src: *PhpObject, copy: *PhpObject) bool {
+    const node = getNodePtr(src) orelse {
+        setNodePtr(copy, null);
+        return true;
+    };
+    const dup = c.xmlDocCopyNode(node, node.doc, 1) orelse return false;
+    setNodePtr(copy, dup);
+    copy.native.owns = true;
+    return true;
 }
 
 fn getThis(ctx: *NativeContext) ?*PhpObject {
@@ -185,7 +218,7 @@ fn wrapNode(ctx: *NativeContext, node: ?*c.xmlNode, owner_doc: ?*PhpObject) !Val
     const n = node orelse return .null;
     const cls = classForNodeType(n.type);
     const obj = try ctx.createObject(cls);
-    try setNodePtr(obj, ctx.allocator, n);
+    setNodePtr(obj, n);
     if (owner_doc) |d| try obj.set(ctx.allocator, "__owner", .{ .object = d });
     return .{ .object = obj };
 }
@@ -213,7 +246,7 @@ fn domDocConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Native
         const enc_z = try dupZ(ctx, encoding);
         doc.*.encoding = c.xmlStrdup(@ptrCast(enc_z.ptr));
     }
-    try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
+    setDocPtr(obj, doc);
     try obj.set(ctx.allocator, "__owner", .{ .object = obj });
     try obj.set(ctx.allocator, "formatOutput", .{ .bool = false });
     try obj.set(ctx.allocator, "preserveWhiteSpace", .{ .bool = true });
@@ -239,12 +272,12 @@ fn domDocLoadXML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRe
     // replace any prior doc
     if (getDocPtr(obj)) |old| {
         c.xmlFreeDoc(old);
-        try setNodePtr(obj, ctx.allocator, null);
+        obj.native.ptr = 0;
     }
 
     const doc = c.xmlReadMemory(src.ptr, @intCast(src.len), null, null, opts);
     if (doc == null) return NativeResult.scalar(.{ .bool = false });
-    try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
+    setDocPtr(obj, doc);
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -270,12 +303,12 @@ fn domDocLoad(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResul
 
     if (getDocPtr(obj)) |old| {
         c.xmlFreeDoc(old);
-        try setNodePtr(obj, ctx.allocator, null);
+        obj.native.ptr = 0;
     }
 
     const doc = c.xmlReadFile(path_z.ptr, null, opts);
     if (doc == null) return NativeResult.scalar(.{ .bool = false });
-    try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
+    setDocPtr(obj, doc);
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -287,12 +320,12 @@ fn domDocLoadHTML(ctx: *NativeContext, args: []const Value) RuntimeError!NativeR
 
     if (getDocPtr(obj)) |old| {
         c.xmlFreeDoc(old);
-        try setNodePtr(obj, ctx.allocator, null);
+        obj.native.ptr = 0;
     }
 
     const doc = c.htmlReadMemory(src.ptr, @intCast(src.len), null, null, opts);
     if (doc == null) return NativeResult.scalar(.{ .bool = false });
-    try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
+    setDocPtr(obj, doc);
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -304,12 +337,12 @@ fn domDocLoadHTMLFile(ctx: *NativeContext, args: []const Value) RuntimeError!Nat
 
     if (getDocPtr(obj)) |old| {
         c.xmlFreeDoc(old);
-        try setNodePtr(obj, ctx.allocator, null);
+        obj.native.ptr = 0;
     }
 
     const doc = c.htmlReadFile(path_z.ptr, null, opts);
     if (doc == null) return NativeResult.scalar(.{ .bool = false });
-    try setNodePtr(obj, ctx.allocator, @ptrCast(doc));
+    setDocPtr(obj, doc);
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -1469,7 +1502,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
 }
 
 fn registerDocClass(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "DOMDocument" };
+    var def = ClassDef{ .name = "DOMDocument", .native_clone = cloneDocHandle };
     try def.methods.put(a, "__construct", .{ .name = "__construct", .arity = 0 });
     try def.methods.put(a, "loadXML", .{ .name = "loadXML", .arity = 1 });
     try def.methods.put(a, "load", .{ .name = "load", .arity = 1 });
@@ -1534,7 +1567,7 @@ fn registerDocClass(vm: *VM, a: Allocator) !void {
 }
 
 fn registerNodeClass(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "DOMNode" };
+    var def = ClassDef{ .name = "DOMNode", .native_clone = cloneNodeHandle };
     try def.methods.put(a, "appendChild", .{ .name = "appendChild", .arity = 1 });
     try def.methods.put(a, "removeChild", .{ .name = "removeChild", .arity = 1 });
     try def.methods.put(a, "replaceChild", .{ .name = "replaceChild", .arity = 2 });
@@ -1579,7 +1612,7 @@ fn registerNodeNativeFns(vm: *VM, a: Allocator, comptime class_name: []const u8)
 }
 
 fn registerElementClass(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "DOMElement" };
+    var def = ClassDef{ .name = "DOMElement", .native_clone = cloneNodeHandle };
     def.parent = "DOMNode";
     try def.methods.put(a, "getAttribute", .{ .name = "getAttribute", .arity = 1 });
     try def.methods.put(a, "setAttribute", .{ .name = "setAttribute", .arity = 2 });
@@ -1625,7 +1658,7 @@ fn registerElementClass(vm: *VM, a: Allocator) !void {
 
 fn registerCharacterDataClasses(vm: *VM, a: Allocator) !void {
     inline for (.{ "DOMText", "DOMComment", "DOMCdataSection", "DOMCharacterData", "DOMProcessingInstruction", "DOMEntityReference", "DOMDocumentFragment" }) |name| {
-        var def = ClassDef{ .name = name };
+        var def = ClassDef{ .name = name, .native_clone = cloneNodeHandle };
         def.parent = "DOMNode";
         try def.methods.put(a, "appendData", .{ .name = "appendData", .arity = 1 });
         try def.methods.put(a, "substringData", .{ .name = "substringData", .arity = 2 });
@@ -1645,7 +1678,7 @@ fn registerCharacterDataClasses(vm: *VM, a: Allocator) !void {
 }
 
 fn registerAttrClass(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "DOMAttr" };
+    var def = ClassDef{ .name = "DOMAttr", .native_clone = cloneNodeHandle };
     def.parent = "DOMNode";
     try def.methods.put(a, "appendChild", .{ .name = "appendChild", .arity = 1 });
     try def.methods.put(a, "cloneNode", .{ .name = "cloneNode", .arity = 0 });
@@ -1896,9 +1929,17 @@ fn libxmlSetExternalEntityLoader(_: *NativeContext, _: []const Value) RuntimeErr
 }
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
+    for (objects.items) |obj| freeDetachedCopy(obj);
     for (objects.items) |obj| {
         if (std.mem.eql(u8, obj.class_name, "DOMDocument")) {
             if (getDocPtr(obj)) |doc| c.xmlFreeDoc(doc);
         }
     }
+}
+
+// a cloned node that was appended somewhere is freed with its tree
+fn freeDetachedCopy(obj: *PhpObject) void {
+    if (!obj.native.owns) return;
+    const node = getNodePtr(obj) orelse return;
+    if (node.parent == null) c.xmlFreeNode(node);
 }

--- a/src/stdlib/gd.zig
+++ b/src/stdlib/gd.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const vm_mod = @import("../runtime/vm.zig");
 const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
@@ -20,19 +21,14 @@ const c = @cImport({
     @cInclude("unistd.h");
 });
 
-// PHP's GD functions return/accept a GdImage object whose underlying state is
-// a gdImagePtr (a C pointer). zphp wraps it in a PhpObject with __gd_ptr.
-
 fn getImg(obj: *const PhpObject) ?*c.gdImageStruct {
-    const v = obj.get("__gd_ptr");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.gdImageStruct, .gd);
 }
 
 fn wrapImg(ctx: *NativeContext, im: ?*c.gdImageStruct) RuntimeError!NativeResult {
     if (im == null) return NativeResult.scalar(.{ .bool = false });
     const obj = try ctx.createObject("GdImage");
-    try obj.set(ctx.allocator, "__gd_ptr", .{ .int = @intCast(@intFromPtr(im.?)) });
+    obj.native = .{ .kind = .gd, .ptr = NativeHandle.addr(im) };
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -97,10 +93,7 @@ fn imgDestroy(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResul
     _ = ctx;
     const im = argImg(args, 0) orelse return NativeResult.scalar(.{ .bool = false });
     c.gdImageDestroy(im);
-    if (args[0] == .object) {
-        // zero the pointer so later operations no-op
-        args[0].object.set(std.heap.page_allocator, "__gd_ptr", .{ .int = 0 }) catch {};
-    }
+    if (args[0] == .object) args[0].object.native.ptr = 0;
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -720,7 +713,7 @@ pub const entries = .{
 
 fn cleanupImage(obj: *PhpObject) bool {
     if (getImg(obj)) |im| c.gdImageDestroy(im);
-    if (obj.properties.getPtr("__gd_ptr")) |slot| slot.* = .{ .int = 0 };
+    obj.native.ptr = 0;
     return true;
 }
 
@@ -757,7 +750,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
-        if (obj.pooled or !std.mem.eql(u8, obj.class_name, "GdImage")) continue;
+        if (obj.pooled or obj.native.kind != .gd) continue;
         _ = cleanupImage(obj);
     }
 }

--- a/src/stdlib/gmp.zig
+++ b/src/stdlib/gmp.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const vm_mod = @import("../runtime/vm.zig");
 const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
@@ -17,6 +18,7 @@ const ZphpMpz = opaque {};
 
 extern fn zphp_mpz_create() ?*ZphpMpz;
 extern fn zphp_mpz_destroy(p: ?*ZphpMpz) void;
+extern fn zphp_mpz_set(r: *ZphpMpz, a: *const ZphpMpz) void;
 extern fn zphp_mpz_set_str(p: *ZphpMpz, s: [*:0]const u8, base: c_int) c_int;
 extern fn zphp_mpz_set_si(p: *ZphpMpz, v: i64) i64;
 extern fn zphp_mpz_get_si(p: *const ZphpMpz) i64;
@@ -79,20 +81,17 @@ fn cstrLen(p: [*c]const u8) usize {
 }
 
 fn getMpz(obj: *const PhpObject) ?*ZphpMpz {
-    const v = obj.get("__mpz");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(ZphpMpz, .gmp);
 }
 
-fn setMpz(obj: *PhpObject, allocator: Allocator, p: ?*ZphpMpz) !void {
-    const i: i64 = if (p) |x| @intCast(@intFromPtr(x)) else 0;
-    try obj.set(allocator, "__mpz", .{ .int = i });
+fn setMpz(obj: *PhpObject, p: ?*ZphpMpz) void {
+    obj.native = .{ .kind = .gmp, .ptr = NativeHandle.addr(p) };
 }
 
 fn createGmpObj(ctx: *NativeContext) !*PhpObject {
     const obj = try ctx.createObject("GMP");
     const p = zphp_mpz_create() orelse return error.OutOfMemory;
-    try setMpz(obj, ctx.allocator, p);
+    setMpz(obj, p);
     return obj;
 }
 
@@ -512,12 +511,19 @@ pub const entries = .{
 
 fn cleanupGmp(obj: *PhpObject) bool {
     if (getMpz(obj)) |p| zphp_mpz_destroy(p);
-    if (obj.properties.getPtr("__mpz")) |slot| slot.* = .{ .int = 0 };
+    obj.native.ptr = 0;
+    return true;
+}
+
+fn cloneGmp(_: *VM, src: *PhpObject, copy: *PhpObject) bool {
+    const p = zphp_mpz_create() orelse return false;
+    if (getMpz(src)) |orig| zphp_mpz_set(p, orig);
+    setMpz(copy, p);
     return true;
 }
 
 pub fn register(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "GMP", .native_cleanup = cleanupGmp };
+    var def = ClassDef{ .name = "GMP", .native_cleanup = cleanupGmp, .native_clone = cloneGmp };
     // GMP is mostly a value-holding class; user-facing methods are
     // PHP's procedural ones. providing __toString lets `(string)$gmp` work
     try def.methods.put(a, "__toString", .{ .name = "__toString", .arity = 0 });
@@ -548,7 +554,7 @@ fn gmpToString(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult 
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
-        if (obj.pooled or !std.mem.eql(u8, obj.class_name, "GMP")) continue;
+        if (obj.pooled or obj.native.kind != .gmp) continue;
         _ = cleanupGmp(obj);
     }
 }

--- a/src/stdlib/gmp_shim.c
+++ b/src/stdlib/gmp_shim.c
@@ -30,6 +30,10 @@ void zphp_mpz_destroy(zphp_mpz* p) {
     free(p);
 }
 
+void zphp_mpz_set(zphp_mpz* r, const zphp_mpz* a) {
+    mpz_set(r->v, a->v);
+}
+
 int zphp_mpz_set_str(zphp_mpz* p, const char* s, int base) {
     return mpz_set_str(p->v, s, base);
 }

--- a/src/stdlib/icu_shim.c
+++ b/src/stdlib/icu_shim.c
@@ -98,6 +98,7 @@ UNumberFormat* zphp_unum_open(UNumberFormatStyle s, const UChar* pat, int32_t pa
     return unum_open(s, pat, patLen, loc, parse_err, err);
 }
 void zphp_unum_close(UNumberFormat* f) { unum_close(f); }
+UNumberFormat* zphp_unum_clone(const UNumberFormat* f, UErrorCode* err) { return unum_clone(f, err); }
 int32_t zphp_unum_formatInt64(const UNumberFormat* f, int64_t v, UChar* buf, int32_t cap, void* pos, UErrorCode* err) {
     return unum_formatInt64(f, v, buf, cap, pos, err);
 }
@@ -120,6 +121,7 @@ UTransliterator* zphp_utrans_openU(const UChar* id, int32_t idLen, UTransDirecti
     return utrans_openU(id, idLen, dir, rules, rulesLen, pe, err);
 }
 void zphp_utrans_close(UTransliterator* t) { utrans_close(t); }
+UTransliterator* zphp_utrans_clone(const UTransliterator* t, UErrorCode* err) { return utrans_clone(t, err); }
 void zphp_utrans_transUChars(const UTransliterator* t, UChar* text, int32_t* textLen, int32_t textCap, int32_t start, int32_t* limit, UErrorCode* err) {
     utrans_transUChars(t, text, textLen, textCap, start, limit, err);
 }
@@ -130,6 +132,7 @@ UDateFormat* zphp_udat_open(UDateFormatStyle timeStyle, UDateFormatStyle dateSty
     return udat_open(timeStyle, dateStyle, locale, tzID, tzIDLen, pattern, patternLen, err);
 }
 void zphp_udat_close(UDateFormat* f) { udat_close(f); }
+UDateFormat* zphp_udat_clone(const UDateFormat* f, UErrorCode* err) { return udat_clone(f, err); }
 int32_t zphp_udat_format(const UDateFormat* f, double date, UChar* result, int32_t resultLen, void* pos, UErrorCode* err) {
     return udat_format(f, date, result, resultLen, pos, err);
 }
@@ -299,6 +302,21 @@ void zphp_ubrk_setText(zphp_brk* w, const char* text, int32_t len, UErrorCode* e
     w->ut = utext_openUTF8(NULL, w->text_copy, w->text_len, err);
     if (U_FAILURE(*err)) return;
     ubrk_setUText(w->bi, w->ut, err);
+}
+
+/* ubrk_clone shares the source's UText, so the copy gets its own text buffer
+ * and is moved back to the source's boundary */
+zphp_brk* zphp_ubrk_clone(const zphp_brk* src, UErrorCode* err) {
+    zphp_brk* w = (zphp_brk*)calloc(1, sizeof(zphp_brk));
+    if (!w) { *err = U_MEMORY_ALLOCATION_ERROR; return NULL; }
+    w->bi = ubrk_clone(src->bi, err);
+    if (U_FAILURE(*err)) { free(w); return NULL; }
+    if (!src->text_copy) return w;
+    int32_t pos = ubrk_current(src->bi);
+    zphp_ubrk_setText(w, src->text_copy, src->text_len, err);
+    if (U_FAILURE(*err)) { zphp_ubrk_close(w); return NULL; }
+    if (pos >= 0) ubrk_isBoundary(w->bi, pos);
+    return w;
 }
 
 const char* zphp_ubrk_getText(zphp_brk* w, int32_t* len) {

--- a/src/stdlib/intl.zig
+++ b/src/stdlib/intl.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const vm_mod = @import("../runtime/vm.zig");
 const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
@@ -58,6 +59,7 @@ extern fn zphp_ucol_getStrength(c: *const UCollator) i32;
 
 extern fn zphp_unum_open(style: i32, pattern: ?[*]const UChar, patLen: i32, locale: [*:0]const u8, parseErr: ?*anyopaque, err: *UErrorCode) ?*UNumberFormat;
 extern fn zphp_unum_close(f: *UNumberFormat) void;
+extern fn zphp_unum_clone(f: *const UNumberFormat, err: *UErrorCode) ?*UNumberFormat;
 extern fn zphp_unum_formatInt64(f: *const UNumberFormat, v: i64, buf: [*]UChar, cap: i32, pos: ?*anyopaque, err: *UErrorCode) i32;
 extern fn zphp_unum_formatDouble(f: *const UNumberFormat, v: f64, buf: [*]UChar, cap: i32, pos: ?*anyopaque, err: *UErrorCode) i32;
 extern fn zphp_unum_formatDoubleCurrency(f: *const UNumberFormat, v: f64, ccy: [*]UChar, buf: [*]UChar, cap: i32, pos: ?*anyopaque, err: *UErrorCode) i32;
@@ -68,11 +70,13 @@ extern fn zphp_unum_getAttribute(f: *const UNumberFormat, attr: i32) i32;
 
 extern fn zphp_utrans_openU(id: [*]const UChar, idLen: i32, dir: i32, rules: ?[*]const UChar, rulesLen: i32, parseErr: ?*anyopaque, err: *UErrorCode) ?*UTransliterator;
 extern fn zphp_utrans_close(t: *UTransliterator) void;
+extern fn zphp_utrans_clone(t: *const UTransliterator, err: *UErrorCode) ?*UTransliterator;
 extern fn zphp_utrans_transUChars(t: *const UTransliterator, text: [*]UChar, textLen: *i32, textCap: i32, start: i32, limit: *i32, err: *UErrorCode) void;
 
 const UDateFormat = opaque {};
 extern fn zphp_udat_open(timeStyle: i32, dateStyle: i32, locale: [*:0]const u8, tzId: ?[*]const UChar, tzIdLen: i32, pattern: ?[*]const UChar, patternLen: i32, err: *UErrorCode) ?*UDateFormat;
 extern fn zphp_udat_close(f: *UDateFormat) void;
+extern fn zphp_udat_clone(f: *const UDateFormat, err: *UErrorCode) ?*UDateFormat;
 extern fn zphp_udat_format(f: *const UDateFormat, date: f64, result: [*]UChar, resultLen: i32, pos: ?*anyopaque, err: *UErrorCode) i32;
 extern fn zphp_udat_parse(f: *const UDateFormat, text: [*]const UChar, textLen: i32, parsePos: ?*i32, err: *UErrorCode) f64;
 extern fn zphp_udat_applyPattern(f: *UDateFormat, localized: u8, pattern: [*]const UChar, patternLen: i32) void;
@@ -133,6 +137,7 @@ extern fn zphp_ucal_setLenient(cal: *UCalendar, lenient: i32) void;
 const ZphpBrk = opaque {};
 extern fn zphp_ubrk_open(brk_type: c_int, locale: [*:0]const u8, err: *UErrorCode) ?*ZphpBrk;
 extern fn zphp_ubrk_close(w: *ZphpBrk) void;
+extern fn zphp_ubrk_clone(w: *const ZphpBrk, err: *UErrorCode) ?*ZphpBrk;
 extern fn zphp_ubrk_setText(w: *ZphpBrk, text: [*]const u8, len: i32, err: *UErrorCode) void;
 extern fn zphp_ubrk_getText(w: *ZphpBrk, len: *i32) [*:0]const u8;
 extern fn zphp_ubrk_first(w: *ZphpBrk) i32;
@@ -180,6 +185,32 @@ fn getThis(ctx: *NativeContext) ?*PhpObject {
     if (v != .object) return null;
     return v.object;
 }
+
+fn handle(kind: NativeHandle.Kind, ptr: anytype) NativeHandle {
+    return .{ .kind = kind, .ptr = @intFromPtr(ptr) };
+}
+
+fn cloneHook(comptime T: type, comptime kind: NativeHandle.Kind, comptime dupFn: anytype, comptime closeFn: anytype) fn (*VM, *PhpObject, *PhpObject) bool {
+    return struct {
+        fn hook(_: *VM, src: *PhpObject, copy: *PhpObject) bool {
+            const p = src.native.get(T, kind) orelse return false;
+            var status: UErrorCode = U_ZERO_ERROR;
+            const dup = dupFn(p, &status);
+            if (status > U_ZERO_ERROR) {
+                if (dup) |d| closeFn(d);
+                return false;
+            }
+            copy.native = handle(kind, dup orelse return false);
+            return true;
+        }
+    }.hook;
+}
+
+const cloneNumFmt = cloneHook(UNumberFormat, .number_formatter, zphp_unum_clone, zphp_unum_close);
+const cloneTranslit = cloneHook(UTransliterator, .transliterator, zphp_utrans_clone, zphp_utrans_close);
+const cloneDateFmt = cloneHook(UDateFormat, .date_formatter, zphp_udat_clone, zphp_udat_close);
+const cloneCal = cloneHook(UCalendar, .calendar, zphp_ucal_clone, zphp_ucal_close);
+const cloneBrk = cloneHook(ZphpBrk, .break_iterator, zphp_ubrk_clone, zphp_ubrk_close);
 
 // utf-8 → utf-16. shrinks to actual length so caller can free the returned slice
 fn utf8ToU16(ctx: *NativeContext, s: []const u8) ![]u16 {
@@ -350,9 +381,7 @@ fn localeGetDisplayScript(ctx: *NativeContext, args: []const Value) RuntimeError
 // ---------------- Collator ----------------
 
 fn getCollator(obj: *const PhpObject) ?*UCollator {
-    const v = obj.get("__coll");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(UCollator, .collator);
 }
 
 fn openCollatorFor(ctx: *NativeContext, locale: []const u8) !?*UCollator {
@@ -367,7 +396,7 @@ fn collConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRe
     if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
     const c = (try openCollatorFor(ctx, args[0].string.bytes())) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__coll", .{ .int = @intCast(@intFromPtr(c)) });
+    obj.native = handle(.collator, c);
     try obj.set(ctx.allocator, "__locale", .{ .string = args[0].string });
     return NativeResult.scalar(.null);
 }
@@ -376,7 +405,7 @@ fn collCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!Nativ
     if (args.len < 1 or args[0] != .string) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("Collator");
     const c = (try openCollatorFor(ctx, args[0].string.bytes())) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__coll", .{ .int = @intCast(@intFromPtr(c)) });
+    obj.native = handle(.collator, c);
     try obj.set(ctx.allocator, "__locale", .{ .string = args[0].string });
     return NativeResult.borrowed(.{ .object = obj });
 }
@@ -445,9 +474,7 @@ fn collSort(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult 
 // ---------------- NumberFormatter ----------------
 
 fn getNumFmt(obj: *const PhpObject) ?*UNumberFormat {
-    const v = obj.get("__nfmt");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(UNumberFormat, .number_formatter);
 }
 
 fn openNumFmt(ctx: *NativeContext, locale: []const u8, style: i32, pattern: ?[]const u8) !?*UNumberFormat {
@@ -476,7 +503,7 @@ fn nfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResu
     const style: i32 = if (args[1] == .int) @intCast(args[1].int) else 1;
     const pattern: ?[]const u8 = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else null;
     const f = (try openNumFmt(ctx, args[0].string.bytes(), style, pattern)) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__nfmt", .{ .int = @intCast(@intFromPtr(f)) });
+    obj.native = handle(.number_formatter, f);
     return NativeResult.scalar(.null);
 }
 
@@ -486,7 +513,7 @@ fn nfCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!NativeR
     const style: i32 = if (args[1] == .int) @intCast(args[1].int) else 1;
     const pattern: ?[]const u8 = if (args.len >= 3 and args[2] == .string) args[2].string.bytes() else null;
     const f = (try openNumFmt(ctx, args[0].string.bytes(), style, pattern)) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__nfmt", .{ .int = @intCast(@intFromPtr(f)) });
+    obj.native = handle(.number_formatter, f);
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -565,9 +592,7 @@ fn nfGetAttribute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeR
 // ---------------- Transliterator ----------------
 
 fn getTranslit(obj: *const PhpObject) ?*UTransliterator {
-    const v = obj.get("__trans");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(UTransliterator, .transliterator);
 }
 
 fn transCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
@@ -579,7 +604,7 @@ fn transCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!Nati
     const t = zphp_utrans_openU(id_u16.ptr, @intCast(id_u16.len), dir, null, 0, null, &status);
     if (status > U_ZERO_ERROR or t == null) return NativeResult.scalar(.null);
     const obj = try ctx.createObject("Transliterator");
-    try obj.set(ctx.allocator, "__trans", .{ .int = @intCast(@intFromPtr(t.?)) });
+    obj.native = handle(.transliterator, t.?);
     try obj.set(ctx.allocator, "id", .{ .string = args[0].string });
     return NativeResult.borrowed(.{ .object = obj });
 }
@@ -607,9 +632,7 @@ fn transTransliterate(ctx: *NativeContext, args: []const Value) RuntimeError!Nat
 // ---------------- IntlDateFormatter ----------------
 
 fn getDateFmt(obj: *const PhpObject) ?*UDateFormat {
-    const v = obj.get("__dfmt");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(UDateFormat, .date_formatter);
 }
 
 fn openDateFmt(ctx: *NativeContext, locale: []const u8, date_style: i32, time_style: i32, tz: ?[]const u8, pattern: ?[]const u8) !?*UDateFormat {
@@ -649,7 +672,7 @@ fn dfConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResu
     const pat_opt: ?[]const u8 = if (args.len > 5 and args[5] == .string and args[5].string.bytes().len > 0) args[5].string.bytes() else null;
 
     const f = (try openDateFmt(ctx, args[0].string.bytes(), date_style, time_style, tz_opt, pat_opt)) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__dfmt", .{ .int = @intCast(@intFromPtr(f)) });
+    obj.native = handle(.date_formatter, f);
     return NativeResult.scalar(.null);
 }
 
@@ -661,7 +684,7 @@ fn dfCreateStatic(ctx: *NativeContext, args: []const Value) RuntimeError!NativeR
     const tz_opt: ?[]const u8 = if (args.len > 3 and args[3] == .string and args[3].string.bytes().len > 0) args[3].string.bytes() else defaultTzName(ctx);
     const pat_opt: ?[]const u8 = if (args.len > 5 and args[5] == .string and args[5].string.bytes().len > 0) args[5].string.bytes() else null;
     const f = (try openDateFmt(ctx, args[0].string.bytes(), date_style, time_style, tz_opt, pat_opt)) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__dfmt", .{ .int = @intCast(@intFromPtr(f)) });
+    obj.native = handle(.date_formatter, f);
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -890,9 +913,7 @@ fn mfGetLocale(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult 
 // ---------------- IntlCalendar ----------------
 
 fn getCal(obj: *const PhpObject) ?*UCalendar {
-    const v = obj.get("__cal");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(UCalendar, .calendar);
 }
 
 fn openCalendar(ctx: *NativeContext, tz_opt: ?[]const u8, locale: []const u8, cal_type: c_int) !?*UCalendar {
@@ -918,7 +939,7 @@ fn calCreateInstance(ctx: *NativeContext, args: []const Value) RuntimeError!Nati
     }
     const cal = (try openCalendar(ctx, tz_opt, locale, 0)) orelse return NativeResult.scalar(.null);
     const obj = try ctx.createObject("IntlGregorianCalendar");
-    try obj.set(ctx.allocator, "__cal", .{ .int = @intCast(@intFromPtr(cal)) });
+    obj.native = handle(.calendar, cal);
     try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, locale)) });
     return NativeResult.borrowed(.{ .object = obj });
 }
@@ -942,7 +963,7 @@ fn calConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRes
             locale = def[0..cstrLen(def)];
         }
         const cal = (try openCalendar(ctx, tz_opt, locale, 0)) orelse return NativeResult.scalar(.null);
-        try obj.set(ctx.allocator, "__cal", .{ .int = @intCast(@intFromPtr(cal)) });
+        obj.native = handle(.calendar, cal);
         try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, locale)) });
         return NativeResult.scalar(.null);
     }
@@ -951,7 +972,7 @@ fn calConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRes
     const def_locale_ptr = zphp_uloc_getDefault();
     const def_locale = def_locale_ptr[0..cstrLen(def_locale_ptr)];
     const cal = (try openCalendar(ctx, null, def_locale, 0)) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__cal", .{ .int = @intCast(@intFromPtr(cal)) });
+    obj.native = handle(.calendar, cal);
     try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, def_locale)) });
     if (args.len >= 3 and args[0] == .int and args[1] == .int and args[2] == .int) {
         var status: UErrorCode = U_ZERO_ERROR;
@@ -1192,9 +1213,7 @@ fn calEquals(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult
 // ---------------- IntlBreakIterator ----------------
 
 fn getBrk(obj: *const PhpObject) ?*ZphpBrk {
-    const v = obj.get("__brk");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(ZphpBrk, .break_iterator);
 }
 
 fn openBrk(ctx: *NativeContext, brk_type: c_int, locale: []const u8) !?*ZphpBrk {
@@ -1212,7 +1231,7 @@ fn openBrk(ctx: *NativeContext, brk_type: c_int, locale: []const u8) !?*ZphpBrk 
 fn brkMakeInstance(ctx: *NativeContext, brk_type: c_int, locale: []const u8) RuntimeError!NativeResult {
     const w = (try openBrk(ctx, brk_type, locale)) orelse return NativeResult.scalar(.null);
     const obj = try ctx.createObject("IntlBreakIterator");
-    try obj.set(ctx.allocator, "__brk", .{ .int = @intCast(@intFromPtr(w)) });
+    obj.native = handle(.break_iterator, w);
     try obj.set(ctx.allocator, "__type", .{ .int = @intCast(brk_type) });
     try obj.set(ctx.allocator, "__locale", .{ .string = Value.String.borrowed(try dupString(ctx, locale)) });
     return NativeResult.borrowed(.{ .object = obj });
@@ -2003,7 +2022,7 @@ fn intlCharToupper(_: *NativeContext, args: []const Value) RuntimeError!NativeRe
 
 fn registerBreakIteratorClass(vm: *VM, a: Allocator) !void {
     inline for (.{ "IntlBreakIterator", "IntlRuleBasedBreakIterator", "IntlCodePointBreakIterator" }) |cls_name| {
-        var def = ClassDef{ .name = cls_name };
+        var def = ClassDef{ .name = cls_name, .native_clone = cloneBrk };
         if (comptime !std.mem.eql(u8, cls_name, "IntlBreakIterator")) {
             def.parent = "IntlBreakIterator";
         }
@@ -2070,7 +2089,7 @@ fn registerBreakIteratorClass(vm: *VM, a: Allocator) !void {
 
 fn registerIntlCalendarClass(vm: *VM, a: Allocator) !void {
     inline for (.{ "IntlCalendar", "IntlGregorianCalendar" }) |cls_name| {
-        var def = ClassDef{ .name = cls_name };
+        var def = ClassDef{ .name = cls_name, .native_clone = cloneCal };
         if (comptime std.mem.eql(u8, cls_name, "IntlGregorianCalendar")) {
             def.parent = "IntlCalendar";
         }
@@ -2176,12 +2195,12 @@ fn registerMessageFormatterClass(vm: *VM, a: Allocator) !void {
 
 fn cleanupDateFormatter(obj: *PhpObject) bool {
     if (getDateFmt(obj)) |f| zphp_udat_close(f);
-    if (obj.properties.getPtr("__dfmt")) |slot| slot.* = .{ .int = 0 };
+    obj.native.ptr = 0;
     return true;
 }
 
 fn registerDateFormatterClass(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "IntlDateFormatter", .native_cleanup = cleanupDateFormatter };
+    var def = ClassDef{ .name = "IntlDateFormatter", .native_cleanup = cleanupDateFormatter, .native_clone = cloneDateFmt };
     try def.methods.put(a, "__construct", .{ .name = "__construct", .arity = 3 });
     try def.methods.put(a, "create", .{ .name = "create", .arity = 3, .is_static = true });
     try def.methods.put(a, "format", .{ .name = "format", .arity = 1 });
@@ -2426,7 +2445,7 @@ fn registerCollatorClass(vm: *VM, a: Allocator) !void {
 }
 
 fn registerNumberFormatterClass(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "NumberFormatter" };
+    var def = ClassDef{ .name = "NumberFormatter", .native_clone = cloneNumFmt };
     try def.methods.put(a, "__construct", .{ .name = "__construct", .arity = 2 });
     try def.methods.put(a, "create", .{ .name = "create", .arity = 2, .is_static = true });
     try def.methods.put(a, "format", .{ .name = "format", .arity = 1 });
@@ -2468,7 +2487,7 @@ fn registerNumberFormatterClass(vm: *VM, a: Allocator) !void {
 }
 
 fn registerTransliteratorClass(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "Transliterator" };
+    var def = ClassDef{ .name = "Transliterator", .native_clone = cloneTranslit };
     try def.methods.put(a, "create", .{ .name = "create", .arity = 1, .is_static = true });
     try def.methods.put(a, "transliterate", .{ .name = "transliterate", .arity = 1 });
     try def.constant_order.append(a, "FORWARD");
@@ -2543,21 +2562,14 @@ fn registerConstants(vm: *VM, a: Allocator) !void {
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
         if (obj.pooled) continue;
-        if (std.mem.eql(u8, obj.class_name, "Collator")) {
-            if (getCollator(obj)) |c| zphp_ucol_close(c);
-        } else if (std.mem.eql(u8, obj.class_name, "NumberFormatter")) {
-            if (getNumFmt(obj)) |f| zphp_unum_close(f);
-        } else if (std.mem.eql(u8, obj.class_name, "Transliterator")) {
-            if (getTranslit(obj)) |t| zphp_utrans_close(t);
-        } else if (std.mem.eql(u8, obj.class_name, "IntlDateFormatter")) {
-            _ = cleanupDateFormatter(obj);
-        } else if (std.mem.eql(u8, obj.class_name, "IntlCalendar") or std.mem.eql(u8, obj.class_name, "IntlGregorianCalendar")) {
-            if (getCal(obj)) |c| zphp_ucal_close(c);
-        } else if (std.mem.eql(u8, obj.class_name, "IntlBreakIterator") or
-            std.mem.eql(u8, obj.class_name, "IntlRuleBasedBreakIterator") or
-            std.mem.eql(u8, obj.class_name, "IntlCodePointBreakIterator"))
-        {
-            if (getBrk(obj)) |w| zphp_ubrk_close(w);
+        switch (obj.native.kind) {
+            .collator => if (getCollator(obj)) |c| zphp_ucol_close(c),
+            .number_formatter => if (getNumFmt(obj)) |f| zphp_unum_close(f),
+            .transliterator => if (getTranslit(obj)) |t| zphp_utrans_close(t),
+            .date_formatter => _ = cleanupDateFormatter(obj),
+            .calendar => if (getCal(obj)) |c| zphp_ucal_close(c),
+            .break_iterator => if (getBrk(obj)) |w| zphp_ubrk_close(w),
+            else => {},
         }
     }
 }

--- a/src/stdlib/ldap.zig
+++ b/src/stdlib/ldap.zig
@@ -2,6 +2,7 @@ const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
@@ -44,9 +45,7 @@ pub const entries = .{
 };
 
 fn getLdap(obj: *PhpObject) ?*c.LDAP {
-    const v = obj.get("__ptr");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.LDAP, .ldap);
 }
 
 fn getHandle(args: []const Value, expect: []const u8) ?*PhpObject {
@@ -57,9 +56,7 @@ fn getHandle(args: []const Value, expect: []const u8) ?*PhpObject {
 }
 
 fn getResult(obj: *PhpObject) ?*c.LDAPMessage {
-    const v = obj.get("__ptr");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.LDAPMessage, .ldap_result);
 }
 
 fn cstrToOwned(ctx: *NativeContext, p: ?[*:0]const u8) RuntimeError!NativeResult {
@@ -93,7 +90,7 @@ fn native_connect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeR
     _ = c.ldap_set_option(ldap_ptr, c.LDAP_OPT_PROTOCOL_VERSION, &version);
 
     const obj = try ctx.createObject("LDAP\\Connection");
-    try obj.set(ctx.allocator, "__ptr", .{ .int = @intCast(@intFromPtr(ldap_ptr)) });
+    obj.native = .{ .kind = .ldap, .ptr = NativeHandle.addr(ldap_ptr) };
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -120,7 +117,7 @@ fn native_unbind(_: *NativeContext, args: []const Value) RuntimeError!NativeResu
     const o = getHandle(args, "LDAP\\Connection") orelse return NativeResult.scalar(.{ .bool = false });
     const ld = getLdap(o) orelse return NativeResult.scalar(.{ .bool = true });
     _ = c.ldap_unbind_ext_s(ld, null, null);
-    o.set(std.heap.page_allocator, "__ptr", .{ .int = 0 }) catch {};
+    o.native.ptr = 0;
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -159,8 +156,7 @@ fn doSearch(ctx: *NativeContext, args: []const Value, scope: c_int) RuntimeError
         return NativeResult.scalar(.{ .bool = false });
     }
     const obj = try ctx.createObject("LDAP\\Result");
-    try obj.set(ctx.allocator, "__ptr", .{ .int = @intCast(@intFromPtr(result)) });
-    try obj.set(ctx.allocator, "__ld", .{ .int = @intCast(@intFromPtr(ld)) });
+    obj.native = .{ .kind = .ldap_result, .ptr = NativeHandle.addr(result), .aux = @intFromPtr(ld) };
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -482,7 +478,7 @@ fn native_free_result(_: *NativeContext, args: []const Value) RuntimeError!Nativ
     if (!std.mem.eql(u8, o.class_name, "LDAP\\Result")) return NativeResult.scalar(.{ .bool = false });
     const r = getResult(o) orelse return NativeResult.scalar(.{ .bool = true });
     _ = c.ldap_msgfree(r);
-    o.set(std.heap.page_allocator, "__ptr", .{ .int = 0 }) catch {};
+    o.native.ptr = 0;
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -522,19 +518,8 @@ fn native_count_references(_: *NativeContext, _: []const Value) RuntimeError!Nat
 
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
-        if (std.mem.eql(u8, obj.class_name, "LDAP\\Connection")) {
-            const v = obj.get("__ptr");
-            if (v == .int and v.int != 0) {
-                const ld: *c.LDAP = @ptrFromInt(@as(usize, @intCast(v.int)));
-                _ = c.ldap_unbind_ext_s(ld, null, null);
-            }
-        } else if (std.mem.eql(u8, obj.class_name, "LDAP\\Result")) {
-            const v = obj.get("__ptr");
-            if (v == .int and v.int != 0) {
-                const r: *c.LDAPMessage = @ptrFromInt(@as(usize, @intCast(v.int)));
-                _ = c.ldap_msgfree(r);
-            }
-        }
+        if (getLdap(obj)) |ld| _ = c.ldap_unbind_ext_s(ld, null, null);
+        if (getResult(obj)) |r| _ = c.ldap_msgfree(r);
     }
 }
 

--- a/src/stdlib/mysqli.zig
+++ b/src/stdlib/mysqli.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const vm_mod = @import("../runtime/vm.zig");
 const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
@@ -69,15 +70,15 @@ fn fieldName(field: *mysql.MYSQL_FIELD) [*:0]const u8 {
 }
 
 fn getConn(obj: *PhpObject) ?*mysql.MYSQL {
-    const v = obj.get("__conn");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(mysql.MYSQL, .mysqli);
 }
 
 fn getRes(obj: *PhpObject) ?*mysql.MYSQL_RES {
-    const v = obj.get("__res");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(mysql.MYSQL_RES, .mysqli_result);
+}
+
+fn setConn(obj: *PhpObject, conn: ?*mysql.MYSQL) void {
+    obj.native = .{ .kind = .mysqli, .ptr = NativeHandle.addr(conn) };
 }
 
 // returns the mysqli object regardless of whether the user passed a
@@ -114,11 +115,7 @@ fn setErrorState(ctx: *NativeContext, obj: *PhpObject, conn: ?*mysql.MYSQL) !voi
 
 fn mysqliInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = try ctx.createObject("mysqli");
-    if (mysql.mysql_init(null)) |c| {
-        try obj.set(ctx.allocator, "__conn", .{ .int = @intCast(@intFromPtr(c)) });
-    } else {
-        try obj.set(ctx.allocator, "__conn", .{ .int = 0 });
-    }
+    setConn(obj, mysql.mysql_init(null));
     try obj.set(ctx.allocator, "error", .{ .string = Value.String.borrowed("") });
     try obj.set(ctx.allocator, "errno", .{ .int = 0 });
     try obj.set(ctx.allocator, "__connected", .{ .bool = false });
@@ -129,7 +126,7 @@ fn mysqliInit(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
 fn doConnect(ctx: *NativeContext, obj: *PhpObject, host: ?[]const u8, user: ?[]const u8, pass: ?[]const u8, db: ?[]const u8, port: u32, socket: ?[]const u8) !bool {
     const conn = getConn(obj) orelse blk: {
         const c = mysql.mysql_init(null) orelse return false;
-        try obj.set(ctx.allocator, "__conn", .{ .int = @intCast(@intFromPtr(c)) });
+        setConn(obj, c);
         break :blk c;
     };
 
@@ -219,7 +216,7 @@ fn mysqliClose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResu
         // mysql_close is safe to call on a handle returned by mysql_init even
         // when never connected — releases the allocated handle either way
         mysql.mysql_close(c);
-        try link.set(ctx.allocator, "__conn", .{ .int = 0 });
+        link.native.ptr = 0;
         try link.set(ctx.allocator, "__connected", .{ .bool = false });
     }
     return NativeResult.scalar(.{ .bool = true });
@@ -275,7 +272,7 @@ fn mysqliQuery(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResu
     const res = res_opt orelse return NativeResult.scalar(.{ .bool = true });
 
     const result_obj = try ctx.createObject("mysqli_result");
-    try result_obj.set(ctx.allocator, "__res", .{ .int = @intCast(@intFromPtr(res)) });
+    result_obj.native = .{ .kind = .mysqli_result, .ptr = @intFromPtr(res) };
     try result_obj.set(ctx.allocator, "num_rows", .{ .int = @intCast(mysql.mysql_num_rows(res)) });
     const nf: i64 = @intCast(mysql.mysql_num_fields(res));
     try result_obj.set(ctx.allocator, "num_fields", .{ .int = nf });
@@ -555,7 +552,7 @@ fn mysqliFreeResult(ctx: *NativeContext, args: []const Value) RuntimeError!Nativ
     const result_obj = linkObj(ctx, args, 0) orelse return NativeResult.scalar(.null);
     if (getRes(result_obj)) |r| {
         mysql.mysql_free_result(r);
-        try result_obj.set(ctx.allocator, "__res", .{ .int = 0 });
+        result_obj.native.ptr = 0;
     }
     return NativeResult.scalar(.null);
 }
@@ -643,7 +640,7 @@ fn mysqliConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!Native
     try obj.set(ctx.allocator, "__connected", .{ .bool = false });
 
     const c = mysql.mysql_init(null) orelse return NativeResult.scalar(.null);
-    try obj.set(ctx.allocator, "__conn", .{ .int = @intCast(@intFromPtr(c)) });
+    setConn(obj, c);
 
     // when called with no args, leave the handle uninitialized (mirrors mysqli_init)
     if (args.len == 0) return NativeResult.scalar(.null);
@@ -772,13 +769,9 @@ pub fn register(vm: *VM, a: Allocator) !void {
 
 pub fn cleanupConnections(objects: std.ArrayListUnmanaged(*PhpObject)) void {
     for (objects.items) |obj| {
-        if (std.mem.eql(u8, obj.class_name, "mysqli_result")) {
-            if (getRes(obj)) |r| mysql.mysql_free_result(r);
-        }
+        if (getRes(obj)) |r| mysql.mysql_free_result(r);
     }
     for (objects.items) |obj| {
-        if (std.mem.eql(u8, obj.class_name, "mysqli")) {
-            if (getConn(obj)) |c| mysql.mysql_close(c);
-        }
+        if (getConn(obj)) |c| mysql.mysql_close(c);
     }
 }

--- a/src/stdlib/pdo.zig
+++ b/src/stdlib/pdo.zig
@@ -202,12 +202,6 @@ fn sqliteCollationTrampoline(p: ?*anyopaque, alen: c_int, aptr: ?*const anyopaqu
     };
 }
 
-pub fn getOpaquePtr(comptime T: type, obj: *PhpObject, prop: []const u8) ?*T {
-    const v = obj.get(prop);
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
-}
-
 fn getThis(ctx: *NativeContext) ?*PhpObject {
     const v = ctx.vm.currentFrame().vars.get("$this") orelse return null;
     if (v != .object) return null;
@@ -215,11 +209,19 @@ fn getThis(ctx: *NativeContext) ?*PhpObject {
 }
 
 fn getDbPtr(obj: *PhpObject) ?*sqlite.Db {
-    return getOpaquePtr(sqlite.Db, obj, "__db_ptr");
+    return obj.native.get(sqlite.Db, .pdo_sqlite) orelse obj.native.getAux(sqlite.Db, .pdo_sqlite_stmt);
 }
 
 fn getStmtPtr(obj: *PhpObject) ?*sqlite.Stmt {
-    return getOpaquePtr(sqlite.Stmt, obj, "__stmt_ptr");
+    return obj.native.get(sqlite.Stmt, .pdo_sqlite_stmt);
+}
+
+fn attachDb(obj: *PhpObject, db: *sqlite.Db) void {
+    obj.native = .{ .kind = .pdo_sqlite, .ptr = @intFromPtr(db) };
+}
+
+fn attachStmt(obj: *PhpObject, stmt: *sqlite.Stmt, db: *sqlite.Db) void {
+    obj.native = .{ .kind = .pdo_sqlite_stmt, .ptr = @intFromPtr(stmt), .aux = @intFromPtr(db) };
 }
 
 // SQLite callbacks cannot unwind through C. Re-throw their pending PHP
@@ -530,63 +532,54 @@ fn stmtFetchObject(ctx: *NativeContext, args: []const Value) RuntimeError!Native
 }
 
 fn cleanupStatement(obj: *PhpObject) bool {
-    const drv = getDriver(obj);
-    if (std.mem.eql(u8, drv, "mysql")) {
-        pdo_mysql.cleanupStatement(obj);
-    } else if (std.mem.eql(u8, drv, "pgsql")) {
-        pdo_pgsql.cleanupStatement(obj);
-    } else if (getStmtPtr(obj)) |stmt| {
-        _ = sqlite.sqlite3_finalize(stmt);
+    switch (obj.native.kind) {
+        .pdo_mysql_stmt => pdo_mysql.cleanupStatement(obj),
+        .pdo_pgsql_stmt => pdo_pgsql.cleanupStatement(obj),
+        else => if (getStmtPtr(obj)) |stmt| {
+            _ = sqlite.sqlite3_finalize(stmt);
+            obj.native.ptr = 0;
+        },
     }
-    if (obj.properties.getPtr("__stmt_ptr")) |slot| slot.* = .{ .int = 0 };
     return true;
 }
 
 fn cleanupConnection(obj: *PhpObject) bool {
-    const drv = getDriver(obj);
-    if (std.mem.eql(u8, drv, "mysql")) {
-        pdo_mysql.cleanupConnection(obj);
-    } else if (std.mem.eql(u8, drv, "pgsql")) {
-        pdo_pgsql.cleanupConnection(obj);
-    } else if (getDbPtr(obj)) |db| {
-        // v2 defers destruction until outstanding statements are finalized;
-        // sqlite3_close would return BUSY and leak the connection/registrations.
-        _ = sqlite.sqlite3_close_v2(db);
+    switch (obj.native.kind) {
+        .pdo_mysql => pdo_mysql.cleanupConnection(obj),
+        .pdo_pgsql => pdo_pgsql.cleanupConnection(obj),
+        else => if (getDbPtr(obj)) |db| {
+            // v2 defers destruction until outstanding statements are finalized;
+            // sqlite3_close would return BUSY and leak the connection/registrations.
+            _ = sqlite.sqlite3_close_v2(db);
+            obj.native.ptr = 0;
+        },
     }
-    if (obj.properties.getPtr("__db_ptr")) |slot| slot.* = .{ .int = 0 };
     return true;
 }
 
+fn isStatementKind(obj: *PhpObject) bool {
+    return switch (obj.native.kind) {
+        .pdo_sqlite_stmt, .pdo_mysql_stmt, .pdo_pgsql_stmt => true,
+        else => false,
+    };
+}
+
+fn isConnectionKind(obj: *PhpObject) bool {
+    return switch (obj.native.kind) {
+        .pdo_sqlite, .pdo_mysql, .pdo_pgsql => true,
+        else => false,
+    };
+}
+
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
-    // finalize statements first, then close databases. the obj is being torn down
-    // right after this so we don't need to clear the pointer fields in the
-    // property map (which would require the VM allocator to grow the bucket).
+    // finalize statements first, then close databases
     for (objects.items) |obj| {
         if (obj.pooled) continue;
-        if (std.mem.eql(u8, obj.class_name, "PDOStatement")) {
-            const drv = getDriver(obj);
-            if (std.mem.eql(u8, drv, "mysql")) {
-                pdo_mysql.cleanupStatement(obj);
-            } else if (std.mem.eql(u8, drv, "pgsql")) {
-                pdo_pgsql.cleanupStatement(obj);
-            } else {
-                if (getStmtPtr(obj)) |stmt| _ = sqlite.sqlite3_finalize(stmt);
-            }
-        }
+        if (isStatementKind(obj)) _ = cleanupStatement(obj);
     }
     for (objects.items) |obj| {
         if (obj.pooled) continue;
-        // PDO base class plus the PHP 8.4 driver subclasses live under PDO\
-        if (std.mem.eql(u8, obj.class_name, "PDO") or (obj.class_name.len >= 4 and std.ascii.eqlIgnoreCase(obj.class_name[0..4], "PDO\\"))) {
-            const drv = getDriver(obj);
-            if (std.mem.eql(u8, drv, "mysql")) {
-                pdo_mysql.cleanupConnection(obj);
-            } else if (std.mem.eql(u8, drv, "pgsql")) {
-                pdo_pgsql.cleanupConnection(obj);
-            } else {
-                if (getDbPtr(obj)) |db| _ = sqlite.sqlite3_close_v2(db);
-            }
-        }
+        if (isConnectionKind(obj)) _ = cleanupConnection(obj);
     }
 }
 
@@ -596,9 +589,11 @@ const pdo_mysql = @import("pdo_mysql.zig");
 const pdo_pgsql = @import("pdo_pgsql.zig");
 
 fn getDriver(obj: *PhpObject) []const u8 {
-    const v = obj.get("__driver");
-    if (v == .string) return v.string.bytes();
-    return "sqlite";
+    return switch (obj.native.kind) {
+        .pdo_mysql, .pdo_mysql_stmt => "mysql",
+        .pdo_pgsql, .pdo_pgsql_stmt => "pgsql",
+        else => "sqlite",
+    };
 }
 
 fn pdoConnect(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
@@ -830,14 +825,12 @@ fn pdoConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRes
     const driver = dsn[0..colon];
     const rest = dsn[colon + 1 ..];
 
-    try obj.set(ctx.allocator, "__driver", .{ .string = Value.String.borrowed(try ctx.createString(driver)) });
-
     if (std.mem.eql(u8, driver, "sqlite")) {
         const path_z = try dupeZ(ctx, rest);
         var db: ?*sqlite.Db = null;
         const rc = sqlite.sqlite3_open(path_z, &db);
         if (rc != sqlite.OK or db == null) return throwPdo(ctx, "Failed to open database");
-        try obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(db.?)) });
+        attachDb(obj, db.?);
         try applyOptionsArray(ctx, obj, args);
         return NativeResult.scalar(.null);
     }
@@ -908,8 +901,7 @@ fn pdoQuery(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult 
     }
 
     const stmt_obj = try ctx.createObject("PDOStatement");
-    try stmt_obj.set(ctx.allocator, "__stmt_ptr", .{ .int = @intCast(@intFromPtr(stmt_ptr.?)) });
-    try stmt_obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(db)) });
+    attachStmt(stmt_obj, stmt_ptr.?, db);
     try stmt_obj.set(ctx.allocator, "__pdo", .{ .object = obj });
     // step once to position on first row
     const step_rc = try stepSqlite(ctx, stmt_ptr.?);
@@ -938,8 +930,7 @@ fn pdoPrepare(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResul
     }
 
     const stmt_obj = try ctx.createObject("PDOStatement");
-    try stmt_obj.set(ctx.allocator, "__stmt_ptr", .{ .int = @intCast(@intFromPtr(stmt_ptr.?)) });
-    try stmt_obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(db)) });
+    attachStmt(stmt_obj, stmt_ptr.?, db);
     try stmt_obj.set(ctx.allocator, "__pdo", .{ .object = obj });
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = false });
@@ -1086,19 +1077,14 @@ fn stmtExecute(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResu
     try obj.set(ctx.allocator, "__stepped", .{ .bool = true });
 
     if (rc != sqlite.ROW and rc != sqlite.DONE) {
-        const db_val = obj.get("__db_ptr");
-        if (db_val == .int and db_val.int != 0) {
-            const db: *sqlite.Db = @ptrFromInt(@as(usize, @intCast(db_val.int)));
+        if (getDbPtr(obj)) |db| {
             const msg = std.mem.span(sqlite.sqlite3_errmsg(db));
             return throwPdo(ctx, try pdoSqlMsg(ctx, db, msg));
         }
         return NativeResult.scalar(.{ .bool = false });
     }
 
-    // store affected rows
-    const db_val = obj.get("__db_ptr");
-    if (db_val == .int and db_val.int != 0) {
-        const db: *sqlite.Db = @ptrFromInt(@as(usize, @intCast(db_val.int)));
+    if (getDbPtr(obj)) |db| {
         try obj.set(ctx.allocator, "__row_count", .{ .int = sqlite.sqlite3_changes(db) });
     }
 

--- a/src/stdlib/pdo_mysql.zig
+++ b/src/stdlib/pdo_mysql.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 const pdo = @import("pdo.zig");
@@ -42,11 +43,23 @@ fn fieldName(field: *mysql.MYSQL_FIELD) [*:0]const u8 {
 }
 
 fn getConn(obj: *PhpObject) ?*mysql.MYSQL {
-    return pdo.getOpaquePtr(mysql.MYSQL, obj, "__db_ptr");
+    return obj.native.get(mysql.MYSQL, .pdo_mysql) orelse obj.native.getAux(mysql.MYSQL, .pdo_mysql_stmt);
 }
 
 fn getRes(obj: *PhpObject) ?*mysql.MYSQL_RES {
-    return pdo.getOpaquePtr(mysql.MYSQL_RES, obj, "__res_ptr");
+    return obj.native.get(mysql.MYSQL_RES, .pdo_mysql_stmt);
+}
+
+fn attachConn(obj: *PhpObject, conn: *mysql.MYSQL) void {
+    obj.native = .{ .kind = .pdo_mysql, .ptr = @intFromPtr(conn) };
+}
+
+fn attachStmt(obj: *PhpObject, conn: *mysql.MYSQL, res: ?*mysql.MYSQL_RES) void {
+    obj.native = .{ .kind = .pdo_mysql_stmt, .ptr = NativeHandle.addr(res), .aux = @intFromPtr(conn) };
+}
+
+fn setRes(obj: *PhpObject, res: ?*mysql.MYSQL_RES) void {
+    obj.native.ptr = NativeHandle.addr(res);
 }
 
 fn parseDsnParams(rest: []const u8) struct { host: ?[]const u8, port: u16, dbname: ?[]const u8, unix_socket: ?[]const u8 } {
@@ -83,12 +96,12 @@ pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []c
     const sock_z: ?[*:0]const u8 = if (params.unix_socket) |s| (try pdo.dupeZ(ctx, s)).ptr else null;
 
     if (mysql.mysql_real_connect(conn, host_z, user_z, pass_z, db_z, params.port, sock_z, 0) == null) {
-        const msg = std.mem.span(mysql.mysql_error(conn));
+        const msg = try ctx.createString(std.mem.span(mysql.mysql_error(conn)));
         mysql.mysql_close(conn);
         return pdo.throwPdo(ctx, msg);
     }
 
-    try obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
+    attachConn(obj, conn);
     return NativeResult.scalar(.null);
 }
 
@@ -110,9 +123,7 @@ pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError
     const res = mysql.mysql_store_result(conn) orelse return pdo.throwPdo(ctx, std.mem.span(mysql.mysql_error(conn)));
 
     const stmt_obj = try ctx.createObject("PDOStatement");
-    try stmt_obj.set(ctx.allocator, "__driver", .{ .string = Value.String.borrowed("mysql") });
-    try stmt_obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
-    try stmt_obj.set(ctx.allocator, "__res_ptr", .{ .int = @intCast(@intFromPtr(res)) });
+    attachStmt(stmt_obj, conn, res);
     try stmt_obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = true });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = true });
@@ -149,9 +160,7 @@ pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeErr
     }
 
     const stmt_obj = try ctx.createObject("PDOStatement");
-    try stmt_obj.set(ctx.allocator, "__driver", .{ .string = Value.String.borrowed("mysql") });
-    try stmt_obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
-    try stmt_obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
+    attachStmt(stmt_obj, conn, null);
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = false });
 
@@ -187,7 +196,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
     // free previous result if any
     if (getRes(obj)) |old_res| {
         mysql.mysql_free_result(old_res);
-        try obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
+        setRes(obj, null);
     }
 
     if (mysql.mysql_real_query(conn, sql.ptr, @intCast(sql.len)) != 0) {
@@ -195,7 +204,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
     }
 
     if (mysql.mysql_store_result(conn)) |res| {
-        try obj.set(ctx.allocator, "__res_ptr", .{ .int = @intCast(@intFromPtr(res)) });
+        setRes(obj, res);
         try obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
         try obj.set(ctx.allocator, "__has_row", .{ .bool = true });
     } else {
@@ -360,7 +369,7 @@ pub fn stmtColumnCount(obj: *PhpObject) RuntimeError!NativeResult {
 pub fn stmtCloseCursor(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
     if (getRes(obj)) |res| {
         mysql.mysql_free_result(res);
-        try obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
+        setRes(obj, null);
     }
     try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     return NativeResult.scalar(.{ .bool = true });
@@ -409,13 +418,13 @@ pub fn errorInfo(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult
 pub fn cleanupStatement(obj: *PhpObject) void {
     if (getRes(obj)) |res| {
         mysql.mysql_free_result(res);
-        obj.properties.put(std.heap.page_allocator, "__res_ptr", .{ .int = 0 }) catch {};
+        setRes(obj, null);
     }
 }
 
 pub fn cleanupConnection(obj: *PhpObject) void {
-    if (getConn(obj)) |conn| {
+    if (obj.native.get(mysql.MYSQL, .pdo_mysql)) |conn| {
         mysql.mysql_close(conn);
-        obj.properties.put(std.heap.page_allocator, "__db_ptr", .{ .int = 0 }) catch {};
+        obj.native.ptr = 0;
     }
 }

--- a/src/stdlib/pdo_pgsql.zig
+++ b/src/stdlib/pdo_pgsql.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const RuntimeError = error{ RuntimeError, OutOfMemory };
 const pdo = @import("pdo.zig");
@@ -33,11 +34,23 @@ const pg = struct {
 };
 
 fn getConn(obj: *PhpObject) ?*pg.PGconn {
-    return pdo.getOpaquePtr(pg.PGconn, obj, "__db_ptr");
+    return obj.native.get(pg.PGconn, .pdo_pgsql) orelse obj.native.getAux(pg.PGconn, .pdo_pgsql_stmt);
 }
 
 fn getRes(obj: *PhpObject) ?*pg.PGresult {
-    return pdo.getOpaquePtr(pg.PGresult, obj, "__res_ptr");
+    return obj.native.get(pg.PGresult, .pdo_pgsql_stmt);
+}
+
+fn attachConn(obj: *PhpObject, conn: *pg.PGconn) void {
+    obj.native = .{ .kind = .pdo_pgsql, .ptr = @intFromPtr(conn) };
+}
+
+fn attachStmt(obj: *PhpObject, conn: *pg.PGconn, res: ?*pg.PGresult) void {
+    obj.native = .{ .kind = .pdo_pgsql_stmt, .ptr = NativeHandle.addr(res), .aux = @intFromPtr(conn) };
+}
+
+fn setRes(obj: *PhpObject, res: ?*pg.PGresult) void {
+    obj.native.ptr = NativeHandle.addr(res);
 }
 
 pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []const Value) RuntimeError!NativeResult {
@@ -74,12 +87,12 @@ pub fn connect(ctx: *NativeContext, obj: *PhpObject, rest: []const u8, args: []c
 
     const conn = pg.PQconnectdb(conninfo_z) orelse return pdo.throwPdo(ctx, "Failed to connect to PostgreSQL");
     if (pg.PQstatus(conn) != pg.CONNECTION_OK) {
-        const msg = std.mem.span(pg.PQerrorMessage(conn));
+        const msg = try ctx.createString(std.mem.span(pg.PQerrorMessage(conn)));
         pg.PQfinish(conn);
         return pdo.throwPdo(ctx, msg);
     }
 
-    try obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
+    attachConn(obj, conn);
     return NativeResult.scalar(.null);
 }
 
@@ -110,9 +123,7 @@ pub fn query(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeError
     }
 
     const stmt_obj = try ctx.createObject("PDOStatement");
-    try stmt_obj.set(ctx.allocator, "__driver", .{ .string = Value.String.borrowed("pgsql") });
-    try stmt_obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
-    try stmt_obj.set(ctx.allocator, "__res_ptr", .{ .int = @intCast(@intFromPtr(res)) });
+    attachStmt(stmt_obj, conn, res);
     try stmt_obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = pg.PQntuples(res) > 0 });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = true });
@@ -159,9 +170,7 @@ pub fn prepare(ctx: *NativeContext, obj: *PhpObject, sql: []const u8) RuntimeErr
     }
 
     const stmt_obj = try ctx.createObject("PDOStatement");
-    try stmt_obj.set(ctx.allocator, "__driver", .{ .string = Value.String.borrowed("pgsql") });
-    try stmt_obj.set(ctx.allocator, "__db_ptr", .{ .int = @intCast(@intFromPtr(conn)) });
-    try stmt_obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
+    attachStmt(stmt_obj, conn, null);
     try stmt_obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
     try stmt_obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     try stmt_obj.set(ctx.allocator, "__stepped", .{ .bool = false });
@@ -192,7 +201,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
     // free previous result
     if (getRes(obj)) |old_res| {
         pg.PQclear(old_res);
-        try obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
+        setRes(obj, null);
     }
 
     const pc_val = obj.get("__param_count");
@@ -244,7 +253,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
             pg.PQclear(res);
             return pdo.throwPdo(ctx, msg);
         }
-        try obj.set(ctx.allocator, "__res_ptr", .{ .int = @intCast(@intFromPtr(res)) });
+        setRes(obj, res);
         try obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
         try obj.set(ctx.allocator, "__has_row", .{ .bool = pg.PQntuples(res) > 0 });
         try obj.set(ctx.allocator, "__row_count", .{ .int = std.fmt.parseInt(i64, std.mem.span(pg.PQcmdTuples(res)), 10) catch @intCast(pg.PQntuples(res)) });
@@ -256,7 +265,7 @@ pub fn stmtExecute(ctx: *NativeContext, obj: *PhpObject, args: []const Value) Ru
             pg.PQclear(res);
             return pdo.throwPdo(ctx, msg);
         }
-        try obj.set(ctx.allocator, "__res_ptr", .{ .int = @intCast(@intFromPtr(res)) });
+        setRes(obj, res);
         try obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
         try obj.set(ctx.allocator, "__has_row", .{ .bool = pg.PQntuples(res) > 0 });
         try obj.set(ctx.allocator, "__row_count", .{ .int = std.fmt.parseInt(i64, std.mem.span(pg.PQcmdTuples(res)), 10) catch @intCast(pg.PQntuples(res)) });
@@ -354,7 +363,7 @@ pub fn stmtColumnCount(obj: *PhpObject) RuntimeError!NativeResult {
 pub fn stmtCloseCursor(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult {
     if (getRes(obj)) |res| {
         pg.PQclear(res);
-        try obj.set(ctx.allocator, "__res_ptr", .{ .int = 0 });
+        setRes(obj, null);
     }
     try obj.set(ctx.allocator, "__has_row", .{ .bool = false });
     try obj.set(ctx.allocator, "__current_row", .{ .int = 0 });
@@ -412,13 +421,13 @@ pub fn errorInfo(ctx: *NativeContext, obj: *PhpObject) RuntimeError!NativeResult
 pub fn cleanupStatement(obj: *PhpObject) void {
     if (getRes(obj)) |res| {
         pg.PQclear(res);
-        obj.properties.put(std.heap.page_allocator, "__res_ptr", .{ .int = 0 }) catch {};
+        setRes(obj, null);
     }
 }
 
 pub fn cleanupConnection(obj: *PhpObject) void {
-    if (getConn(obj)) |conn| {
+    if (obj.native.get(pg.PGconn, .pdo_pgsql)) |conn| {
         pg.PQfinish(conn);
-        obj.properties.put(std.heap.page_allocator, "__db_ptr", .{ .int = 0 }) catch {};
+        obj.native.ptr = 0;
     }
 }

--- a/src/stdlib/simplexml.zig
+++ b/src/stdlib/simplexml.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
+const dom = @import("dom.zig");
 const vm_mod = @import("../runtime/vm.zig");
 const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
@@ -21,9 +23,13 @@ const c = @cImport({
 // "sibling set" semantics PHP exposes - $root->item is a wrapper around the
 // first <item>, but iterating it walks all <item> siblings under $root
 //
+// the native handle (kind .simplexml) carries the pointers: ptr is the
+// xmlNodePtr of the current element, aux the owning xmlDocPtr (owns_aux
+// when this wrapper frees it at request end), extra the iteration cursor.
+// a wrapper made by `clone` holds a detached node copy and marks owns so
+// the request-end sweep frees it while it is still unattached
+//
 // state stored on the PhpObject:
-//   __node  : xmlNodePtr (the current element)
-//   __doc   : xmlDocPtr (owning document, freed at request end via dom.zig)
 //   __ns    : optional default namespace filter (URI)
 //   __is_attr : bool - this wrapper represents an attribute pseudo-element
 //   __attr_name : when __is_attr, the attribute's name
@@ -60,15 +66,53 @@ fn getThis(ctx: *NativeContext) ?*PhpObject {
 }
 
 fn getNodePtr(obj: *const PhpObject) ?*c.xmlNode {
-    const v = obj.get("__node");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.xmlNode, .simplexml);
 }
 
 fn getDocPtr(obj: *const PhpObject) ?*c.xmlDoc {
-    const v = obj.get("__doc");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.getAux(c.xmlDoc, .simplexml);
+}
+
+fn getCursor(obj: *const PhpObject) ?*c.xmlNode {
+    return obj.native.getExtra(c.xmlNode, .simplexml);
+}
+
+fn setCursor(obj: *PhpObject, node: ?*c.xmlNode) void {
+    obj.native.extra = NativeHandle.addr(node);
+}
+
+fn setHandle(obj: *PhpObject, doc: ?*c.xmlDoc, node: ?*c.xmlNode) void {
+    obj.native = .{ .kind = .simplexml, .ptr = NativeHandle.addr(node), .aux = NativeHandle.addr(doc) };
+}
+
+// php copies the whole document when the wrapper sits on the root element
+// and otherwise copies just the node into the same document
+fn cloneHandle(_: *VM, src: *PhpObject, copy: *PhpObject) bool {
+    const node = getNodePtr(src) orelse {
+        setHandle(copy, getDocPtr(src), null);
+        return true;
+    };
+    if (isRootElement(node)) return cloneWholeDoc(node, copy);
+    const dup = c.xmlDocCopyNode(node, node.doc, 1) orelse return false;
+    setHandle(copy, getDocPtr(src), dup);
+    copy.native.owns = true;
+    return true;
+}
+
+fn isRootElement(node: *const c.xmlNode) bool {
+    const parent = node.parent orelse return false;
+    return parent.*.type == c.XML_DOCUMENT_NODE or parent.*.type == c.XML_HTML_DOCUMENT_NODE;
+}
+
+fn cloneWholeDoc(node: *const c.xmlNode, copy: *PhpObject) bool {
+    const dup = c.xmlCopyDoc(node.doc, 1) orelse return false;
+    const root = c.xmlDocGetRootElement(dup) orelse {
+        c.xmlFreeDoc(dup);
+        return false;
+    };
+    setHandle(copy, dup, root);
+    copy.native.owns_aux = true;
+    return true;
 }
 
 fn buildWrapper(ctx: *NativeContext, doc: *c.xmlDoc, node: *c.xmlNode) !*PhpObject {
@@ -83,8 +127,7 @@ const IterMode = enum { siblings, children };
 
 fn buildWrapperMode(ctx: *NativeContext, doc: *c.xmlDoc, node: *c.xmlNode, mode: IterMode) !*PhpObject {
     const obj = try ctx.createObject("SimpleXMLElement");
-    try obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
-    try obj.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
+    setHandle(obj, doc, node);
     try obj.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try obj.set(ctx.allocator, "__iter_children", .{ .bool = mode == .children });
     return obj;
@@ -92,8 +135,7 @@ fn buildWrapperMode(ctx: *NativeContext, doc: *c.xmlDoc, node: *c.xmlNode, mode:
 
 fn buildAttrWrapper(ctx: *NativeContext, doc: *c.xmlDoc, owner: *c.xmlNode, attr_name: []const u8) !*PhpObject {
     const obj = try ctx.createObject("SimpleXMLElement");
-    try obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(owner)) });
-    try obj.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
+    setHandle(obj, doc, owner);
     try obj.set(ctx.allocator, "__is_attr", .{ .bool = true });
     try obj.set(ctx.allocator, "__attr_name", .{ .string = Value.String.borrowed(try dupString(ctx, attr_name)) });
     return obj;
@@ -275,7 +317,7 @@ fn sxmlLoadString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeR
         return NativeResult.scalar(.{ .bool = false });
     };
     const wrapper = try buildRootWrapper(ctx, doc, root);
-    try wrapper.set(ctx.allocator, "__owns_doc", .{ .bool = true });
+    wrapper.native.owns_aux = true;
     return NativeResult.borrowed(.{ .object = wrapper });
 }
 
@@ -290,17 +332,13 @@ fn sxmlLoadFile(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRes
         return NativeResult.scalar(.{ .bool = false });
     };
     const wrapper = try buildRootWrapper(ctx, doc, root);
-    try wrapper.set(ctx.allocator, "__owns_doc", .{ .bool = true });
+    wrapper.native.owns_aux = true;
     return NativeResult.borrowed(.{ .object = wrapper });
 }
 
 fn sxmlImportDom(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 1 or args[0] != .object) return NativeResult.scalar(.null);
-    const dom_obj = args[0].object;
-    // DOM objects store xmlNodePtr in "__node" via dom.zig - reuse that
-    const node_v = dom_obj.get("__node");
-    if (node_v != .int or node_v.int == 0) return NativeResult.scalar(.null);
-    const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(node_v.int)));
+    const node: *c.xmlNode = @ptrCast(dom.getNodePtr(args[0].object) orelse return NativeResult.scalar(.null));
     // for a DOMDocument, descend to root; for any node, use it
     const target: *c.xmlNode = if (node.type == c.XML_DOCUMENT_NODE or node.type == c.XML_HTML_DOCUMENT_NODE)
         c.xmlDocGetRootElement(@ptrCast(node)) orelse return NativeResult.scalar(.null)
@@ -332,9 +370,8 @@ fn sxmlConstruct(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRe
         c.xmlFreeDoc(doc);
         return NativeResult.scalar(.null);
     };
-    try obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(root)) });
-    try obj.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
-    try obj.set(ctx.allocator, "__owns_doc", .{ .bool = true });
+    setHandle(obj, doc, root);
+    obj.native.owns_aux = true;
     try obj.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try obj.set(ctx.allocator, "__iter_children", .{ .bool = true });
     return NativeResult.scalar(.null);
@@ -459,8 +496,7 @@ fn sxmlAttributes(ctx: *NativeContext, args: []const Value) RuntimeError!NativeR
     const node = getNodePtr(obj) orelse return NativeResult.scalar(.null);
     const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const wrapper = try ctx.createObject("SimpleXMLElement");
-    try wrapper.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
-    try wrapper.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
+    setHandle(wrapper, doc, node);
     try wrapper.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try wrapper.set(ctx.allocator, "__attr_view", .{ .bool = true });
     // namespace filter mirrors children(): when called without args, PHP only
@@ -952,20 +988,19 @@ fn sxmlGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeRes
     // children / sibling iteration uses a custom xml-tree walker so duplicate-
     // name children each get their own (name, child) pair in foreach
     const iter_obj = try ctx.createObject("SimpleXMLChildrenIter");
-    try iter_obj.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
-    try iter_obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
+    setHandle(iter_obj, doc, null);
     // forward namespace filter from the wrapper to the iter so sxiAcceptable
     // can drop nodes outside the requested namespace
     const fwd_ns = obj.get("__ns");
     if (fwd_ns == .string) try iter_obj.set(ctx.allocator, "__ns", .{ .string = fwd_ns.string });
     if (obj.get("__iter_children") == .bool and obj.get("__iter_children").bool) {
         // start from the node's first child
-        try iter_obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
+        iter_obj.native.ptr = @intFromPtr(node);
         try iter_obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("children") });
     } else {
         // sibling mode: start from $this and only emit same-named siblings
         if (node.name == null) return NativeResult.borrowed(.{ .object = iter_obj });
-        try iter_obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
+        iter_obj.native.ptr = @intFromPtr(node);
         try iter_obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("siblings") });
         const name_copy = try dupString(ctx, node.name[0..cstrLen(node.name)]);
         try iter_obj.set(ctx.allocator, "__same_name", .{ .string = Value.String.borrowed(name_copy) });
@@ -976,7 +1011,7 @@ fn sxmlGetIterator(ctx: *NativeContext, _: []const Value) RuntimeError!NativeRes
 // ---------------- registration ----------------
 
 pub fn register(vm: *VM, a: Allocator) !void {
-    var def = ClassDef{ .name = "SimpleXMLElement" };
+    var def = ClassDef{ .name = "SimpleXMLElement", .native_clone = cloneHandle };
     try def.interfaces.append(a, "Countable");
     try def.interfaces.append(a, "IteratorAggregate");
     try def.interfaces.append(a, "ArrayAccess");
@@ -1049,7 +1084,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     // SimpleXMLIterator extends SimpleXMLElement and adds hasChildren /
     // getChildren on top of the regular iteration methods. it's used with
     // RecursiveIteratorIterator so just expose the class with parent = SXE
-    var sxi_def = ClassDef{ .name = "SimpleXMLIterator", .parent = "SimpleXMLElement" };
+    var sxi_def = ClassDef{ .name = "SimpleXMLIterator", .parent = "SimpleXMLElement", .native_clone = cloneHandle };
     try sxi_def.interfaces.append(a, "RecursiveIterator");
     try sxi_def.methods.put(a, "hasChildren", .{ .name = "hasChildren", .arity = 0 });
     try sxi_def.methods.put(a, "getChildren", .{ .name = "getChildren", .arity = 0 });
@@ -1062,7 +1097,7 @@ pub fn register(vm: *VM, a: Allocator) !void {
     try vm.native_fns.put(a, "SimpleXMLIterator::hasChildren", sxmlIterHasChildren);
     try vm.native_fns.put(a, "SimpleXMLIterator::getChildren", sxmlIterGetChildren);
     // share the same node-walker the SimpleXMLChildrenIter helper uses; the
-    // SimpleXMLIterator's $this object stores its own cursor under __cursor
+    // SimpleXMLIterator's $this object keeps its own cursor in its handle
     try vm.native_fns.put(a, "SimpleXMLIterator::rewind", sxmlIterRewind);
     try vm.native_fns.put(a, "SimpleXMLIterator::valid", sxiValid);
     try vm.native_fns.put(a, "SimpleXMLIterator::current", sxmlIterCurrent);
@@ -1082,27 +1117,22 @@ fn sxmlIterCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeRes
     // wrap the child node as another SimpleXMLIterator so the foreach value
     // also implements RecursiveIterator (needed by RecursiveIteratorIterator)
     const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
-    const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
-    const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
-    const doc: *c.xmlDoc = @ptrFromInt(@as(usize, @intCast(obj.get("__doc").int)));
+    const node = getCursor(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const wrapper = try ctx.createObject("SimpleXMLIterator");
-    try wrapper.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
-    try wrapper.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
+    setHandle(wrapper, doc, node);
     try wrapper.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try wrapper.set(ctx.allocator, "__iter_children", .{ .bool = true });
     return NativeResult.borrowed(.{ .object = wrapper });
 }
 
 // hasChildren / getChildren operate on the CURRENT iteration position (cursor)
-// not the wrapper's own __node. zphp's RecursiveIteratorIterator calls these
+// not the wrapper's own node. zphp's RecursiveIteratorIterator calls these
 // on the iterator itself between valid() and current(), expecting them to
 // describe the element about to be yielded
 fn sxmlIterHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
-    const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return NativeResult.scalar(.{ .bool = false });
-    const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
+    const node = getCursor(obj) orelse return NativeResult.scalar(.{ .bool = false });
     var ch = node.children;
     while (ch != null) : (ch = ch.*.next) {
         if (ch.*.type == c.XML_ELEMENT_NODE) return NativeResult.scalar(.{ .bool = true });
@@ -1112,27 +1142,25 @@ fn sxmlIterHasChildren(ctx: *NativeContext, _: []const Value) RuntimeError!Nativ
 
 fn sxmlIterGetChildren(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
-    const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
-    const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
+    const node = getCursor(obj) orelse return NativeResult.scalar(.null);
     const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const wrapper = try ctx.createObject("SimpleXMLIterator");
-    try wrapper.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
-    try wrapper.set(ctx.allocator, "__doc", .{ .int = @intCast(@intFromPtr(doc)) });
+    setHandle(wrapper, doc, node);
     try wrapper.set(ctx.allocator, "__is_attr", .{ .bool = false });
     try wrapper.set(ctx.allocator, "__iter_children", .{ .bool = true });
     return NativeResult.borrowed(.{ .object = wrapper });
 }
 
-// these walk xml node siblings via the underlying libxml node pointers stored
-// on the SimpleXMLChildrenIter. fields: __node (starting parent or sibling),
-// __doc (xmlDoc), __mode ("children" | "siblings"), __cursor (current xmlNode*
-// or 0 when done), __same_name (the element name to filter by in sibling mode)
+// these walk xml node siblings via the libxml node pointers in the
+// SimpleXMLChildrenIter's handle: ptr is the starting parent or sibling, aux
+// the xmlDoc, extra the cursor (null when done). properties: __mode
+// ("children" | "siblings"), __same_name (the element name to filter by in
+// sibling mode)
 
 fn sxiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
-    const node = getIterStartPtr(obj) orelse {
-        try obj.set(ctx.allocator, "__cursor", .{ .int = 0 });
+    const node = getNodePtr(obj) orelse {
+        setCursor(obj, null);
         return NativeResult.scalar(.null);
     };
     const mode = obj.get("__mode");
@@ -1144,32 +1172,26 @@ fn sxiRewind(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     while (p != null) : (p = @ptrCast(p.?.next)) {
         if (sxiAcceptable(obj, p.?)) break;
     }
-    const cur: usize = if (p) |np| @intFromPtr(np) else 0;
-    try obj.set(ctx.allocator, "__cursor", .{ .int = @intCast(cur) });
+    setCursor(obj, p);
     return NativeResult.scalar(.null);
 }
 
 fn sxiValid(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
-    const cur = obj.get("__cursor");
-    return NativeResult.scalar(.{ .bool = cur == .int and cur.int != 0 });
+    return NativeResult.scalar(.{ .bool = getCursor(obj) != null });
 }
 
 fn sxiCurrent(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
-    const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
-    const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
-    const doc: *c.xmlDoc = @ptrFromInt(@as(usize, @intCast(obj.get("__doc").int)));
+    const node = getCursor(obj) orelse return NativeResult.scalar(.null);
+    const doc = getDocPtr(obj) orelse return NativeResult.scalar(.null);
     const wrapper = try buildWrapper(ctx, doc, node);
     return NativeResult.borrowed(.{ .object = wrapper });
 }
 
 fn sxiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
-    const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
-    const node: *c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
+    const node = getCursor(obj) orelse return NativeResult.scalar(.null);
     if (node.name == null) return NativeResult.scalar(.null);
     const name = node.name[0..cstrLen(node.name)];
     return try NativeResult.copyString(ctx.allocator, name);
@@ -1177,15 +1199,12 @@ fn sxiKey(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
 
 fn sxiNext(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.null);
-    const cur = obj.get("__cursor");
-    if (cur != .int or cur.int == 0) return NativeResult.scalar(.null);
-    var p: ?*c.xmlNode = @ptrFromInt(@as(usize, @intCast(cur.int)));
-    if (p) |cp| p = @ptrCast(cp.next);
+    const cur = getCursor(obj) orelse return NativeResult.scalar(.null);
+    var p: ?*c.xmlNode = @ptrCast(cur.next);
     while (p != null) : (p = @ptrCast(p.?.next)) {
         if (sxiAcceptable(obj, p.?)) break;
     }
-    const nxt: usize = if (p) |np| @intFromPtr(np) else 0;
-    try obj.set(ctx.allocator, "__cursor", .{ .int = @intCast(nxt) });
+    setCursor(obj, p);
     return NativeResult.scalar(.null);
 }
 
@@ -1212,20 +1231,18 @@ fn sxiAcceptable(obj: *PhpObject, n: *c.xmlNode) bool {
     return true;
 }
 
-fn getIterStartPtr(obj: *PhpObject) ?*c.xmlNode {
-    const v = obj.get("__node");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
-}
-
 pub fn cleanupResources(objects: std.ArrayListUnmanaged(*PhpObject)) void {
+    for (objects.items) |obj| freeDetachedCopy(obj);
     for (objects.items) |obj| {
         if (!std.mem.eql(u8, obj.class_name, "SimpleXMLElement")) continue;
-        const owns = obj.get("__owns_doc");
-        if (owns != .bool or !owns.bool) continue;
-        const v = obj.get("__doc");
-        if (v != .int or v.int == 0) continue;
-        const doc: *c.xmlDoc = @ptrFromInt(@as(usize, @intCast(v.int)));
-        c.xmlFreeDoc(doc);
+        if (!obj.native.owns_aux) continue;
+        if (getDocPtr(obj)) |doc| c.xmlFreeDoc(doc);
     }
+}
+
+// a cloned node that was appended somewhere is freed with its tree
+fn freeDetachedCopy(obj: *PhpObject) void {
+    if (!obj.native.owns) return;
+    const node = getNodePtr(obj) orelse return;
+    if (node.parent == null) c.xmlFreeNode(node);
 }

--- a/src/stdlib/websocket.zig
+++ b/src/stdlib/websocket.zig
@@ -40,14 +40,9 @@ const WsWriter = struct {
 };
 
 fn getWriter(obj: *PhpObject) ?WsWriter {
-    const fd_val = obj.get("__ws_fd");
-    if (fd_val != .int or fd_val.int < 0) return null;
-    const ssl_val = obj.get("__ws_ssl");
-    const ssl_ptr: ?*tls.SSL = if (ssl_val == .int and ssl_val.int != 0)
-        @ptrFromInt(@as(usize, @intCast(ssl_val.int)))
-    else
-        null;
-    return .{ .fd = platform.socketFromInt(fd_val.int) orelse return null, .ssl = ssl_ptr };
+    if (obj.native.kind != .websocket) return null;
+    const ssl = obj.native.get(tls.SSL, .websocket);
+    return .{ .fd = platform.socketFromInt(@intCast(obj.native.aux)) orelse return null, .ssl = ssl };
 }
 
 fn wsSend(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {

--- a/src/stdlib/xmlreader.zig
+++ b/src/stdlib/xmlreader.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
+const dom = @import("dom.zig");
 const vm_mod = @import("../runtime/vm.zig");
 const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
@@ -39,19 +41,16 @@ fn getThis(ctx: *NativeContext) ?*PhpObject {
 }
 
 fn getReader(obj: *const PhpObject) ?*c.xmlTextReader {
-    const v = obj.get("__reader");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.xmlTextReader, .xml_reader);
 }
 
-fn setReader(obj: *PhpObject, allocator: Allocator, reader: ?*c.xmlTextReader) !void {
-    const p: i64 = if (reader) |r| @intCast(@intFromPtr(r)) else 0;
-    try obj.set(allocator, "__reader", .{ .int = p });
+fn setReader(obj: *PhpObject, reader: ?*c.xmlTextReader) void {
+    obj.native = .{ .kind = .xml_reader, .ptr = NativeHandle.addr(reader) };
 }
 
 fn closeExisting(obj: *PhpObject) void {
     if (getReader(obj)) |r| c.xmlFreeTextReader(r);
-    if (obj.properties.getPtr("__reader")) |slot| slot.* = .{ .int = 0 };
+    obj.native.ptr = 0;
 }
 
 pub fn cleanupObject(obj: *PhpObject) void {
@@ -75,7 +74,7 @@ fn xrOpen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
 
     const reader = c.xmlReaderForFile(path_z.ptr, enc_ptr, opts);
     if (reader == null) return NativeResult.scalar(.{ .bool = false });
-    try setReader(obj, ctx.allocator, reader);
+    setReader(obj, reader);
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -100,11 +99,11 @@ fn xrXml(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     // is absent we synthesize a new instance
     if (getThis(ctx)) |obj| {
         closeExisting(obj);
-        try setReader(obj, ctx.allocator, reader);
+        setReader(obj, reader);
         return NativeResult.scalar(.{ .bool = true });
     }
     const obj = try ctx.createObject("XMLReader");
-    try setReader(obj, ctx.allocator, reader);
+    setReader(obj, reader);
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -120,7 +119,7 @@ fn xrFromString(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRes
     const opts: c_int = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else 0;
     const reader = c.xmlReaderForMemory(src.ptr, @intCast(src.len), null, enc_ptr, opts);
     if (reader == null) return NativeResult.scalar(.{ .bool = false });
-    try setReader(obj, ctx.allocator, reader);
+    setReader(obj, reader);
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -136,14 +135,13 @@ fn xrFromUri(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult
     const opts: c_int = if (args.len > 2 and args[2] == .int) @intCast(args[2].int) else 0;
     const reader = c.xmlReaderForFile(path_z.ptr, enc_ptr, opts);
     if (reader == null) return NativeResult.scalar(.{ .bool = false });
-    try setReader(obj, ctx.allocator, reader);
+    setReader(obj, reader);
     return NativeResult.borrowed(.{ .object = obj });
 }
 
 fn xrClose(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
     const obj = getThis(ctx) orelse return NativeResult.scalar(.{ .bool = false });
     closeExisting(obj);
-    try setReader(obj, ctx.allocator, null);
     return NativeResult.scalar(.{ .bool = true });
 }
 
@@ -300,7 +298,7 @@ fn xrExpand(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
         else => "DOMNode",
     };
     const dom_obj = try ctx.createObject(cls);
-    try dom_obj.set(ctx.allocator, "__node", .{ .int = @intCast(@intFromPtr(node)) });
+    dom.setNodePtr(dom_obj, @ptrCast(node));
     return NativeResult.borrowed(.{ .object = dom_obj });
 }
 

--- a/src/stdlib/xmlwriter.zig
+++ b/src/stdlib/xmlwriter.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Value = @import("../runtime/value.zig").Value;
 const PhpObject = @import("../runtime/value.zig").PhpObject;
+const NativeHandle = @import("../runtime/value.zig").NativeHandle;
 const vm_mod = @import("../runtime/vm.zig");
 const NativeResult = @import("../runtime/native_result.zig").NativeResult;
 const VM = vm_mod.VM;
@@ -34,22 +35,22 @@ fn getThis(ctx: *NativeContext) ?*PhpObject {
 }
 
 fn getWriter(obj: *const PhpObject) ?*c.xmlTextWriter {
-    const v = obj.get("__writer");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.get(c.xmlTextWriter, .xml_writer);
 }
 
 fn getBuffer(obj: *const PhpObject) ?*c.xmlBuffer {
-    const v = obj.get("__buffer");
-    if (v != .int or v.int == 0) return null;
-    return @ptrFromInt(@as(usize, @intCast(v.int)));
+    return obj.native.getAux(c.xmlBuffer, .xml_writer);
+}
+
+fn setWriter(obj: *PhpObject, writer: ?*c.xmlTextWriter, buffer: ?*c.xmlBuffer) void {
+    obj.native = .{ .kind = .xml_writer, .ptr = NativeHandle.addr(writer), .aux = NativeHandle.addr(buffer) };
 }
 
 fn closeExisting(obj: *PhpObject) void {
     if (getWriter(obj)) |w| c.xmlFreeTextWriter(w);
     if (getBuffer(obj)) |b| c.xmlBufferFree(b);
-    if (obj.properties.getPtr("__writer")) |slot| slot.* = .{ .int = 0 };
-    if (obj.properties.getPtr("__buffer")) |slot| slot.* = .{ .int = 0 };
+    obj.native.ptr = 0;
+    obj.native.aux = 0;
 }
 
 pub fn cleanupObject(obj: *PhpObject) void {
@@ -71,8 +72,7 @@ fn xwOpenMemory(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult
         c.xmlBufferFree(buf);
         return NativeResult.scalar(.{ .bool = false });
     }
-    try obj.set(ctx.allocator, "__buffer", .{ .int = @intCast(@intFromPtr(buf)) });
-    try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
+    setWriter(obj, writer, buf);
     if (getThis(ctx) == null) return NativeResult.borrowed(.{ .object = obj });
     return NativeResult.scalar(.{ .bool = true });
 }
@@ -88,7 +88,7 @@ fn xwOpenURI(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult
     defer ctx.allocator.free(path_z);
     const writer = c.xmlNewTextWriterFilename(path_z.ptr, 0);
     if (writer == null) return NativeResult.scalar(.{ .bool = false });
-    try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
+    setWriter(obj, writer, null);
     if (getThis(ctx) == null) return NativeResult.borrowed(.{ .object = obj });
     return NativeResult.scalar(.{ .bool = true });
 }
@@ -101,8 +101,7 @@ fn xwToMemory(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
         c.xmlBufferFree(buf);
         return NativeResult.scalar(.{ .bool = false });
     }
-    try obj.set(ctx.allocator, "__buffer", .{ .int = @intCast(@intFromPtr(buf)) });
-    try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
+    setWriter(obj, writer, buf);
     return NativeResult.borrowed(.{ .object = obj });
 }
 
@@ -113,7 +112,7 @@ fn xwToUri(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     defer ctx.allocator.free(path_z);
     const writer = c.xmlNewTextWriterFilename(path_z.ptr, 0);
     if (writer == null) return NativeResult.scalar(.{ .bool = false });
-    try obj.set(ctx.allocator, "__writer", .{ .int = @intCast(@intFromPtr(writer)) });
+    setWriter(obj, writer, null);
     return NativeResult.borrowed(.{ .object = obj });
 }
 

--- a/tests/native_handle_curl.php
+++ b/tests/native_handle_curl.php
@@ -1,0 +1,44 @@
+<?php
+$ch = curl_init("http://127.0.0.1:9/original");
+var_dump(isset($ch->__curl_ptr), isset($ch->__slist_ptr), isset($ch->__share_state));
+var_dump(curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-One: 1"]));
+var_dump(curl_getinfo($ch, CURLINFO_EFFECTIVE_URL));
+
+$copy = clone $ch;
+var_dump($copy instanceof CurlHandle);
+var_dump($copy !== $ch);
+var_dump(curl_getinfo($copy, CURLINFO_EFFECTIVE_URL));
+var_dump(curl_setopt($copy, CURLOPT_URL, "http://127.0.0.1:9/copy"));
+var_dump(curl_getinfo($copy, CURLINFO_EFFECTIVE_URL));
+var_dump(curl_getinfo($ch, CURLINFO_EFFECTIVE_URL));
+var_dump(curl_setopt($copy, CURLOPT_HTTPHEADER, ["X-Two: 2"]));
+var_dump(curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-Three: 3"]));
+var_dump(curl_errno($copy));
+curl_close($copy);
+curl_close($ch);
+
+$sh = curl_share_init();
+var_dump(isset($sh->__share_state));
+var_dump(curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE));
+var_dump(curl_share_errno($sh));
+try {
+    $x = clone $sh;
+    echo "unexpected clone\n";
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+var_dump(curl_share_errno($sh));
+
+$mh = curl_multi_init();
+var_dump(isset($mh->__multi_ptr));
+$e1 = curl_init("http://127.0.0.1:9/a");
+var_dump(curl_multi_add_handle($mh, $e1));
+var_dump(curl_multi_remove_handle($mh, $e1));
+try {
+    $y = clone $mh;
+    echo "unexpected clone\n";
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+curl_multi_close($mh);
+echo "done\n";

--- a/tests/native_handle_gd_gmp.php
+++ b/tests/native_handle_gd_gmp.php
@@ -1,0 +1,27 @@
+<?php
+// covers: GdImage and GMP keep working when a script overwrites the property names that once held their C pointers, clone semantics per class
+
+$im = imagecreatetruecolor(12, 7);
+try {
+    $im->__gd_ptr = 0x41414141;
+} catch (Error $e) {
+}
+var_dump(imagesx($im), imagesy($im));
+try {
+    $copy = clone $im;
+    echo "cloned\n";
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+imagedestroy($im);
+
+$n = gmp_init("123456789012345678901234567890");
+$n->__mpz = 0x41414141;
+var_dump(gmp_strval($n));
+var_dump(isset($n->__mpz));
+$m = clone $n;
+$m = gmp_add($m, 1);
+var_dump(gmp_strval($n), gmp_strval($m));
+$k = clone $n;
+var_dump(gmp_cmp($k, $n) === 0);
+var_dump($k !== $n);

--- a/tests/native_handle_intl.php
+++ b/tests/native_handle_intl.php
@@ -1,0 +1,83 @@
+<?php
+// covers: intl objects keep working after their old pointer-carrying property names are overwritten, and clone duplicates the ICU state
+
+echo "--- Collator ---\n";
+$coll = new Collator("en_US");
+$coll->__coll = 0x41414141;
+var_dump($coll->compare("apple", "banana"));
+$coll->setStrength(Collator::PRIMARY);
+var_dump($coll->getStrength());
+var_dump(isset($coll->__coll));
+try {
+    $copy = clone $coll;
+    echo "cloned\n";
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "--- NumberFormatter ---\n";
+$nf = new NumberFormatter("en_US", NumberFormatter::DECIMAL);
+$nf->__nfmt = 0x41414141;
+echo $nf->format(1234567.891), "\n";
+var_dump(isset($nf->__nfmt));
+$nf2 = clone $nf;
+$nf2->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 1);
+echo $nf2->format(1234567.891), "\n";
+echo $nf->format(1234567.891), "\n";
+var_dump($nf2->parse("42.5"));
+
+echo "--- IntlDateFormatter ---\n";
+$df = new IntlDateFormatter("en_US", IntlDateFormatter::NONE, IntlDateFormatter::NONE, "UTC", null, "yyyy-MM-dd HH:mm");
+$df->__dfmt = 0x41414141;
+echo $df->format(86400 * 365), "\n";
+var_dump(isset($df->__dfmt));
+$df2 = clone $df;
+$df2->setPattern("dd/MM/yyyy");
+echo $df2->format(86400 * 365), "\n";
+echo $df->format(86400 * 365), "\n";
+echo $df->getPattern(), " | ", $df2->getPattern(), "\n";
+var_dump($df2->parse("15/03/2021"));
+
+echo "--- IntlCalendar ---\n";
+$cal = IntlCalendar::createInstance("UTC", "en_US");
+$cal->__cal = 0x41414141;
+$cal->setTime(86400000.0 * 400);
+var_dump($cal->get(IntlCalendar::FIELD_YEAR));
+var_dump(isset($cal->__cal));
+$cal2 = clone $cal;
+$cal2->add(IntlCalendar::FIELD_YEAR, 5);
+var_dump($cal->get(IntlCalendar::FIELD_YEAR), $cal2->get(IntlCalendar::FIELD_YEAR));
+
+echo "--- IntlGregorianCalendar ---\n";
+$greg = new IntlGregorianCalendar(2020, 1, 15);
+$greg->__cal = 0x41414141;
+var_dump($greg->get(IntlCalendar::FIELD_MONTH));
+var_dump(isset($greg->__cal));
+$greg2 = clone $greg;
+$greg2->set(IntlCalendar::FIELD_YEAR, 1999);
+var_dump($greg->get(IntlCalendar::FIELD_YEAR), $greg2->get(IntlCalendar::FIELD_YEAR));
+
+echo "--- IntlBreakIterator ---\n";
+$brk = IntlBreakIterator::createWordInstance("en_US");
+$brk->__brk = 0x41414141;
+$brk->setText("hello big world");
+var_dump($brk->first());
+var_dump($brk->next());
+var_dump(isset($brk->__brk));
+$brk2 = clone $brk;
+var_dump($brk2->current());
+var_dump($brk2->next());
+var_dump($brk->current());
+var_dump($brk2->getText());
+$brk->setText("other text");
+var_dump($brk2->getText());
+var_dump($brk2->last());
+
+echo "--- Transliterator ---\n";
+$tr = Transliterator::create("Any-Upper");
+$tr->__trans = 0x41414141;
+echo $tr->transliterate("hello"), "\n";
+var_dump(isset($tr->__trans));
+$tr2 = clone $tr;
+echo $tr2->transliterate("world"), "\n";
+echo $tr2->id, "\n";

--- a/tests/native_handle_pdo.php
+++ b/tests/native_handle_pdo.php
@@ -1,0 +1,54 @@
+<?php
+// covers: PDO sqlite connection and statement handles surviving forged __db_ptr/__stmt_ptr/__driver properties, uncloneable PDO/Pdo\Sqlite/PDOStatement
+
+$pdo = new PDO("sqlite::memory:");
+$pdo->__db_ptr = 0x41414141;
+$pdo->__driver = "mysql";
+$pdo->exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
+$pdo->exec("INSERT INTO t (name) VALUES ('alpha'), ('beta')");
+echo "driver: ", $pdo->getAttribute(PDO::ATTR_DRIVER_NAME), "\n";
+echo "last id: ", $pdo->lastInsertId(), "\n";
+var_dump(isset($pdo->__db_ptr));
+var_dump(isset($pdo->__driver));
+
+$stmt = $pdo->prepare("SELECT name FROM t WHERE id = ?");
+$stmt->__stmt_ptr = 0x42424242;
+$stmt->__db_ptr = 0x43434343;
+$stmt->__driver = "pgsql";
+$stmt->execute([2]);
+echo "row: ", $stmt->fetchColumn(), "\n";
+var_dump(isset($stmt->__stmt_ptr));
+var_dump(isset($stmt->__db_ptr));
+
+$q = $pdo->query("SELECT COUNT(*) AS n FROM t");
+$q->__stmt_ptr = 0;
+$q->__db_ptr = 0;
+echo "count: ", $q->fetch(PDO::FETCH_ASSOC)["n"], "\n";
+var_dump(isset($q->__stmt_ptr));
+
+$bad = $pdo->prepare("SELECT json_extract('{', '$')");
+$bad->__db_ptr = 0x44444444;
+try {
+    $bad->execute();
+} catch (PDOException $e) {
+    echo "error: ", $e->getMessage(), "\n";
+}
+
+$sub = new Pdo\Sqlite("sqlite::memory:");
+echo "sub: ", $sub->query("SELECT 7")->fetchColumn(), "\n";
+echo "sub class: ", get_class($sub), "\n";
+
+foreach ([$pdo, $sub, $stmt] as $obj) {
+    try {
+        $copy = clone $obj;
+        echo "cloned ", get_class($copy), "\n";
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+$stmt->closeCursor();
+$stmt = null;
+$q = null;
+$bad = null;
+echo "after: ", $pdo->query("SELECT name FROM t ORDER BY id")->fetchColumn(), "\n";

--- a/tests/native_handle_xml.php
+++ b/tests/native_handle_xml.php
@@ -1,0 +1,137 @@
+<?php
+// covers: DOM/SimpleXML/XMLReader/XMLWriter keep working when a script writes the old pointer property names, clone semantics per class
+
+$xml = '<?xml version="1.0"?>' . "\n" . '<root><item id="1">one</item><item id="2">two</item></root>' . "\n";
+
+// ---- DOMDocument ----
+$doc = new DOMDocument();
+$doc->__node = 0x41414141;
+$doc->loadXML($xml);
+echo "doc: ", $doc->documentElement->nodeName, " ", $doc->getElementsByTagName('item')->length, "\n";
+var_dump(isset($doc->__node));
+
+$docCopy = clone $doc;
+$docCopy->documentElement->appendChild($docCopy->createElement('added', 'x'));
+echo "orig items: ", $doc->getElementsByTagName('added')->length, "\n";
+echo "copy items: ", $docCopy->getElementsByTagName('added')->length, "\n";
+echo "copy owner is copy: ", var_export($docCopy->documentElement->ownerDocument === $docCopy, true), "\n";
+echo $docCopy->saveXML();
+
+// ---- DOMElement ----
+$el = $doc->documentElement->firstChild;
+$el->__node = 0x41414141;
+echo "el: ", $el->nodeName, " ", $el->getAttribute('id'), " ", $el->textContent, "\n";
+var_dump(isset($el->__node));
+
+$elCopy = clone $el;
+$elCopy->setAttribute('id', '9');
+echo "orig id: ", $el->getAttribute('id'), "\n";
+echo "copy id: ", $elCopy->getAttribute('id'), "\n";
+echo "copy detached: ", var_export($elCopy->parentNode === null, true), "\n";
+echo "copy owner: ", var_export($elCopy->ownerDocument === $doc, true), "\n";
+$doc->documentElement->appendChild($elCopy);
+echo "after append: ", $doc->getElementsByTagName('item')->length, "\n";
+
+// ---- DOMText / DOMComment / DOMAttr ----
+$text = $el->firstChild;
+$text->__node = 0x41414141;
+$textCopy = clone $text;
+$textCopy->data = 'changed';
+echo "text: ", $text->data, " / ", $textCopy->data, "\n";
+
+$comment = $doc->createComment('note');
+$comment->__node = 0x41414141;
+$commentCopy = clone $comment;
+echo "comment: ", $commentCopy->data, " ", $commentCopy->nodeName, "\n";
+
+$attr = $el->getAttributeNode('id');
+$attr->__node = 0x41414141;
+$attrCopy = clone $attr;
+echo "attr: ", $attrCopy->name, "=", $attrCopy->value, "\n";
+
+// ---- SimpleXMLElement ----
+$sx = simplexml_load_string($xml);
+$sx->__node = 'n';
+$sx->__doc = 'd';
+$sx->__owns_doc = 'o';
+$sx->__cursor = 'c';
+echo "sx: ", $sx->getName(), " ", count($sx->item), " ", (string) $sx->item[1], "\n";
+var_dump(isset($sx->__node));
+echo "sx children: ";
+foreach ($sx->children() as $name => $child) echo $name, ",";
+echo "\n";
+
+$sxCopy = clone $sx;
+$sxCopy->addChild('added', 'v');
+echo "orig added: ", var_export(isset($sx->added), true), "\n";
+echo "copy added: ", var_export(isset($sxCopy->added), true), " ", (string) $sxCopy->added, "\n";
+echo "copy name: ", $sxCopy->getName(), "\n";
+echo $sxCopy->asXML(), "\n";
+
+$itemCopy = clone $sx->item[0];
+$itemCopy['id'] = '7';
+echo "item ids: ", (string) $sx->item[0]['id'], " / ", (string) $itemCopy['id'], "\n";
+
+// ---- SimpleXMLIterator ----
+$it = new SimpleXMLIterator('<list><a>1</a><b>2</b><c><d>3</d></c></list>');
+$it->__cursor = 'c';
+$it->__node = 'n';
+echo "iter: ";
+foreach ($it as $k => $v) echo $k, "=", trim((string) $v), ";";
+echo "\n";
+echo "iter leaves: ";
+foreach (new RecursiveIteratorIterator($it) as $k => $v) echo $k, "=", (string) $v, ";";
+echo "\n";
+var_dump(isset($it->__cursor));
+
+$itCopy = clone $it;
+$itCopy->addChild('e', '4');
+echo "iter copy: ";
+foreach ($itCopy as $k => $v) echo $k, ";";
+echo "\n";
+echo "iter orig count: ", count($it->children()), "\n";
+
+// ---- XMLReader ----
+$reader = XMLReader::XML($xml);
+$reader->__reader = 0x41414141;
+$names = [];
+while ($reader->read()) {
+    if ($reader->nodeType === XMLReader::ELEMENT) $names[] = $reader->name;
+}
+echo "reader: ", implode(',', $names), "\n";
+var_dump(isset($reader->__reader));
+$reader->close();
+
+$reader2 = XMLReader::XML('<r><x a="1">t</x></r>');
+$reader2->read();
+$reader2->read();
+$expanded = $reader2->expand();
+echo "expand: ", $expanded->nodeName, " ", $expanded->getAttribute('a'), " ", $expanded->textContent, "\n";
+$imported = simplexml_import_dom($doc->documentElement);
+echo "import: ", $imported->getName(), " ", count($imported->item), "\n";
+
+try {
+    $r = clone $reader2;
+    echo "reader cloned\n";
+} catch (Error $e) {
+    echo get_class($e), ": ", $e->getMessage(), "\n";
+}
+
+// ---- XMLWriter ----
+$writer = new XMLWriter();
+$writer->openMemory();
+$writer->__writer = 0x41414141;
+$writer->__buffer = 0x42424242;
+$writer->startElement('w');
+$writer->writeAttribute('k', 'v');
+$writer->text('body');
+$writer->endElement();
+echo "writer: ", $writer->outputMemory(), "\n";
+var_dump(isset($writer->__writer));
+
+try {
+    $w = clone $writer;
+    echo "writer cloned\n";
+} catch (Error $e) {
+    echo get_class($e), ": ", $e->getMessage(), "\n";
+}


### PR DESCRIPTION
Follow-up to #63. The built-in bindings had the same shape as the extension resources: PDO, SimpleXML, DOM, cURL, intl, gd, GMP, LDAP, mysqli, XMLReader, XMLWriter, and the WebSocket connection each kept raw C pointers as integers in public `__` properties. A script could overwrite `$pdo->__db_ptr` or `$xml->__node` and crash the process, and PDO's `__driver` string chose which C type the pointer was cast to.

Every object now carries a native handle: a kind tag naming the binding, three address slots, and two ownership flags. Reads go through the handle with a kind check, so a pointer from one binding never reaches another binding's code. The old property names are gone from every class; assigning them just creates an ordinary dynamic property.

`clone` no longer copies pointers. Classes PHP allows to be cloned duplicate the C object through a per-class hook (GMP, CurlHandle, DOM documents and nodes, SimpleXMLElement, NumberFormatter, IntlDateFormatter, IntlCalendar, the break iterators, Transliterator), and the rest throw PHP's uncloneable error. Cleanup timing is unchanged.

Two latent bugs surfaced on the way: `CURLOPT_HTTPHEADER` with an array containing no strings left a freed header list behind for cleanup to free again, and a refused PDO MySQL or PostgreSQL connection printed a blank error message because the text was read after the connection was closed.

Five new compat tests forge the old property names on each class, use the objects afterwards, and exercise `clone` on every class, matching PHP 8.5 byte for byte.