### PR TITLE
Run serve and the process natives on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,8 @@ jobs:
         run: zig build test
       - name: PHP compat
         run: ZPHP=./zig-out/bin/zphp.exe ./tests/run
+      - name: serve
+        run: unset OPENSSL_CONF; ZPHP=./zig-out/bin/zphp.exe ./tests/serve_test
 
   extensions:
     needs: changes

--- a/src/h2.zig
+++ b/src/h2.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const tls = @import("tls.zig");
-const posix = std.posix;
 const Allocator = std.mem.Allocator;
 
 const c = @cImport({
@@ -71,7 +70,7 @@ pub const H2Stream = struct {
 
 const SessionConn = struct {
     ssl: *tls.SSL,
-    fd: posix.fd_t,
+    fd: std.posix.socket_t,
 };
 
 pub const H2Session = struct {
@@ -82,7 +81,7 @@ pub const H2Session = struct {
     send_buf: std.ArrayListUnmanaged(u8) = .{},
 
     // call initSession after allocating on heap so user_data pointer is stable
-    pub fn initSession(self: *H2Session, allocator: Allocator, ssl: *tls.SSL, fd: posix.fd_t) !void {
+    pub fn initSession(self: *H2Session, allocator: Allocator, ssl: *tls.SSL, fd: std.posix.socket_t) !void {
         self.allocator = allocator;
         self.io = .{ .ssl = ssl, .fd = fd };
         self.streams = [_]H2Stream{.{ .stream_id = 0 }} ** MAX_STREAMS;

--- a/src/main.zig
+++ b/src/main.zig
@@ -109,10 +109,7 @@ fn dispatch(allocator: std.mem.Allocator, args: []const []const u8) !void {
         try requireArg(args, 3, "usage: zphp run <file>\n");
         try runFile(allocator, args[2], if (args.len > 3) args[3..] else &.{});
     } else if (std.mem.eql(u8, cmd, "serve")) {
-        if (platform.is_windows) {
-            try writeStderr("zphp serve is not available on Windows yet\n");
-            std.process.exit(1);
-        } else try serveCommand(allocator, args);
+        try serveCommand(allocator, args);
     } else if (std.mem.eql(u8, cmd, "test")) {
         try @import("test_runner.zig").run(allocator, if (args.len >= 3) args[2] else null);
     } else if (std.mem.eql(u8, cmd, "install")) {
@@ -344,33 +341,10 @@ fn loadFile(path: []const u8, allocator: std.mem.Allocator, vm: *@import("runtim
     const closure_counter = compiler.closureCounter();
 
     if (std.mem.startsWith(u8, path, "phar://")) {
-        // resolve phar://[alias-or-fspath]/[internal-path] to (archive-path, internal-path)
-        // alias-aware lookup uses the VM's phar_aliases table populated by Phar::mapPhar
-        const tail = path[7..];
-        var archive: []const u8 = "";
-        var internal: []const u8 = "";
-        const sep = std.mem.indexOfScalar(u8, tail, '/') orelse tail.len;
-        const head = tail[0..sep];
-        if (vm.phar_aliases.get(head)) |arc| {
-            archive = arc;
-            internal = if (sep < tail.len) tail[sep + 1 ..] else "";
-        } else {
-            var split: usize = tail.len;
-            while (split > 0) {
-                while (split > 0 and tail[split - 1] != '/') split -= 1;
-                if (split == 0) break;
-                const candidate = tail[0 .. split - 1];
-                if (std.fs.cwd().statFile(candidate)) |st| {
-                    if (st.kind == .file) {
-                        archive = candidate;
-                        internal = tail[split..];
-                        break;
-                    }
-                } else |_| {}
-                split -= 1;
-            }
-        }
-        if (archive.len == 0) return null;
+        const phar_path = @import("stdlib/phar_path.zig");
+        const resolved_phar = phar_path.resolve(path, &vm.phar_aliases) orelse return null;
+        const archive = resolved_phar.archive_path;
+        const internal = resolved_phar.internal_path;
 
         const phar_mod = @import("stdlib/phar.zig");
         const PharCacheEntry = @import("runtime/vm.zig").PharCacheEntry;
@@ -410,9 +384,9 @@ fn loadFile(path: []const u8, allocator: std.mem.Allocator, vm: *@import("runtim
             };
             cache_entry = e;
         }
-        const normalized_internal = std.fs.path.resolve(allocator, &.{ "/", internal }) catch return null;
+        const normalized_internal = phar_path.normalizeInternal(allocator, internal) catch return null;
         defer allocator.free(normalized_internal);
-        const entry = cache_entry.parsed.lookup(std.mem.trimLeft(u8, normalized_internal, "/")) orelse return null;
+        const entry = cache_entry.parsed.lookup(normalized_internal) orelse return null;
         const payload = phar_mod.extract(allocator, &cache_entry.parsed, entry) catch return null;
         source = payload;
         // synthesize a display path so error messages identify the entry inside the phar
@@ -747,7 +721,8 @@ test {
     _ = @import("stdlib/exceptions.zig");
     _ = @import("stdlib/registry.zig");
     _ = @import("stdlib/datetime.zig");
-    if (!platform.is_windows) _ = @import("serve.zig");
+    _ = @import("stdlib/phar_path.zig");
+    _ = @import("serve.zig");
     _ = @import("stdlib/pcre.zig");
     _ = @import("pipeline/parser_tests.zig");
     _ = @import("integration_tests.zig");

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -274,3 +274,102 @@ pub fn setReadOnly(path: []const u8, read_only: bool) bool {
     const next = if (read_only) attrs | readonly_bit else attrs & ~readonly_bit;
     return SetFileAttributesW(wide.ptr, next) != 0;
 }
+
+// tcp sockets are created here so windows gets synchronous (non-overlapped)
+// handles: those work with ReadFile/WriteFile, which is what std.fs.File and
+// std.net.Stream use, while std's own sockets are overlapped and fail there
+pub fn tcpSocket(family: u32) !std.posix.socket_t {
+    if (is_windows) {
+        const ws = std.os.windows.ws2_32;
+        return std.os.windows.WSASocketW(@intCast(family), ws.SOCK.STREAM, ws.IPPROTO.TCP, null, 0, ws.WSA_FLAG_NO_HANDLE_INHERIT) catch return error.SocketCreationFailed;
+    }
+    return std.posix.socket(family, std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC, 0);
+}
+
+pub fn tcpListen(addr: std.net.Address, reuse_address: bool) !std.net.Server {
+    const sock = try tcpSocket(addr.any.family);
+    errdefer closeSocket(socketToInt(sock));
+    if (reuse_address) try std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
+    var len = addr.getOsSockLen();
+    try std.posix.bind(sock, &addr.any, len);
+    try std.posix.listen(sock, 128);
+    var bound: std.net.Address = undefined;
+    try std.posix.getsockname(sock, &bound.any, &len);
+    return .{ .listen_address = bound, .stream = .{ .handle = sock } };
+}
+
+pub fn tcpConnect(addr: std.net.Address) !std.net.Stream {
+    const sock = try tcpSocket(addr.any.family);
+    errdefer closeSocket(socketToInt(sock));
+    try std.posix.connect(sock, &addr.any, addr.getOsSockLen());
+    return .{ .handle = sock };
+}
+
+// a connected pair of stream sockets: unix domain elsewhere, a loopback tcp
+// connection on windows, where WSAPoll only waits on sockets so this is
+// also the wakeup primitive serve uses instead of a pipe
+pub fn socketPair() ![2]std.posix.socket_t {
+    if (!is_windows) {
+        var pair: [2]std.posix.socket_t = undefined;
+        if (std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &pair) != 0) return error.SocketPairFailed;
+        return pair;
+    }
+    var server = try tcpListen(std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0), false);
+    defer server.deinit();
+    const client = try tcpConnect(server.listen_address);
+    errdefer client.close();
+    const accepted = try server.accept();
+    return .{ client.handle, accepted.stream.handle };
+}
+
+pub fn setNonBlocking(sock: std.posix.socket_t, enabled: bool) !void {
+    if (is_windows) {
+        var mode: c_ulong = if (enabled) 1 else 0;
+        if (std.os.windows.ws2_32.ioctlsocket(sock, std.os.windows.ws2_32.FIONBIO, &mode) != 0) return error.SetNonBlockingFailed;
+        return;
+    }
+    const nonblock: u32 = @as(u32, 1) << @bitOffsetOf(std.posix.O, "NONBLOCK");
+    const flags = try std.posix.fcntl(sock, std.posix.F.GETFL, 0);
+    const next = if (enabled) flags | nonblock else flags & ~@as(usize, nonblock);
+    _ = try std.posix.fcntl(sock, std.posix.F.SETFL, next);
+}
+
+pub fn recv(sock: std.posix.socket_t, buf: []u8) !usize {
+    return std.posix.recv(sock, buf, 0);
+}
+
+pub fn send(sock: std.posix.socket_t, buf: []const u8) !usize {
+    const flags: u32 = if (@import("builtin").os.tag == .linux) std.posix.MSG.NOSIGNAL else 0;
+    return std.posix.send(sock, buf, flags);
+}
+
+// SIGINT/SIGTERM elsewhere, the console control handler on windows; the
+// callback runs on a signal or console thread and may only touch a socket
+var shutdown_callback: ?*const fn () void = null;
+
+fn posixShutdownSignal(_: c_int) callconv(.c) void {
+    if (shutdown_callback) |cb| cb();
+}
+
+fn windowsShutdownSignal(_: u32) callconv(.winapi) std.os.windows.BOOL {
+    if (shutdown_callback) |cb| cb();
+    return std.os.windows.TRUE;
+}
+
+pub fn installShutdownHandler(cb: *const fn () void) !void {
+    shutdown_callback = cb;
+    if (is_windows) return std.os.windows.SetConsoleCtrlHandler(windowsShutdownSignal, true);
+    const action: std.posix.Sigaction = .{ .handler = .{ .handler = posixShutdownSignal }, .mask = std.posix.sigemptyset(), .flags = 0 };
+    std.posix.sigaction(std.posix.SIG.INT, &action, null);
+    std.posix.sigaction(std.posix.SIG.TERM, &action, null);
+}
+
+comptime {
+    _ = &tcpListen;
+    _ = &tcpConnect;
+    _ = &socketPair;
+    _ = &setNonBlocking;
+    _ = &recv;
+    _ = &send;
+    _ = &installShutdownHandler;
+}

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -34,6 +34,7 @@ pub const ProcChild = struct {
     pid: platform.Pid,
     reaped: bool,
     pipe_fds: std.ArrayListUnmanaged(ProcPipe) = .{},
+    process: usize = 0,
 };
 const ProcChildMap = std.AutoHashMapUnmanaged(*PhpObject, ProcChild);
 
@@ -813,14 +814,17 @@ pub const VM = struct {
     }
 
     // reap every still-live child. an un-reaped pid is SIGKILL'd + waited (one
-    // waitpid per pid - again would ECHILD->unreachable). then any parent-side
+    // waitpid per pid - again would ECHILD->unreachable); on windows the
+    // process handle is terminated, waited, and closed. then any parent-side
     // pipe fd the script never fclose'd is closed. runs at reset (before
     // freeHeapItems) and deinit; clears the map after
     fn reapProcChildren(self: *VM) void {
         const pc = self.proc_children orelse return;
         var it = pc.valueIterator();
         while (it.next()) |entry| {
-            if (!platform.is_windows) {
+            if (platform.is_windows) {
+                reapWindowsChild(entry);
+            } else {
                 if (!entry.reaped) {
                     std.posix.kill(entry.pid, std.posix.SIG.KILL) catch {};
                     _ = std.posix.waitpid(entry.pid, 0);
@@ -832,6 +836,20 @@ pub const VM = struct {
             entry.pipe_fds.deinit(self.allocator);
         }
         pc.clearRetainingCapacity();
+    }
+
+    fn reapWindowsChild(entry: *ProcChild) void {
+        const kernel32 = std.os.windows.kernel32;
+        if (entry.process != 0) {
+            const handle: std.os.windows.HANDLE = @ptrFromInt(entry.process);
+            if (!entry.reaped) {
+                _ = kernel32.TerminateProcess(handle, 255);
+                _ = kernel32.WaitForSingleObject(handle, std.os.windows.INFINITE);
+            }
+            std.os.windows.CloseHandle(handle);
+            entry.process = 0;
+        }
+        for (entry.pipe_fds.items) |pipe| platform.closeFd(pipe.fd);
     }
 
     fn newRefCell(self: *VM) RuntimeError!*Value {

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -18,7 +18,27 @@ const posix = std.posix;
 const zlib = @cImport(@cInclude("zlib.h"));
 const ws_proto = @import("websocket.zig");
 
-var signal_pipe: [2]posix.fd_t = .{ -1, -1 };
+// wakeups travel over connected socket pairs: the read end sits in the
+// poll set next to the connections, which is the only thing poll can wait on
+// everywhere
+const WakePair = [2]posix.socket_t;
+const no_socket: posix.socket_t = if (platform.is_windows) std.os.windows.ws2_32.INVALID_SOCKET else -1;
+
+var signal_socket: WakePair = .{ no_socket, no_socket };
+
+fn wake(pair: WakePair) void {
+    _ = platform.send(pair[1], &[_]u8{1}) catch {};
+}
+
+fn drainWake(pair: WakePair) void {
+    var drain: [64]u8 = undefined;
+    _ = platform.recv(pair[0], &drain) catch {};
+}
+
+fn closeWakePair(pair: WakePair) void {
+    platform.closeSocket(platform.socketToInt(pair[0]));
+    platform.closeSocket(platform.socketToInt(pair[1]));
+}
 
 fn maxPhpMtime(dir_path: []const u8) i128 {
     var max: i128 = 0;
@@ -36,8 +56,8 @@ fn maxPhpMtime(dir_path: []const u8) i128 {
     return max;
 }
 
-fn signalHandler(_: c_int) callconv(.c) void {
-    _ = posix.write(signal_pipe[1], &[_]u8{1}) catch {};
+fn requestShutdown() void {
+    wake(signal_socket);
 }
 
 pub const ServeConfig = struct {
@@ -81,7 +101,7 @@ const Request = struct {
 const ConnState = enum { tls_handshaking, http_reading, h2_active, ws_idle, closing };
 
 const Connection = struct {
-    fd: posix.fd_t,
+    fd: posix.socket_t,
     stream: std.net.Stream,
     ssl: ?*tls.SSL,
     addr_bytes: u32,
@@ -111,12 +131,12 @@ const Connection = struct {
 
     fn ioRead(self: *Connection, buf: []u8) !usize {
         if (self.ssl) |s| return tls.read(s, buf);
-        return posix.read(self.fd, buf);
+        return platform.recv(self.fd, buf);
     }
 
     fn ioWrite(self: *Connection, data: []const u8) !usize {
         if (self.ssl) |s| return tls.write(s, data);
-        return self.stream.write(data);
+        return platform.send(self.fd, data);
     }
 
     pub fn write(self: *Connection, data: []const u8) !usize {
@@ -211,7 +231,7 @@ const Worker = struct {
     ws_initialized: bool,
     tls_ctx: ?*tls.SSL_CTX,
     env_snapshot: ?env.EnvSnapshot,
-    wake_pipe: [2]posix.fd_t,
+    wake_socket: WakePair,
     poll_fds: [MAX_CONNS + 1]posix.pollfd,
     conns: [MAX_CONNS + 1]?Connection,
     n_fds: usize,
@@ -222,7 +242,7 @@ const Worker = struct {
     script_cache: std.StringHashMapUnmanaged(*CompileResult),
     // the process umask a request may change with umask(); restored before
     // the next request runs, as php_request_shutdown does
-    umask: std.c.mode_t,
+    umask: Umask.Mask,
 };
 
 // what to run for a request, and how to shape $_SERVER for it
@@ -290,11 +310,8 @@ fn initWorker(allocator: Allocator, result: *const CompileResult, doc_root: []co
     errdefer vm.deinit();
     vm.file_loader = &loadFile;
     vm.serve_mode = true;
-    const wake_pipe = try posix.pipe();
-    errdefer {
-        posix.close(wake_pipe[0]);
-        posix.close(wake_pipe[1]);
-    }
+    const wake_socket = try platform.socketPair();
+    errdefer closeWakePair(wake_socket);
     return .{
         .allocator = allocator,
         .result = result,
@@ -306,23 +323,33 @@ fn initWorker(allocator: Allocator, result: *const CompileResult, doc_root: []co
         .ws_initialized = false,
         .tls_ctx = tls_ctx,
         .env_snapshot = env.EnvSnapshot.capture(allocator),
-        .wake_pipe = wake_pipe,
-        .poll_fds = [_]posix.pollfd{.{ .fd = -1, .events = 0, .revents = 0 }} ** (MAX_CONNS + 1),
+        .wake_socket = wake_socket,
+        .poll_fds = [_]posix.pollfd{.{ .fd = no_socket, .events = 0, .revents = 0 }} ** (MAX_CONNS + 1),
         .conns = [_]?Connection{null} ** (MAX_CONNS + 1),
         .n_fds = 1,
         .script_cache = .{},
-        .umask = currentUmask(),
+        .umask = Umask.current(),
     };
 }
 
-fn currentUmask() std.c.mode_t {
-    const current = std.c.umask(0);
-    _ = std.c.umask(current);
-    return current;
-}
+const Umask = if (platform.is_windows) struct {
+    const Mask = void;
+    fn current() Mask {}
+    fn restore(_: Mask) void {}
+} else struct {
+    const Mask = std.c.mode_t;
+    fn current() Mask {
+        const mask = std.c.umask(0);
+        _ = std.c.umask(mask);
+        return mask;
+    }
+    fn restore(mask: Mask) void {
+        _ = std.c.umask(mask);
+    }
+};
 
 // workers come up one at a time into the leading slots. a worker whose VM,
-// pipe, or thread fails is torn down on the spot and never counted, so
+// wake socket, or thread fails is torn down on the spot and never counted, so
 // routing and shutdown only ever touch the first `active` slots
 fn startWorkers(allocator: Allocator, workers: []Worker, threads: []std.Thread, result: *const CompileResult, doc_root: []const u8, port: u16, ws_enabled: bool, tls_ctx: ?*tls.SSL_CTX, idle_timeout_ms: i64) !usize {
     var active: usize = 0;
@@ -333,7 +360,7 @@ fn startWorkers(allocator: Allocator, workers: []Worker, threads: []std.Thread, 
             reportWorkerFailure(err);
             continue;
         };
-        wd.poll_fds[0] = .{ .fd = wd.wake_pipe[0], .events = posix.POLL.IN, .revents = 0 };
+        wd.poll_fds[0] = .{ .fd = wd.wake_socket[0], .events = posix.POLL.IN, .revents = 0 };
         threads[active] = std.Thread.spawn(.{}, eventLoop, .{wd}) catch |err| {
             deinitWorker(wd);
             reportWorkerFailure(err);
@@ -347,7 +374,7 @@ fn startWorkers(allocator: Allocator, workers: []Worker, threads: []std.Thread, 
 
 fn stopWorkers(workers: []Worker, threads: []std.Thread) void {
     queue.close();
-    for (workers) |*wd| _ = posix.write(wd.wake_pipe[1], &[_]u8{1}) catch {};
+    for (workers) |*wd| wake(wd.wake_socket);
     for (threads) |t| t.join();
     for (workers) |*wd| deinitWorker(wd);
 }
@@ -366,8 +393,7 @@ fn deinitWorker(w: *Worker) void {
             conn.deinit(w.allocator);
         }
     }
-    posix.close(w.wake_pipe[0]);
-    posix.close(w.wake_pipe[1]);
+    closeWakePair(w.wake_socket);
     if (w.env_snapshot) |*s| @constCast(s).deinit();
     // deinit the VM FIRST: a leftover frame from a direct-dispatched script that
     // exit()'d (e.g. wp-login.php) still points at that script's slot_names, which
@@ -429,12 +455,6 @@ fn resolveDispatch(w: *Worker, req: *const Request) Dispatch {
     return .{ .result = compiled, .script_filename = compiled.file_path, .front_controller = false };
 }
 
-fn setNonBlocking(fd: posix.fd_t) void {
-    const O_NONBLOCK: u32 = if (@import("builtin").os.tag == .linux) 0x800 else 0x4;
-    const flags = posix.fcntl(fd, 3, 0) catch return;
-    _ = posix.fcntl(fd, 4, flags | O_NONBLOCK) catch return;
-}
-
 fn certMtime(path: []const u8) i128 {
     const f = std.fs.cwd().openFile(path, .{}) catch return 0;
     defer f.close();
@@ -454,19 +474,9 @@ pub fn serve(allocator: Allocator, config: ServeConfig) !void {
         break :blk @max(cpus, 1);
     };
 
-    signal_pipe = try posix.pipe();
-    defer {
-        posix.close(signal_pipe[0]);
-        posix.close(signal_pipe[1]);
-    }
-
-    var sa: posix.Sigaction = .{
-        .handler = .{ .handler = signalHandler },
-        .mask = posix.sigemptyset(),
-        .flags = 0,
-    };
-    posix.sigaction(posix.SIG.INT, &sa, null);
-    posix.sigaction(posix.SIG.TERM, &sa, null);
+    signal_socket = try platform.socketPair();
+    defer closeWakePair(signal_socket);
+    try platform.installShutdownHandler(requestShutdown);
 
     var tls_ctx: ?*tls.SSL_CTX = null;
     var tls_cert_z: ?[:0]u8 = null;
@@ -491,7 +501,7 @@ pub fn serve(allocator: Allocator, config: ServeConfig) !void {
     }
 
     const addr = std.net.Address.parseIp4("0.0.0.0", config.port) catch unreachable;
-    var server = try addr.listen(.{ .reuse_address = true });
+    var server = try platform.tcpListen(addr, true);
     defer server.deinit();
 
     const abs_path = std.fs.cwd().realpathAlloc(allocator, config.file) catch
@@ -513,7 +523,7 @@ pub fn serve(allocator: Allocator, config: ServeConfig) !void {
     const threads = try allocator.alloc(std.Thread, worker_count);
     defer allocator.free(threads);
 
-    setNonBlocking(server.stream.handle);
+    platform.setNonBlocking(server.stream.handle, true) catch {};
 
     var watch_mtime: i128 = if (config.watch) maxPhpMtime(doc_root) else 0;
     var first_run = true;
@@ -603,7 +613,7 @@ pub fn serve(allocator: Allocator, config: ServeConfig) !void {
 
         var main_poll: [2]posix.pollfd = .{
             .{ .fd = server.stream.handle, .events = posix.POLL.IN, .revents = 0 },
-            .{ .fd = signal_pipe[0], .events = posix.POLL.IN, .revents = 0 },
+            .{ .fd = signal_socket[0], .events = posix.POLL.IN, .revents = 0 },
         };
 
         const poll_timeout: i32 = if (config.watch or tls_ctx != null) 1000 else -1;
@@ -620,7 +630,7 @@ pub fn serve(allocator: Allocator, config: ServeConfig) !void {
             if (main_poll[0].revents & posix.POLL.IN != 0) {
                 const conn = server.accept() catch continue;
                 queue.push(.{ .conn = conn });
-                _ = posix.write(workers_data[robin].wake_pipe[1], &[_]u8{1}) catch {};
+                wake(workers_data[robin].wake_socket);
                 robin = (robin + 1) % active;
             }
 
@@ -663,10 +673,8 @@ fn eventLoop(w: *Worker) void {
     while (!queue.shutdown) {
         _ = posix.poll(w.poll_fds[0..w.n_fds], 1000) catch continue;
 
-        // check wake pipe
         if (w.poll_fds[0].revents & posix.POLL.IN != 0) {
-            var drain: [64]u8 = undefined;
-            _ = posix.read(w.wake_pipe[0], &drain) catch {};
+            drainWake(w.wake_socket);
             while (queue.tryPop()) |item| {
                 registerConnection(w, item.conn);
             }
@@ -721,7 +729,10 @@ fn registerConnection(w: *Worker, server_conn: std.net.Server.Connection) void {
         server_conn.stream.close();
         return;
     }
-    setNonBlocking(server_conn.stream.handle);
+    platform.setNonBlocking(server_conn.stream.handle, true) catch {
+        server_conn.stream.close();
+        return;
+    };
     var ssl_ptr: ?*tls.SSL = null;
     var initial_state: ConnState = .http_reading;
     var poll_events: i16 = posix.POLL.IN;
@@ -779,7 +790,7 @@ fn compactConnections(w: *Worker) void {
                     w.conns[i] = w.conns[last];
                 }
                 w.conns[last] = null;
-                w.poll_fds[last] = .{ .fd = -1, .events = 0, .revents = 0 };
+                w.poll_fds[last] = .{ .fd = no_socket, .events = 0, .revents = 0 };
                 w.n_fds -= 1;
                 continue;
             }
@@ -972,7 +983,7 @@ fn processHttpRead(w: *Worker, c: *Connection) void {
     // PHP execution - php-fpm dispatch: an existing .php file runs directly,
     // anything else routes to the front-controller entry
     const dispatch = resolveDispatch(w, &req);
-    _ = std.c.umask(w.umask);
+    Umask.restore(w.umask);
     w.vm.reset();
     const mock_conn = std.net.Server.Connection{
         .stream = c.stream,
@@ -1105,7 +1116,7 @@ fn handleH2Request(w: *Worker, conn: *Connection, session: *h2.H2Session, stream
 
     // PHP execution - php-fpm dispatch (see HTTP/1.1 path)
     const dispatch = resolveDispatch(w, &req);
-    _ = std.c.umask(w.umask);
+    Umask.restore(w.umask);
     w.vm.reset();
     const mock_conn = std.net.Server.Connection{
         .stream = conn.stream,
@@ -1182,7 +1193,7 @@ fn handleWsUpgrade(w: *Worker, c: *Connection, ws_key: []const u8) void {
     };
 
     if (!w.ws_initialized) {
-        _ = std.c.umask(w.umask);
+        Umask.restore(w.umask);
         w.vm.reset();
         w.vm.interpret(w.result) catch {
             c.state = .closing;
@@ -1577,34 +1588,38 @@ fn extractParam(header: []const u8, name: []const u8) ?[]const u8 {
     return header[start..end];
 }
 
-const c_mkstemp = @cImport(@cInclude("stdlib.h"));
+fn uploadTempPath(a: Allocator) ![]const u8 {
+    const dir = platform.tempDir();
+    const sep = if (dir.len > 0 and platform.isSep(dir[dir.len - 1])) "" else platform.sep_str;
+    return std.fmt.allocPrint(a, "{s}{s}zphp_upload_{x:0>16}", .{ dir, sep, std.crypto.random.int(u64) });
+}
+
+const UploadTempFile = struct { path: []const u8, file: std.fs.File };
+
+fn createUploadTempFile(a: Allocator) !UploadTempFile {
+    var attempts: usize = 0;
+    while (attempts < 64) : (attempts += 1) {
+        const path = try uploadTempPath(a);
+        const file = std.fs.cwd().createFile(path, .{ .exclusive = true, .mode = 0o600 }) catch |err| {
+            a.free(path);
+            if (err == error.PathAlreadyExists) continue;
+            return error.TempFileCreation;
+        };
+        return .{ .path = path, .file = file };
+    }
+    return error.TempFileCreation;
+}
 
 fn writeTempFile(a: Allocator, data: []const u8) ![]const u8 {
-    const template = "/tmp/zphp_upload_XXXXXX";
-    const buf = try a.alloc(u8, template.len + 1);
-    @memcpy(buf[0..template.len], template);
-    buf[template.len] = 0;
-
-    const fd = c_mkstemp.mkstemp(buf.ptr);
-    if (fd < 0) {
-        a.free(buf);
-        return error.TempFileCreation;
-    }
-    defer posix.close(fd);
-
-    var written: usize = 0;
-    while (written < data.len) {
-        const n = posix.write(fd, data[written..]) catch {
-            a.free(buf);
-            return error.TempFileWrite;
-        };
-        written += n;
-    }
-
-    // return path without null terminator, but keep same allocation
-    const path = try a.dupe(u8, buf[0..template.len]);
-    a.free(buf);
-    return path;
+    const temp = try createUploadTempFile(a);
+    const written = temp.file.writeAll(data);
+    temp.file.close();
+    written catch {
+        std.fs.cwd().deleteFile(temp.path) catch {};
+        a.free(temp.path);
+        return error.TempFileWrite;
+    };
+    return temp.path;
 }
 
 fn urlDecode(a: Allocator, input: []const u8) ![]const u8 {
@@ -1828,7 +1843,7 @@ fn isCompressible(mime: []const u8) bool {
 
 fn gzipCompress(allocator: Allocator, input: []const u8) ?[]u8 {
     if (input.len == 0) return null;
-    const bound = zlib.compressBound(input.len);
+    const bound: usize = @intCast(zlib.compressBound(@intCast(input.len)));
     const out = allocator.alloc(u8, bound) catch return null;
 
     var stream: zlib.z_stream = std.mem.zeroes(zlib.z_stream);

--- a/src/stdlib/filesystem.zig
+++ b/src/stdlib/filesystem.zig
@@ -9,6 +9,7 @@ const VM = vm_mod.VM;
 const NativeContext = vm_mod.NativeContext;
 const ClassDef = vm_mod.ClassDef;
 const phar = @import("phar.zig");
+const phar_path = @import("phar_path.zig");
 const zlib = @cImport(@cInclude("zlib.h"));
 
 const Allocator = std.mem.Allocator;
@@ -212,9 +213,16 @@ pub fn register(vm: *VM, a: Allocator) !void {
     }
 }
 
+fn isNetStream(obj: *PhpObject) bool {
+    const net = obj.get("__net");
+    return net == .bool and net.bool;
+}
+
+// a socket is a handle of its own on windows, not a crt descriptor
 fn getFileHandle(obj: *PhpObject) ?std.fs.File {
     const v = obj.get("__fd");
     if (v != .int or v.int < 0) return null;
+    if (platform.is_windows and isNetStream(obj)) return .{ .handle = platform.socketFromInt(v.int) orelse return null };
     return platform.fileFromFd(v.int);
 }
 
@@ -284,54 +292,9 @@ fn base64DecodeBytes(a: Allocator, s: []const u8) !?[]u8 {
     return out;
 }
 
-const PharResolved = struct {
-    archive_path: []const u8, // slice into input - not owned
-    internal_path: []const u8, // slice into input - not owned
-};
-
-// resolves "phar:///abs/path/to/file.phar/internal/dir/file.txt" by walking
-// path components from longest to shortest until one names a real file on disk.
-// PHP allows phars without a .phar extension, so we can't shortcut on suffix
-fn resolvePharPath(path: []const u8) ?PharResolved {
-    return resolvePharPathWithCtx(path, null);
-}
-
-fn resolvePharPathWithCtx(path: []const u8, ctx: ?*NativeContext) ?PharResolved {
-    if (!std.mem.startsWith(u8, path, "phar://")) return null;
-    const tail = path[7..];
-    // try alias resolution first: the leading path component before the next
-    // slash may be a registered phar alias (set by Phar::mapPhar). this lets
-    // a phar self-reference its embedded files via `phar://my-alias/foo.php`
-    if (ctx) |c| {
-        if (c.vm.phar_aliases.count() > 0) {
-            const sep = std.mem.indexOfScalar(u8, tail, '/') orelse tail.len;
-            const alias = tail[0..sep];
-            if (c.vm.phar_aliases.get(alias)) |archive| {
-                const inner = if (sep < tail.len) tail[sep + 1 ..] else "";
-                return .{ .archive_path = archive, .internal_path = inner };
-            }
-        }
-    }
-    var split: usize = tail.len;
-    while (split > 0) {
-        // find the next slash from the right
-        while (split > 0 and tail[split - 1] != '/') split -= 1;
-        if (split == 0) break;
-        const candidate = tail[0 .. split - 1];
-        const stat = std.fs.cwd().statFile(candidate) catch {
-            split -= 1;
-            continue;
-        };
-        if (stat.kind == .file) {
-            return .{ .archive_path = candidate, .internal_path = tail[split..] };
-        }
-        split -= 1;
-    }
-    // try the whole tail as an archive (no internal path)
-    if (std.fs.cwd().statFile(tail)) |st| {
-        if (st.kind == .file) return .{ .archive_path = tail, .internal_path = "" };
-    } else |_| {}
-    return null;
+fn resolvePharPathWithCtx(path: []const u8, ctx: ?*NativeContext) ?phar_path.Resolved {
+    const aliases: ?*const phar_path.AliasMap = if (ctx) |c| &c.vm.phar_aliases else null;
+    return phar_path.resolve(path, aliases);
 }
 
 // loads and parses a phar from disk. caller owns returned bytes and must
@@ -355,13 +318,7 @@ fn freePhar(a: Allocator, loaded: *PharLoaded) void {
 
 // returns the raw decoded contents of the file at internal_path, or null if missing
 fn normalizePharInternalPath(a: Allocator, internal_path: []const u8) ![]u8 {
-    const resolved = try std.fs.path.resolve(a, &.{ "/", internal_path });
-    if (resolved.len > 0 and resolved[0] == '/') {
-        const normalized = try a.dupe(u8, resolved[1..]);
-        a.free(resolved);
-        return normalized;
-    }
-    return resolved;
+    return phar_path.normalizeInternal(a, internal_path);
 }
 
 fn readPharEntry(a: Allocator, archive_path: []const u8, internal_path: []const u8) !?[]u8 {
@@ -740,7 +697,9 @@ fn native_is_dir(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRe
         if (r.internal_path.len == 0) return NativeResult.scalar(.{ .bool = false }); // the archive is a file, not a dir
         var loaded = loadPhar(ctx.allocator, r.archive_path) catch return NativeResult.scalar(Value{ .bool = false });
         defer freePhar(ctx.allocator, &loaded);
-        return NativeResult.scalar(.{ .bool = loaded.parsed.isDir(r.internal_path) });
+        const normalized = normalizePharInternalPath(ctx.allocator, r.internal_path) catch return NativeResult.scalar(.{ .bool = false });
+        defer ctx.allocator.free(normalized);
+        return NativeResult.scalar(.{ .bool = loaded.parsed.isDir(normalized) });
     }
     var dir = std.fs.cwd().openDir(path, .{}) catch return NativeResult.scalar(Value{ .bool = false });
     dir.close();
@@ -1482,7 +1441,7 @@ fn openErrorReason(err: anyerror) []const u8 {
     };
 }
 
-fn openWithMode(path: []const u8, mode: []const u8) !std.fs.File {
+pub fn openWithMode(path: []const u8, mode: []const u8) !std.fs.File {
     if (mode.len == 0) return error.RuntimeError;
     const has_plus = mode.len > 1 and (mode[1] == '+' or (mode.len > 2 and mode[2] == '+'));
     return switch (mode[0]) {
@@ -1568,7 +1527,11 @@ fn native_fclose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRe
     }
     if (getFileHandle(obj)) |file| {
         // never close stdin/stdout/stderr - they're shared with the host process
-        if (!platform.isStdio(file)) platform.closeFile(file, obj.get("__fd").int);
+        if (isNetStream(obj)) {
+            platform.closeSocket(obj.get("__fd").int);
+        } else if (!platform.isStdio(file)) {
+            platform.closeFile(file, obj.get("__fd").int);
+        }
     }
     obj.set(ctx.allocator, "__open", .{ .bool = false }) catch {};
     return NativeResult.scalar(.{ .bool = true });
@@ -2900,7 +2863,8 @@ fn runShellWith(
     stdout_b: StdioBehavior,
     stderr_b: StdioBehavior,
 ) !ShellResult {
-    var child = std.process.Child.init(&.{ "/bin/sh", "-c", command }, allocator);
+    const argv = platform.shellArgv(command);
+    var child = std.process.Child.init(&argv, allocator);
     child.stdin_behavior = if (stdin_data != null) .Pipe else .Ignore;
     child.stdout_behavior = if (stdout_b == .capture) .Pipe else .Inherit;
     child.stderr_behavior = if (stderr_b == .capture) .Pipe else .Inherit;
@@ -2949,7 +2913,7 @@ fn makePopenWriteHandle(ctx: *NativeContext, command: []const u8) !*PhpObject {
     return obj;
 }
 
-fn native_popen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+pub fn native_popen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2 or args[0] != .string or args[1] != .string) return NativeResult.scalar(.{ .bool = false });
     const cmd = args[0].string.bytes();
     const mode = args[1].string.bytes();
@@ -2968,7 +2932,7 @@ fn native_popen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeRes
     return NativeResult.scalar(.{ .bool = false });
 }
 
-fn native_pclose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+pub fn native_pclose(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .int = -1 });
     const obj = args[0].object;
     const cmd_v = obj.get("__popen_cmd");
@@ -3364,12 +3328,10 @@ fn native_proc_terminate(ctx: *NativeContext, args: []const Value) RuntimeError!
 
 fn native_stream_set_blocking(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
-    const file = getFileHandle(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
-    const enable = args[1].isTruthy();
-    const O_NONBLOCK: u32 = if (@import("builtin").os.tag == .linux) 0x800 else 0x4;
-    const flags = std.posix.fcntl(file.handle, 3, 0) catch return NativeResult.scalar(.{ .bool = false });
-    const new_flags = if (enable) flags & ~@as(usize, O_NONBLOCK) else flags | O_NONBLOCK;
-    _ = std.posix.fcntl(file.handle, 4, new_flags) catch return NativeResult.scalar(.{ .bool = false });
+    const fd = args[0].object.get("__fd");
+    if (fd != .int) return NativeResult.scalar(.{ .bool = false });
+    const descriptor = platform.socketFromInt(fd.int) orelse return NativeResult.scalar(.{ .bool = false });
+    platform.setNonBlocking(descriptor, !args[1].isTruthy()) catch return NativeResult.scalar(.{ .bool = false });
     return NativeResult.scalar(.{ .bool = true });
 }
 

--- a/src/stdlib/filesystem_win.zig
+++ b/src/stdlib/filesystem_win.zig
@@ -1,7 +1,10 @@
 // the windows side of the filesystem natives that are posix calls on other
-// platforms. ownership, modes, links, and process pipes either have no
-// windows equivalent (php returns false there too) or are on the roadmap
+// platforms. ownership, modes, and links have no windows equivalent (php
+// returns false there too); processes go through proc_win.zig
 const std = @import("std");
+const platform = @import("../platform.zig");
+const filesystem = @import("filesystem.zig");
+const proc_win = @import("proc_win.zig");
 const NativeContext = @import("../runtime/vm.zig").NativeContext;
 const Value = @import("../runtime/value.zig").Value;
 const PhpArray = @import("../runtime/value.zig").PhpArray;
@@ -22,12 +25,12 @@ pub const entries = .{
     .{ "stat", native_stat },
     .{ "lstat", native_stat },
     .{ "flock", native_flock },
-    .{ "popen", unsupported },
-    .{ "pclose", unsupported },
-    .{ "proc_open", unsupported },
-    .{ "proc_close", unsupported },
-    .{ "proc_get_status", unsupported },
-    .{ "proc_terminate", unsupported },
+    .{ "popen", filesystem.native_popen },
+    .{ "pclose", filesystem.native_pclose },
+    .{ "proc_open", proc_win.native_proc_open },
+    .{ "proc_close", proc_win.native_proc_close },
+    .{ "proc_get_status", proc_win.native_proc_get_status },
+    .{ "proc_terminate", proc_win.native_proc_terminate },
     .{ "stream_set_blocking", native_stream_set_blocking },
 };
 
@@ -96,10 +99,19 @@ fn native_flock(_: *NativeContext, args: []const Value) RuntimeError!NativeResul
     }
 }
 
-// php on windows accepts the call for its own memory and temp streams and
-// refuses it for plain files; sockets wait for the serve port
+// sockets switch modes; php's own memory and temp streams accept the call;
+// a plain file refuses it, as php does on windows
 fn native_stream_set_blocking(_: *NativeContext, args: []const Value) RuntimeError!NativeResult {
     if (args.len < 2 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
-    const path = args[0].object.get("__path");
+    const obj = args[0].object;
+    const net = obj.get("__net");
+    if (net == .bool and net.bool) {
+        const fd = obj.get("__fd");
+        if (fd != .int) return NativeResult.scalar(.{ .bool = false });
+        const sock = platform.socketFromInt(fd.int) orelse return NativeResult.scalar(.{ .bool = false });
+        platform.setNonBlocking(sock, !args[1].isTruthy()) catch return NativeResult.scalar(.{ .bool = false });
+        return NativeResult.scalar(.{ .bool = true });
+    }
+    const path = obj.get("__path");
     return NativeResult.scalar(.{ .bool = path == .string and std.mem.startsWith(u8, path.string.bytes(), "php://") });
 }

--- a/src/stdlib/ftp.zig
+++ b/src/stdlib/ftp.zig
@@ -104,7 +104,7 @@ fn connectTcp(host: []const u8, port: u16, allocator: std.mem.Allocator) !posix.
     const list = try net.getAddressList(allocator, host, port);
     defer list.deinit();
     for (list.addrs) |addr| {
-        const sock = posix.socket(addr.any.family, posix.SOCK.STREAM, 0) catch continue;
+        const sock = platform.tcpSocket(addr.any.family) catch continue;
         posix.connect(sock, &addr.any, addr.getOsSockLen()) catch {
             posix.close(sock);
             continue;

--- a/src/stdlib/network.zig
+++ b/src/stdlib/network.zig
@@ -33,36 +33,44 @@ pub const entries = .{
     .{ "stream_socket_pair", native_stream_socket_pair },
 };
 
-fn streamFd(v: Value) ?std.posix.socket_t {
+fn streamFd(v: Value) ?i64 {
     if (v != .object) return null;
     const fdv = v.object.get("__fd");
     if (fdv != .int or fdv.int < 0) return null;
-    return platform.socketFromInt(fdv.int);
+    return fdv.int;
 }
 
-// stream_select(&$read, &$write, &$except, ?int $seconds, int $microseconds = 0): int|false
-// polls the underlying fds of the stream objects in each (by-ref) array and
-// rewrites each array to the ready subset, returning the number ready (false on
-// error). read=POLLIN, write=POLLOUT, except=POLLPRI. null $seconds blocks
-fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
-    var pollfds: std.ArrayListUnmanaged(std.posix.pollfd) = .{};
-    defer pollfds.deinit(ctx.allocator);
-    const Tracked = struct { slot: u8, val: Value };
-    var tracked: std.ArrayListUnmanaged(Tracked) = .{};
-    defer tracked.deinit(ctx.allocator);
+fn isNetStream(v: Value) bool {
+    const net = v.object.get("__net");
+    return net == .bool and net.bool;
+}
 
-    const want = [_]i16{ std.posix.POLL.IN, std.posix.POLL.OUT, std.posix.POLL.PRI };
-    var total_streams: usize = 0;
-    var slot: usize = 0;
-    while (slot < 3) : (slot += 1) {
-        if (slot >= args.len or args[slot] != .array) continue;
-        for (args[slot].array.entries.items) |entry| {
-            total_streams += 1;
-            const fd = streamFd(entry.value) orelse continue;
-            try pollfds.append(ctx.allocator, .{ .fd = fd, .events = want[slot], .revents = 0 });
-            try tracked.append(ctx.allocator, .{ .slot = @intCast(slot), .val = entry.value });
-        }
-    }
+const poll_events = [_]i16{ std.posix.POLL.IN, std.posix.POLL.OUT, std.posix.POLL.PRI };
+
+// one stream from one of the three select sets. sockets sit in the poll
+// list; on windows every other descriptor is a crt handle that WSAPoll
+// cannot wait on, so it is checked by hand
+const Watched = struct {
+    slot: u8,
+    val: Value,
+    fd: i64,
+    poll_index: ?usize,
+    ready: bool = false,
+};
+
+const WatchList = std.ArrayListUnmanaged(Watched);
+const PollList = std.ArrayListUnmanaged(std.posix.pollfd);
+
+// stream_select(&$read, &$write, &$except, ?int $seconds, int $microseconds = 0): int|false
+// waits on the streams in each (by-ref) array and rewrites each array to the
+// ready subset, returning the number ready (false on error). null $seconds blocks
+fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    var watched: WatchList = .{};
+    defer watched.deinit(ctx.allocator);
+    var pollfds: PollList = .{};
+    defer pollfds.deinit(ctx.allocator);
+
+    const total_streams = try watchStreams(ctx, args, &watched, &pollfds);
     if (total_streams == 0) {
         try ctx.vm.setPendingException("ValueError", "No stream arrays were passed");
         return error.RuntimeError;
@@ -73,22 +81,17 @@ fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!N
     const usec: i64 = if (args.len > 4) Value.toInt(args[4]) else 0;
     const timeout_ms: i32 = if (block) -1 else @intCast(@max(0, sec * 1000 + @divTrunc(usec, 1000)));
 
-    if (pollfds.items.len > 0) {
-        _ = std.posix.poll(pollfds.items, timeout_ms) catch return NativeResult.scalar(.{ .bool = false });
-    }
+    awaitReady(watched.items, pollfds.items, timeout_ms) catch return NativeResult.scalar(.{ .bool = false });
 
     var out = [_]?*PhpArray{ null, null, null };
     var count: i64 = 0;
-    for (pollfds.items, tracked.items) |pfd, t| {
-        const mask = want[t.slot] | std.posix.POLL.ERR | std.posix.POLL.HUP;
-        if ((pfd.revents & mask) != 0) {
-            if (out[t.slot] == null) out[t.slot] = try ctx.createArray();
-            try out[t.slot].?.append(ctx.allocator, t.val);
-            count += 1;
-        }
+    for (watched.items) |w| {
+        if (!w.ready) continue;
+        if (out[w.slot] == null) out[w.slot] = try ctx.createArray();
+        try out[w.slot].?.append(ctx.allocator, w.val);
+        count += 1;
     }
-    // rewrite each by-ref array to the ready subset (empty array if none ready)
-    slot = 0;
+    var slot: usize = 0;
     while (slot < 3) : (slot += 1) {
         if (slot >= args.len or args[slot] != .array) continue;
         const arr = out[slot] orelse try ctx.createArray();
@@ -97,34 +100,123 @@ fn native_stream_select(ctx: *NativeContext, args: []const Value) RuntimeError!N
     return NativeResult.scalar(.{ .int = count });
 }
 
-extern "c" fn socketpair(domain: c_int, sock_type: c_int, protocol: c_int, sv: *[2]c_int) c_int;
-
-// stream_socket_pair(int $domain, int $type, int $protocol): array|false
-// creates a connected pair of sockets (socketpair(2)) returned as two stream
-// objects (each with __fd) usable by fread/fwrite/stream_select/fclose
-fn native_stream_socket_pair(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
-    if (platform.is_windows) return NativeResult.scalar(.{ .bool = false });
-    return posixSocketPair(ctx, args);
+fn watchStreams(ctx: *NativeContext, args: []const Value, watched: *WatchList, pollfds: *PollList) !usize {
+    var total: usize = 0;
+    var slot: usize = 0;
+    while (slot < 3) : (slot += 1) {
+        if (slot >= args.len or args[slot] != .array) continue;
+        for (args[slot].array.entries.items) |entry| {
+            total += 1;
+            const fd = streamFd(entry.value) orelse continue;
+            var poll_index: ?usize = null;
+            if (!platform.is_windows or isNetStream(entry.value)) {
+                const sock = platform.socketFromInt(fd) orelse continue;
+                poll_index = pollfds.items.len;
+                try pollfds.append(ctx.allocator, .{ .fd = sock, .events = poll_events[slot], .revents = 0 });
+            }
+            try watched.append(ctx.allocator, .{ .slot = @intCast(slot), .val = entry.value, .fd = fd, .poll_index = poll_index });
+        }
+    }
+    return total;
 }
 
-fn posixSocketPair(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
-    const domain: c_int = if (args.len > 0) @intCast(Value.toInt(args[0])) else @intCast(std.posix.AF.UNIX);
-    const sock_type: c_int = if (args.len > 1) @intCast(Value.toInt(args[1])) else @intCast(std.posix.SOCK.STREAM);
-    const protocol: c_int = if (args.len > 2) @intCast(Value.toInt(args[2])) else 0;
-    var sv: [2]c_int = undefined;
-    if (socketpair(domain, sock_type, protocol, &sv) != 0) return NativeResult.scalar(.{ .bool = false });
+fn hasHandles(watched: []const Watched) bool {
+    for (watched) |w| if (w.poll_index == null) return true;
+    return false;
+}
+
+fn anyReady(watched: []const Watched) bool {
+    for (watched) |w| if (w.ready) return true;
+    return false;
+}
+
+// sockets wait in poll. with crt handles in the mix (windows only) the wait
+// is sliced: each slice peeks the handles, then polls or sleeps for the
+// slice, until something is ready or the timeout runs out
+fn awaitReady(watched: []Watched, pollfds: []std.posix.pollfd, timeout_ms: i32) !void {
+    if (!platform.is_windows or !hasHandles(watched)) {
+        try pollSockets(pollfds, timeout_ms);
+        markSocketsReady(watched, pollfds);
+        return;
+    }
+    const slice_ms: i32 = 10;
+    var remaining = timeout_ms;
+    while (true) {
+        const handle_ready = markHandlesReady(watched);
+        const wait_ms: i32 = if (handle_ready or remaining == 0) 0 else if (remaining < 0) slice_ms else @min(slice_ms, remaining);
+        try pollSockets(pollfds, wait_ms);
+        markSocketsReady(watched, pollfds);
+        if (anyReady(watched) or remaining == 0) return;
+        if (pollfds.len == 0) std.Thread.sleep(@as(u64, @intCast(wait_ms)) * std.time.ns_per_ms);
+        if (remaining > 0) remaining -= wait_ms;
+    }
+}
+
+fn pollSockets(pollfds: []std.posix.pollfd, timeout_ms: i32) !void {
+    if (pollfds.len == 0) return;
+    _ = std.posix.poll(pollfds, timeout_ms) catch return error.PollFailed;
+}
+
+fn markSocketsReady(watched: []Watched, pollfds: []const std.posix.pollfd) void {
+    for (watched) |*w| {
+        const idx = w.poll_index orelse continue;
+        const mask = poll_events[w.slot] | std.posix.POLL.ERR | std.posix.POLL.HUP;
+        if ((pollfds[idx].revents & mask) != 0) w.ready = true;
+    }
+}
+
+fn markHandlesReady(watched: []Watched) bool {
+    var any = false;
+    for (watched) |*w| {
+        if (w.poll_index != null) continue;
+        w.ready = switch (w.slot) {
+            0 => handleReadable(w.fd),
+            1 => true,
+            else => false,
+        };
+        if (w.ready) any = true;
+    }
+    return any;
+}
+
+const win = std.os.windows;
+const FILE_TYPE_PIPE: u32 = 3;
+extern "kernel32" fn GetFileType(handle: win.HANDLE) callconv(.winapi) u32;
+extern "kernel32" fn PeekNamedPipe(pipe: win.HANDLE, buffer: ?*anyopaque, size: u32, read: ?*u32, available: ?*u32, left: ?*u32) callconv(.winapi) win.BOOL;
+
+// a pipe is readable once bytes are pending or its writer is gone; a disk
+// file or console reads without waiting, which is what php's own select
+// emulation on windows reports
+fn handleReadable(fd: i64) bool {
+    const file = platform.fileFromFd(fd) orelse return true;
+    if (GetFileType(file.handle) != FILE_TYPE_PIPE) return true;
+    var available: u32 = 0;
+    if (PeekNamedPipe(file.handle, null, 0, null, &available, null) != 0) return available > 0;
+    return win.GetLastError() == .BROKEN_PIPE;
+}
+
+// stream_socket_pair(int $domain, int $type, int $protocol): array|false
+// a connected pair of stream sockets (a unix pair, or the loopback tcp pair
+// php itself uses on windows) returned as two net stream objects
+fn native_stream_socket_pair(ctx: *NativeContext, _: []const Value) RuntimeError!NativeResult {
+    const pair = platform.socketPair() catch return NativeResult.scalar(.{ .bool = false });
     const arr = try ctx.createArray();
-    for (sv) |fd| {
-        const obj = try ctx.allocator.create(PhpObject);
-        obj.* = .{ .class_name = "FileHandle" };
-        try ctx.vm.objects.append(ctx.allocator, obj);
-        try obj.set(ctx.allocator, "__fd", .{ .int = @intCast(fd) });
-        try obj.set(ctx.allocator, "__open", .{ .bool = true });
-        try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("r+") });
-        try obj.set(ctx.allocator, "__net", .{ .bool = true });
+    for (pair) |sock| {
+        const obj = try socketStream(ctx, sock);
         try arr.append(ctx.allocator, .{ .object = obj });
     }
     return NativeResult.borrowed(.{ .array = arr });
+}
+
+fn socketStream(ctx: *NativeContext, sock: std.posix.socket_t) !*PhpObject {
+    const obj = try ctx.allocator.create(PhpObject);
+    obj.* = .{ .class_name = "FileHandle" };
+    try ctx.vm.objects.append(ctx.allocator, obj);
+    try obj.set(ctx.allocator, "__fd", .{ .int = platform.socketToInt(sock) });
+    try obj.set(ctx.allocator, "__open", .{ .bool = true });
+    try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("r+") });
+    try obj.set(ctx.allocator, "__net", .{ .bool = true });
+    return obj;
 }
 
 fn native_stream_context_create(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
@@ -358,15 +450,8 @@ fn openTcpHandle(ctx: *NativeContext, host: []const u8, port: u16) !*PhpObject {
     const addr_list = std.net.getAddressList(ctx.allocator, host, port) catch return error.RuntimeError;
     defer addr_list.deinit();
     if (addr_list.addrs.len == 0) return error.RuntimeError;
-    const stream = std.net.tcpConnectToAddress(addr_list.addrs[0]) catch return error.RuntimeError;
-    const obj = try ctx.allocator.create(PhpObject);
-    obj.* = .{ .class_name = "FileHandle" };
-    try ctx.vm.objects.append(ctx.allocator, obj);
-    try obj.set(ctx.allocator, "__fd", .{ .int = platform.socketToInt(stream.handle) });
-    try obj.set(ctx.allocator, "__open", .{ .bool = true });
-    try obj.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed("r+") });
-    try obj.set(ctx.allocator, "__net", .{ .bool = true });
-    return obj;
+    const stream = platform.tcpConnect(addr_list.addrs[0]) catch return error.RuntimeError;
+    return socketStream(ctx, stream.handle);
 }
 
 fn native_fsockopen(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {

--- a/src/stdlib/phar_path.zig
+++ b/src/stdlib/phar_path.zig
@@ -1,0 +1,128 @@
+// phar://archive-or-alias/entry split into the archive on disk and the entry
+// inside it. the archive is the longest prefix that names a file, so phars
+// without a .phar suffix resolve, and both separators count so an archive
+// under a windows path resolves too
+const std = @import("std");
+const platform = @import("../platform.zig");
+
+pub const prefix = "phar://";
+
+pub const AliasMap = std.StringHashMapUnmanaged([]const u8);
+
+pub const Resolved = struct {
+    archive_path: []const u8,
+    internal_path: []const u8,
+};
+
+pub fn resolve(path: []const u8, aliases: ?*const AliasMap) ?Resolved {
+    if (!std.mem.startsWith(u8, path, prefix)) return null;
+    const tail = path[prefix.len..];
+    if (aliases) |map| {
+        if (resolveAlias(tail, map)) |r| return r;
+    }
+    return resolveArchive(tail);
+}
+
+fn resolveAlias(tail: []const u8, aliases: *const AliasMap) ?Resolved {
+    const sep = firstSep(tail) orelse tail.len;
+    const archive = aliases.get(tail[0..sep]) orelse return null;
+    const internal = if (sep < tail.len) tail[sep + 1 ..] else "";
+    return .{ .archive_path = archive, .internal_path = internal };
+}
+
+fn resolveArchive(tail: []const u8) ?Resolved {
+    var end = tail.len;
+    while (lastSepBefore(tail, end)) |sep| : (end = sep) {
+        if (isFile(tail[0..sep])) return .{ .archive_path = tail[0..sep], .internal_path = tail[sep + 1 ..] };
+    }
+    if (isFile(tail)) return .{ .archive_path = tail, .internal_path = "" };
+    return null;
+}
+
+fn firstSep(s: []const u8) ?usize {
+    for (s, 0..) |c, i| if (platform.isSep(c)) return i;
+    return null;
+}
+
+fn lastSepBefore(s: []const u8, end: usize) ?usize {
+    var i = end;
+    while (i > 0) : (i -= 1) if (platform.isSep(s[i - 1])) return i - 1;
+    return null;
+}
+
+fn isFile(path: []const u8) bool {
+    const stat = std.fs.cwd().statFile(path) catch return false;
+    return stat.kind == .file;
+}
+
+// entry names inside a phar always use '/', and php resolves '.' and '..'
+// against the archive root, so "lib/../data/x" and a backslash path both
+// map to their canonical entry
+pub fn normalizeInternal(a: std.mem.Allocator, internal: []const u8) ![]u8 {
+    var segments: std.ArrayListUnmanaged([]const u8) = .{};
+    defer segments.deinit(a);
+    var start: usize = 0;
+    var i: usize = 0;
+    while (i <= internal.len) : (i += 1) {
+        if (i < internal.len and !platform.isSep(internal[i])) continue;
+        try pushSegment(a, &segments, internal[start..i]);
+        start = i + 1;
+    }
+    return std.mem.join(a, "/", segments.items);
+}
+
+fn pushSegment(a: std.mem.Allocator, segments: *std.ArrayListUnmanaged([]const u8), segment: []const u8) !void {
+    if (segment.len == 0 or std.mem.eql(u8, segment, ".")) return;
+    if (std.mem.eql(u8, segment, "..")) {
+        _ = segments.pop();
+        return;
+    }
+    try segments.append(a, segment);
+}
+
+test "normalizeInternal resolves dot segments against the root" {
+    const a = std.testing.allocator;
+    const cases = [_]struct { in: []const u8, out: []const u8 }{
+        .{ .in = "lib/../data/config.json", .out = "data/config.json" },
+        .{ .in = "a/./b//c", .out = "a/b/c" },
+        .{ .in = "../../readme.md", .out = "readme.md" },
+        .{ .in = "lib/", .out = "lib" },
+        .{ .in = "", .out = "" },
+    };
+    for (cases) |case| {
+        const got = try normalizeInternal(a, case.in);
+        defer a.free(got);
+        try std.testing.expectEqualStrings(case.out, got);
+    }
+}
+
+test "resolve splits on the longest prefix that is a file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "a.phar", .data = "x" });
+    const a = std.testing.allocator;
+    const base = try tmp.dir.realpathAlloc(a, "a.phar");
+    defer a.free(base);
+    const path = try std.mem.concat(a, u8, &.{ prefix, base, "/lib/util.php" });
+    defer a.free(path);
+    const r = resolve(path, null) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(base, r.archive_path);
+    try std.testing.expectEqualStrings("lib/util.php", r.internal_path);
+    const whole = try std.mem.concat(a, u8, &.{ prefix, base });
+    defer a.free(whole);
+    const w = resolve(whole, null) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("", w.internal_path);
+    try std.testing.expect(resolve("phar:///nope/x.phar/f", null) == null);
+}
+
+test "resolve prefers a registered alias" {
+    const a = std.testing.allocator;
+    var aliases: AliasMap = .{};
+    defer aliases.deinit(a);
+    try aliases.put(a, "app", "/opt/app.phar");
+    const r = resolve("phar://app/src/main.php", &aliases) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("/opt/app.phar", r.archive_path);
+    try std.testing.expectEqualStrings("src/main.php", r.internal_path);
+    const bare = resolve("phar://app", &aliases) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("", bare.internal_path);
+}

--- a/src/stdlib/proc_win.zig
+++ b/src/stdlib/proc_win.zig
@@ -1,0 +1,503 @@
+// proc_open on windows. the descriptor spec becomes inheritable child ends
+// (CreatePipe pairs, opened files, duplicated stream handles), cmd.exe runs
+// the command through CreateProcessW, and the parent pipe ends turn into
+// crt descriptors so the FileHandle natives use them like any other stream
+const std = @import("std");
+const windows = std.os.windows;
+const kernel32 = windows.kernel32;
+const platform = @import("../platform.zig");
+const filesystem = @import("filesystem.zig");
+const vm_mod = @import("../runtime/vm.zig");
+const NativeContext = vm_mod.NativeContext;
+const ProcChild = vm_mod.ProcChild;
+const ProcPipe = vm_mod.ProcPipe;
+const value_mod = @import("../runtime/value.zig");
+const Value = value_mod.Value;
+const PhpObject = value_mod.PhpObject;
+const NativeResult = @import("../runtime/native_result.zig").NativeResult;
+const RuntimeError = error{ RuntimeError, OutOfMemory };
+
+extern "c" fn _get_osfhandle(fd: c_int) isize;
+extern "kernel32" fn PeekNamedPipe(
+    pipe: windows.HANDLE,
+    buffer: ?*anyopaque,
+    size: u32,
+    bytes_read: ?*u32,
+    available: ?*u32,
+    left: ?*u32,
+) callconv(.winapi) windows.BOOL;
+
+const terminate_exit_code: u32 = 255;
+
+const inheritable: windows.SECURITY_ATTRIBUTES = .{
+    .nLength = @sizeOf(windows.SECURITY_ATTRIBUTES),
+    .lpSecurityDescriptor = null,
+    .bInheritHandle = windows.TRUE,
+};
+
+const Spec = union(enum) {
+    pipe_r,
+    pipe_w,
+    file: struct { path: []const u8, mode: []const u8 },
+    redirect: i64,
+    blackhole,
+};
+
+const Desc = struct { role: i64, spec: Spec };
+
+// one descriptor's handles around the spawn: the child end is closed once
+// the child holds its own copy, the parent end outlives the call as a pipe
+const Slot = struct {
+    role: i64,
+    child: ?windows.HANDLE = null,
+    parent: ?windows.HANDLE = null,
+
+    fn closeAll(self: *Slot) void {
+        if (self.child) |h| windows.CloseHandle(h);
+        if (self.parent) |h| windows.CloseHandle(h);
+        self.child = null;
+        self.parent = null;
+    }
+};
+
+fn warn(ctx: *NativeContext, comptime fmt: []const u8, args: anytype) RuntimeError!void {
+    const msg = try std.fmt.allocPrint(ctx.allocator, "proc_open(): " ++ fmt, args);
+    try ctx.vm.strings.append(ctx.allocator, msg);
+    ctx.vm.emitWarning(msg);
+}
+
+fn parseSpec(ctx: *NativeContext, item: Value) RuntimeError!?Spec {
+    if (item == .object) {
+        const fdv = item.object.get("__fd");
+        if (fdv != .int or fdv.int < 0) return null;
+        return .{ .redirect = fdv.int };
+    }
+    if (item != .array) {
+        try ctx.vm.setPendingException("ValueError", "proc_open(): Argument #2 ($descriptor_spec) must only contain arrays and streams");
+        return error.RuntimeError;
+    }
+    const tag = item.array.get(.{ .int = 0 });
+    if (tag != .string) return null;
+    const kind = tag.string.bytes();
+    if (std.mem.eql(u8, kind, "pipe")) {
+        const mode = item.array.get(.{ .int = 1 });
+        const reads = mode == .string and mode.string.bytes().len > 0 and mode.string.bytes()[0] == 'r';
+        return if (reads) .pipe_r else .pipe_w;
+    }
+    if (std.mem.eql(u8, kind, "file")) {
+        const path = item.array.get(.{ .int = 1 });
+        const mode = item.array.get(.{ .int = 2 });
+        if (path != .string or mode != .string) return null;
+        return .{ .file = .{ .path = path.string.bytes(), .mode = mode.string.bytes() } };
+    }
+    if (std.mem.eql(u8, kind, "null")) return .blackhole;
+    if (std.mem.eql(u8, kind, "pty")) {
+        try warn(ctx, "PTY (pseudoterminal) not supported on this system", .{});
+        return error.RuntimeError;
+    }
+    if (std.mem.eql(u8, kind, "socket")) {
+        try warn(ctx, "socket descriptors are not supported on Windows", .{});
+        return error.RuntimeError;
+    }
+    try warn(ctx, "{s} is not a valid descriptor spec/mode", .{kind});
+    return error.RuntimeError;
+}
+
+fn parseDescriptors(ctx: *NativeContext, spec: Value, out: *std.ArrayListUnmanaged(Desc)) RuntimeError!void {
+    if (spec != .array) return;
+    for (spec.array.entries.items) |entry| {
+        if (entry.key != .int or entry.key.int < 0) continue;
+        const parsed = try parseSpec(ctx, entry.value) orelse continue;
+        try out.append(ctx.allocator, .{ .role = entry.key.int, .spec = parsed });
+    }
+}
+
+fn setInherit(handle: windows.HANDLE, inherit: bool) !void {
+    const flag: u32 = if (inherit) windows.HANDLE_FLAG_INHERIT else 0;
+    if (kernel32.SetHandleInformation(handle, windows.HANDLE_FLAG_INHERIT, flag) == 0) return error.ProcSpawnFailed;
+}
+
+fn makePipe(slot: *Slot, child_reads: bool) !void {
+    var rd: windows.HANDLE = undefined;
+    var wr: windows.HANDLE = undefined;
+    windows.CreatePipe(&rd, &wr, &inheritable) catch return error.ProcSpawnFailed;
+    slot.child = if (child_reads) rd else wr;
+    slot.parent = if (child_reads) wr else rd;
+    try setInherit(slot.parent.?, false);
+}
+
+fn duplicateInheritable(source: windows.HANDLE) !windows.HANDLE {
+    const me = kernel32.GetCurrentProcess();
+    var dup: windows.HANDLE = undefined;
+    if (kernel32.DuplicateHandle(me, source, me, &dup, 0, windows.TRUE, windows.DUPLICATE_SAME_ACCESS) == 0) return error.ProcSpawnFailed;
+    return dup;
+}
+
+fn openBlackhole() !windows.HANDLE {
+    const nul = std.unicode.utf8ToUtf16LeStringLiteral("nul");
+    const handle = kernel32.CreateFileW(
+        nul,
+        windows.GENERIC_READ | windows.GENERIC_WRITE,
+        windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE,
+        @constCast(&inheritable),
+        windows.OPEN_EXISTING,
+        0,
+        null,
+    );
+    if (handle == windows.INVALID_HANDLE_VALUE) return error.ProcSpawnFailed;
+    return handle;
+}
+
+fn prepareSlot(slot: *Slot, spec: Spec) !void {
+    switch (spec) {
+        .pipe_r => try makePipe(slot, true),
+        .pipe_w => try makePipe(slot, false),
+        .file => |f| {
+            const file = try filesystem.openWithMode(f.path, f.mode);
+            slot.child = file.handle;
+            try setInherit(file.handle, true);
+        },
+        .redirect => |fd| {
+            const raw = _get_osfhandle(@intCast(fd));
+            if (raw == -1 or raw == -2) return error.ProcSpawnFailed;
+            slot.child = try duplicateInheritable(@ptrFromInt(@as(usize, @intCast(raw))));
+        },
+        .blackhole => slot.child = try openBlackhole(),
+    }
+}
+
+fn stdHandle(id: u32) ?windows.HANDLE {
+    return windows.GetStdHandle(id) catch null;
+}
+
+fn startupInfo(slots: []const Slot) windows.STARTUPINFOW {
+    var si: windows.STARTUPINFOW = std.mem.zeroes(windows.STARTUPINFOW);
+    si.cb = @sizeOf(windows.STARTUPINFOW);
+    si.dwFlags = windows.STARTF_USESTDHANDLES;
+    si.hStdInput = stdHandle(windows.STD_INPUT_HANDLE);
+    si.hStdOutput = stdHandle(windows.STD_OUTPUT_HANDLE);
+    si.hStdError = stdHandle(windows.STD_ERROR_HANDLE);
+    for (slots) |slot| switch (slot.role) {
+        0 => si.hStdInput = slot.child,
+        1 => si.hStdOutput = slot.child,
+        2 => si.hStdError = slot.child,
+        else => {},
+    };
+    return si;
+}
+
+// php's windows build hands the command to cmd.exe as `/s /c "<command>"`
+// so cmd strips exactly the outer quotes and runs the rest verbatim
+fn commandLine(allocator: std.mem.Allocator, command: []const u8) ![:0]u16 {
+    const argv = platform.shellArgv(command);
+    const joined = try std.fmt.allocPrint(allocator, "{s} /s {s} \"{s}\"", .{ argv[0], argv[1], command });
+    defer allocator.free(joined);
+    return std.unicode.wtf8ToWtf16LeAllocZ(allocator, joined);
+}
+
+fn appendEnvString(allocator: std.mem.Allocator, block: *std.ArrayListUnmanaged(u16), text: []const u8) !void {
+    const wide = try std.unicode.wtf8ToWtf16LeAlloc(allocator, text);
+    defer allocator.free(wide);
+    try block.appendSlice(allocator, wide);
+}
+
+fn envValueText(allocator: std.mem.Allocator, v: Value) !?[]const u8 {
+    return switch (v) {
+        .string => |s| try allocator.dupe(u8, s.bytes()),
+        .int => |i| try std.fmt.allocPrint(allocator, "{d}", .{i}),
+        .float => |f| try std.fmt.allocPrint(allocator, "{d}", .{f}),
+        .bool => |b| try allocator.dupe(u8, if (b) "1" else ""),
+        .null => try allocator.dupe(u8, ""),
+        else => null,
+    };
+}
+
+// a unicode environment block: NUL-separated `name=value` strings with a
+// second NUL at the end, which an empty block still needs
+fn envBlock(allocator: std.mem.Allocator, env: Value) !?[]u16 {
+    if (env != .array) return null;
+    var block: std.ArrayListUnmanaged(u16) = .{};
+    errdefer block.deinit(allocator);
+    for (env.array.entries.items) |entry| {
+        const text = try envValueText(allocator, entry.value) orelse continue;
+        defer allocator.free(text);
+        switch (entry.key) {
+            .string => |k| try appendEnvString(allocator, &block, k.bytes()),
+            .int => |k| {
+                const key = try std.fmt.allocPrint(allocator, "{d}", .{k});
+                defer allocator.free(key);
+                try appendEnvString(allocator, &block, key);
+            },
+        }
+        try block.append(allocator, '=');
+        try appendEnvString(allocator, &block, text);
+        try block.append(allocator, 0);
+    }
+    try block.append(allocator, 0);
+    if (block.items.len == 1) try block.append(allocator, 0);
+    return try block.toOwnedSlice(allocator);
+}
+
+const Spawned = struct {
+    process: windows.HANDLE,
+    pid: u32,
+    pipes: std.ArrayListUnmanaged(ProcPipe),
+};
+
+const SpawnOptions = struct {
+    command: []const u8,
+    descs: []const Desc,
+    cwd: ?[]const u8,
+    env: Value,
+};
+
+fn createProcess(allocator: std.mem.Allocator, opts: SpawnOptions, slots: []Slot) !windows.PROCESS_INFORMATION {
+    const cmdline = try commandLine(allocator, opts.command);
+    defer allocator.free(cmdline);
+    const env = try envBlock(allocator, opts.env);
+    defer if (env) |e| allocator.free(e);
+    const cwd_w: ?[:0]u16 = if (opts.cwd) |dir| try std.unicode.wtf8ToWtf16LeAllocZ(allocator, dir) else null;
+    defer if (cwd_w) |w| allocator.free(w);
+
+    var si = startupInfo(slots);
+    var pi: windows.PROCESS_INFORMATION = undefined;
+    const flags: windows.CreateProcessFlags = .{
+        .normal_priority_class = true,
+        .create_unicode_environment = env != null,
+    };
+    const ok = kernel32.CreateProcessW(
+        null,
+        cmdline.ptr,
+        null,
+        null,
+        windows.TRUE,
+        flags,
+        if (env) |e| @ptrCast(e.ptr) else null,
+        if (cwd_w) |w| w.ptr else null,
+        &si,
+        &pi,
+    );
+    if (ok == 0) return error.ProcSpawnFailed;
+    return pi;
+}
+
+fn spawn(allocator: std.mem.Allocator, opts: SpawnOptions) !Spawned {
+    const slots = try allocator.alloc(Slot, opts.descs.len);
+    defer allocator.free(slots);
+    for (opts.descs, 0..) |desc, i| slots[i] = .{ .role = desc.role };
+    errdefer for (slots) |*slot| slot.closeAll();
+    for (opts.descs, 0..) |desc, i| try prepareSlot(&slots[i], desc.spec);
+
+    const pi = try createProcess(allocator, opts, slots);
+    windows.CloseHandle(pi.hThread);
+    for (slots) |*slot| if (slot.child) |h| {
+        windows.CloseHandle(h);
+        slot.child = null;
+    };
+
+    var pipes: std.ArrayListUnmanaged(ProcPipe) = .{};
+    errdefer pipes.deinit(allocator);
+    for (slots) |*slot| if (slot.parent) |h| {
+        try pipes.append(allocator, .{ .role = slot.role, .fd = @intCast(platform.fdFromFile(.{ .handle = h })) });
+        slot.parent = null;
+    };
+    return .{ .process = pi.hProcess, .pid = pi.dwProcessId, .pipes = pipes };
+}
+
+fn flushInheritedOutput(ctx: *NativeContext, descs: []const Desc) void {
+    var stdout_owned = false;
+    var stderr_owned = false;
+    for (descs) |desc| {
+        if (desc.role == 1) stdout_owned = true;
+        if (desc.role == 2) stderr_owned = true;
+    }
+    if (stdout_owned and stderr_owned) return;
+    if (ctx.vm.output.items.len == 0) return;
+    platform.writeStdout(ctx.vm.output.items);
+    ctx.vm.output.clearRetainingCapacity();
+}
+
+fn pipeMode(spec: Spec) ?[]const u8 {
+    return switch (spec) {
+        .pipe_r => "w",
+        .pipe_w => "r",
+        else => null,
+    };
+}
+
+fn pipeFd(pipes: []const ProcPipe, role: i64) ?platform.Fd {
+    for (pipes) |pipe| if (pipe.role == role) return pipe.fd;
+    return null;
+}
+
+fn makePipeHandle(ctx: *NativeContext, proc: *PhpObject, role: i64, fd: platform.Fd, mode: []const u8) RuntimeError!*PhpObject {
+    const handle = try ctx.createObject("FileHandle");
+    try handle.set(ctx.allocator, "__open", .{ .bool = true });
+    try handle.set(ctx.allocator, "__mode", .{ .string = Value.String.borrowed(mode) });
+    try handle.set(ctx.allocator, "__fd", .{ .int = @intCast(fd) });
+    try handle.set(ctx.allocator, "__proc_ref", .{ .object = proc });
+    try handle.set(ctx.allocator, "__proc_role", .{ .int = role });
+    return handle;
+}
+
+fn buildPipesArray(ctx: *NativeContext, proc: *PhpObject, descs: []const Desc, pipes: []const ProcPipe) RuntimeError!Value {
+    const arr = try ctx.createArray();
+    for (descs) |desc| {
+        const mode = pipeMode(desc.spec) orelse continue;
+        const fd = pipeFd(pipes, desc.role) orelse continue;
+        const handle = try makePipeHandle(ctx, proc, desc.role, fd, mode);
+        try arr.set(ctx.allocator, .{ .int = desc.role }, .{ .object = handle });
+    }
+    return .{ .array = arr };
+}
+
+fn markSpawnFailed(ctx: *NativeContext, proc: *PhpObject) RuntimeError!void {
+    try proc.set(ctx.allocator, "__pid", .{ .int = 0 });
+    try proc.set(ctx.allocator, "__reaped", .{ .bool = true });
+    try proc.set(ctx.allocator, "__running", .{ .bool = false });
+    try proc.set(ctx.allocator, "__exit", .{ .int = -1 });
+}
+
+pub fn native_proc_open(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len < 3 or args[0] != .string) return NativeResult.scalar(.{ .bool = false });
+    const cmd_copy = try ctx.vm.allocator.dupe(u8, args[0].string.bytes());
+    try ctx.vm.strings.append(ctx.allocator, cmd_copy);
+
+    const proc = try ctx.createObject("ProcessResource");
+    try proc.set(ctx.allocator, "__cmd", .{ .string = Value.String.borrowed(cmd_copy) });
+    try proc.set(ctx.allocator, "__exit", .{ .int = 0 });
+    try proc.set(ctx.allocator, "__running", .{ .bool = true });
+
+    var descs: std.ArrayListUnmanaged(Desc) = .{};
+    defer descs.deinit(ctx.allocator);
+    parseDescriptors(ctx, args[1], &descs) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        if (ctx.vm.pending_exception != null) return err;
+        return NativeResult.scalar(.{ .bool = false });
+    };
+    flushInheritedOutput(ctx, descs.items);
+
+    const opts: SpawnOptions = .{
+        .command = cmd_copy,
+        .descs = descs.items,
+        .cwd = if (args.len >= 4 and args[3] == .string) args[3].string.bytes() else null,
+        .env = if (args.len >= 5) args[4] else .null,
+    };
+    const spawned = spawn(ctx.vm.allocator, opts) catch |err| {
+        const code = @intFromEnum(windows.GetLastError());
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        try markSpawnFailed(ctx, proc);
+        try warn(ctx, "CreateProcess failed: error code {d}", .{code});
+        return NativeResult.scalar(.{ .bool = false });
+    };
+    try ctx.vm.registerProcChild(proc, @intCast(spawned.pid), spawned.pipes);
+    ctx.vm.lookupProcChild(proc).?.process = @intFromPtr(spawned.process);
+    try proc.set(ctx.allocator, "__pid", .{ .int = @intCast(spawned.pid) });
+    try proc.set(ctx.allocator, "__reaped", .{ .bool = false });
+
+    const pipes = try buildPipesArray(ctx, proc, descs.items, spawned.pipes.items);
+    ctx.setCallerVar(2, args.len, pipes);
+    return NativeResult.borrowed(.{ .object = proc });
+}
+
+fn processHandle(pc: *const ProcChild) ?windows.HANDLE {
+    if (pc.process == 0) return null;
+    return @ptrFromInt(pc.process);
+}
+
+fn exitCodeOf(handle: windows.HANDLE) i64 {
+    var code: u32 = 0;
+    if (kernel32.GetExitCodeProcess(handle, &code) == 0) return -1;
+    return @intCast(code);
+}
+
+// the exit code once the process has ended, null while it still runs
+fn pollExit(handle: windows.HANDLE) ?i64 {
+    if (kernel32.WaitForSingleObject(handle, 0) != windows.WAIT_OBJECT_0) return null;
+    return exitCodeOf(handle);
+}
+
+fn waitExit(handle: windows.HANDLE) i64 {
+    _ = kernel32.WaitForSingleObject(handle, windows.INFINITE);
+    return exitCodeOf(handle);
+}
+
+fn cacheExit(ctx: *NativeContext, proc: *PhpObject, pc: *ProcChild, code: i64) void {
+    pc.reaped = true;
+    proc.set(ctx.allocator, "__reaped", .{ .bool = true }) catch {};
+    proc.set(ctx.allocator, "__running", .{ .bool = false }) catch {};
+    proc.set(ctx.allocator, "__exit", .{ .int = code }) catch {};
+}
+
+fn closePipe(pipe: *ProcPipe) void {
+    if (pipe.fd == -1) return;
+    platform.closeFd(pipe.fd);
+    pipe.fd = -1;
+}
+
+fn cachedExit(proc: *PhpObject) i64 {
+    const exit = proc.get("__exit");
+    return if (exit == .int) exit.int else 0;
+}
+
+pub fn native_proc_close(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .int = -1 });
+    const proc = args[0].object;
+    const pc = ctx.vm.lookupProcChild(proc) orelse return NativeResult.scalar(.{ .int = cachedExit(proc) });
+    for (pc.pipe_fds.items) |*pipe| if (pipe.role == 0) closePipe(pipe);
+    if (processHandle(pc)) |handle| {
+        if (!pc.reaped) cacheExit(ctx, proc, pc, waitExit(handle));
+        windows.CloseHandle(handle);
+        pc.process = 0;
+    }
+    for (pc.pipe_fds.items) |*pipe| closePipe(pipe);
+    pc.pipe_fds.deinit(ctx.allocator);
+    ctx.vm.removeProcChild(proc);
+    return NativeResult.scalar(.{ .int = cachedExit(proc) });
+}
+
+pub fn native_proc_get_status(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const proc = args[0].object;
+    var running = false;
+    if (ctx.vm.lookupProcChild(proc)) |pc| {
+        if (!pc.reaped) {
+            if (processHandle(pc)) |handle| {
+                if (pollExit(handle)) |code| cacheExit(ctx, proc, pc, code) else running = true;
+            }
+        }
+    }
+    const result = try ctx.createArray();
+    const cmd = proc.get("__cmd");
+    const pid = proc.get("__pid");
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("command") }, if (cmd == .string) cmd else .{ .string = Value.String.borrowed("") });
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("pid") }, if (pid == .int) pid else .{ .int = 0 });
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("running") }, .{ .bool = running });
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("signaled") }, .{ .bool = false });
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("stopped") }, .{ .bool = false });
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("exitcode") }, .{ .int = if (running) -1 else cachedExit(proc) });
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("termsig") }, .{ .int = 0 });
+    try result.set(ctx.allocator, .{ .string = Value.String.borrowed("stopsig") }, .{ .int = 0 });
+    return NativeResult.borrowed(.{ .array = result });
+}
+
+// php's windows build ignores the signal argument and always ends the
+// process with exit code 255
+pub fn native_proc_terminate(ctx: *NativeContext, args: []const Value) RuntimeError!NativeResult {
+    if (args.len == 0 or args[0] != .object) return NativeResult.scalar(.{ .bool = false });
+    const pc = ctx.vm.lookupProcChild(args[0].object) orelse return NativeResult.scalar(.{ .bool = false });
+    const handle = processHandle(pc) orelse return NativeResult.scalar(.{ .bool = false });
+    return NativeResult.scalar(.{ .bool = kernel32.TerminateProcess(handle, terminate_exit_code) != 0 });
+}
+
+// whether a read on the crt descriptor would return without blocking: data
+// is waiting, the writer has gone away, or the handle is not a pipe at all
+pub fn pipeReadable(fd: i64) bool {
+    if (fd < 0) return true;
+    const raw = _get_osfhandle(@intCast(fd));
+    if (raw == -1 or raw == -2) return true;
+    const handle: windows.HANDLE = @ptrFromInt(@as(usize, @intCast(raw)));
+    var available: u32 = 0;
+    if (PeekNamedPipe(handle, null, 0, null, &available, null) == 0) return true;
+    return available > 0;
+}

--- a/src/stdlib/websocket.zig
+++ b/src/stdlib/websocket.zig
@@ -30,12 +30,12 @@ fn getThis(ctx: *NativeContext) ?*PhpObject {
 }
 
 const WsWriter = struct {
-    fd: std.posix.fd_t,
+    fd: std.posix.socket_t,
     ssl: ?*tls.SSL,
 
     pub fn write(self: WsWriter, data: []const u8) !usize {
         if (self.ssl) |s| return tls.write(s, data);
-        return std.posix.write(self.fd, data);
+        return platform.send(self.fd, data);
     }
 };
 

--- a/src/tls.zig
+++ b/src/tls.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const posix = std.posix;
+const platform = @import("platform.zig");
 
 const c = @cImport({
     @cInclude("openssl/ssl.h");
@@ -74,9 +74,9 @@ pub fn freeContext(ctx: *SSL_CTX) void {
 
 pub const HandshakeResult = enum { complete, want_read, want_write, failed };
 
-pub fn beginAccept(ctx: *SSL_CTX, fd: posix.fd_t) ?*SSL {
+pub fn beginAccept(ctx: *SSL_CTX, fd: std.posix.socket_t) ?*SSL {
     const ssl = c.SSL_new(ctx) orelse return null;
-    if (c.SSL_set_fd(ssl, fd) != 1) {
+    if (c.SSL_set_fd(ssl, @intCast(platform.socketToInt(fd))) != 1) {
         c.SSL_free(ssl);
         return null;
     }

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -221,19 +221,9 @@ test "accept key computation" {
     try std.testing.expectEqualStrings("7PUt+8lkGD5HVZbKJuYuOJV1CNA=", result);
 }
 
-// test scaffolding: a connected local pair. windows has no socketpair, and
-// the tests that need one skip there
 fn makeSocketPair() ![2]std.net.Stream {
-    if (@import("platform.zig").is_windows) {
-        return error.SkipZigTest;
-    } else {
-        var fds: [2]std.posix.fd_t = undefined;
-        if (std.c.socketpair(std.posix.AF.UNIX, std.posix.SOCK.STREAM, 0, &fds) != 0) return error.IoError;
-        return .{
-            std.net.Stream{ .handle = fds[0] },
-            std.net.Stream{ .handle = fds[1] },
-        };
-    }
+    const pair = try @import("platform.zig").socketPair();
+    return .{ std.net.Stream{ .handle = pair[0] }, std.net.Stream{ .handle = pair[1] } };
 }
 
 fn writeMaskedFrame(stream: std.net.Stream, opcode: Opcode, payload: []const u8) !void {

--- a/tests/serve_test
+++ b/tests/serve_test
@@ -274,7 +274,8 @@ fi
 
 # --- TLS tests ---
 TLS_PORT=19877
-openssl req -x509 -newkey rsa:2048 -keyout /tmp/zphp_test.key -out /tmp/zphp_test.crt -days 1 -nodes -subj "/CN=localhost" 2>/dev/null
+# msys2 would rewrite the subject as a path without the exclusion
+MSYS2_ARG_CONV_EXCL="/CN" openssl req -x509 -newkey rsa:2048 -keyout /tmp/zphp_test.key -out /tmp/zphp_test.crt -days 1 -nodes -subj "/CN=localhost" 2>/dev/null
 
 "$ZPHP" serve "$APP" --port $TLS_PORT --workers 2 --tls-cert /tmp/zphp_test.crt --tls-key /tmp/zphp_test.key &
 TLS_PID=$!
@@ -450,13 +451,15 @@ rm -f /tmp/zphp_test.key /tmp/zphp_test.crt
 FAIL_PORT="${CURL_FAIL_PORT:-$((PORT + 25))}"
 READY_FILE=$(mktemp /tmp/zphp_fail_server.XXXXXX)
 rm -f "$READY_FILE"
+# python is a native program under msys2 and needs the windows spelling
+READY_NATIVE=$(command -v cygpath >/dev/null 2>&1 && cygpath -m "$READY_FILE" || echo "$READY_FILE")
 python3 -c "
 import socket
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.bind(('127.0.0.1', $FAIL_PORT))
 s.listen(1)
-with open('$READY_FILE', 'w') as f:
+with open('$READY_NATIVE', 'w') as f:
     f.write('ready')
 while True:
     try:
@@ -562,7 +565,7 @@ except OSError:
 PY
 )
 check "stalled connection closed by idle timeout" "closed" "$idle_result"
-kill $IDLE_PID 2>/dev/null; wait $IDLE_PID 2>/dev/null
+kill $IDLE_PID 2>/dev/null; wait $IDLE_PID 2>/dev/null || true
 
 # test: graceful shutdown
 kill -TERM $SERVER_PID

--- a/tests/windows-skip.txt
+++ b/tests/windows-skip.txt
@@ -1,8 +1,6 @@
-proc_open_live.php: proc_open is not on windows yet
-proc_get_status_running.php: proc_open is not on windows yet
-proc_open_stream_select.php: proc_open is not on windows yet
-shell_exec_proc_open_basic.php: proc_open is not on windows yet
-stream_select.php: stream_socket_pair is not on windows yet
+proc_get_status_running.php: cmd.exe does not treat ; as a command separator, so `sleep 1; exit 5` exits at once and the liveness poll races in php too
+proc_open_stream_select.php: cmd.exe does not treat ; as a command separator, so the child never sleeps between the two lines
+shell_exec_proc_open_basic.php: the test writes under a literal /tmp through the shell, which msys resolves to its own root and file_get_contents to the drive root
 libxml_collect_errors.php: mingw libxml2 reports one error fewer than the linux build
 missing_constants.php: the runner's php has no sockets extension, so it lacks AF_INET and friends
 strncmp_byte_difference.php: msvcrt memcmp returns -1/1 where glibc returns the byte difference
@@ -20,11 +18,9 @@ soap_server.php: the runner's php has no soap extension
 posix.php: neither php nor zphp has the posix extension on windows; the fatal error lines differ
 pcntl_sigprocmask.php: php reports the missing function before evaluating its arguments, zphp the missing constant
 stream_set_blocking.php: the runner's php fails the test itself on windows
-stream_socket_pair.php: stream_socket_pair is not on windows yet
-proc_open_descriptors.php: proc_open is not on windows yet
+proc_open_descriptors.php: descriptors above 2, socket and pty specs, pwd and test -t are not available to php on windows either
 process_resource_long_running.php: 10000 process spawns exceed the 60 second bound on the runner
 require_global_scope_live.php: the test interpolates a backslash-t from the windows temp path
 pdo_prepared_bindings_fetchall_modes.php: php on windows cannot unlink a sqlite file it still holds open
 pdo_sqlite_query_prepare_txn.php: php on windows cannot unlink a sqlite file it still holds open
-phar_streams.php: phar archives under a windows temp path do not resolve yet; tracked for the serve port
-phar_streams_gz.php: phar archives under a windows temp path do not resolve yet; tracked for the serve port
+stream_socket_pair.php: the runner's php fails stream_socket_pair(STREAM_PF_UNIX) itself on windows (setsockopt 10042); zphp's pair works


### PR DESCRIPTION
Second of the three Windows PRs. `zphp serve` now runs on Windows with HTTP/1.1, keep-alive, static files, uploads, sessions, TLS, HTTP/2, WebSocket and WSS, and the `windows` CI job runs the full serve harness (129 checks) after the compat suite.

Serve's self-pipe wakeups became connected socket pairs so WSAPoll can wait on them next to the connections, `SIGINT`/`SIGTERM` handling became a console control handler on Windows, upload temp files go under the Windows temp directory, and umask handling is a no-op there. Every TCP socket is now created through one place that asks Winsock for a synchronous socket: the overlapped sockets Zig's standard library creates fail `ReadFile` with error 87, which is what `std.fs.File` and `std.net.Stream` use on Windows.

`proc_open`, `proc_close`, `proc_get_status`, and `proc_terminate` spawn through `CreateProcessW` using the same `cmd.exe /s /c` form php-src uses, with pipe, file, stream, and null descriptors for fds 0 to 2; `pty` and `socket` descriptors are refused with PHP's warnings. `popen` and `pclose` reuse the existing child-process path. `stream_socket_pair` returns the loopback pair PHP itself emulates on Windows, `stream_select` peeks pipes with `PeekNamedPipe`, and `stream_set_blocking` works on sockets. `phar://` paths now resolve through one parser that accepts both separators, so archives under a Windows temp directory work.

Three harness details surfaced on the Windows runner and are fixed in `tests/serve_test`: MSYS2 rewrote the certificate subject as a path, the native Python mock server needed a Windows path for its ready file, and a `wait` after killing the idle-timeout server lacked `|| true` under `set -e`. Seven more compat tests run on Windows now; the remaining skips list their reasons.