### PR TITLE
Ship a Windows x86_64 release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,8 +187,105 @@ jobs:
             zphp-${{ matrix.name }}
             zphp-${{ matrix.name }}.libs.txt
 
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          path-type: inherit
+          update: true
+          install: >-
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-pcre2
+            mingw-w64-x86_64-sqlite3
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-libmariadbclient
+            mingw-w64-x86_64-postgresql
+            mingw-w64-x86_64-openssl
+            mingw-w64-x86_64-nghttp2
+            mingw-w64-x86_64-curl
+            mingw-w64-x86_64-libxml2
+            mingw-w64-x86_64-icu
+            mingw-w64-x86_64-gmp
+            mingw-w64-x86_64-libgd
+            mingw-w64-x86_64-libsodium
+            mingw-w64-x86_64-openldap
+            zip
+            unzip
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.1
+
+      - name: build
+        run: zig build -Doptimize=ReleaseFast
+
+      # the exe links the mingw dlls dynamically; ldd resolves the whole
+      # closure, and everything it finds under /mingw64 ships next to the exe
+      - name: package
+        run: |
+          set -euo pipefail
+          dir=zphp-windows-x86_64
+          mkdir -p "$dir"
+          cp zig-out/bin/zphp.exe "$dir/zphp.exe"
+          ldd zig-out/bin/zphp.exe | awk '/=> \/mingw64\//{print $3}' | sort -u | while read -r dll; do
+            cp "$dll" "$dir/"
+          done
+          ls "$dir"
+
+      # PATH without /mingw64/bin: only the bundled dlls can satisfy the exe
+      - name: smoke test packaged binary
+        run: |
+          set -euo pipefail
+          unset OPENSSL_CONF
+          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '/mingw64/bin' | paste -sd:)
+          ./zphp-windows-x86_64/zphp.exe version
+          ./zphp-windows-x86_64/zphp.exe run .github/scripts/release_smoke.php
+
+      - name: record linked libraries
+        run: |
+          {
+            echo "zphp-windows-x86_64 built on windows-latest with zig 0.15.1 and msys2 mingw-w64"
+            echo
+            ldd zig-out/bin/zphp.exe
+            echo
+            pacman -Q | grep -E '^mingw-w64-x86_64-(gcc-libs|libwinpthread|pcre2|sqlite3|zlib|libmariadbclient|postgresql|openssl|nghttp2|curl|libxml2|icu|gmp|libgd|libsodium|openldap|libpng|libjpeg|freetype|libtiff|libwebp|libiconv|gettext|xz|zstd|brotli|libpsl|libidn2|libunistring|libssh2|c-ares|bzip2|libavif|libheif|libimagequant|libxpm|expat|readline|termcap|libtasn1|p11-kit|ca-certificates|libffi|libsystre|libtre|cyrus-sasl|krb5|libwebp|libdeflate|jbigkit|lerc|zlib)' || true
+          } > zphp-windows-x86_64.libs.txt
+          cat zphp-windows-x86_64.libs.txt
+
+      - name: zip
+        run: zip -r zphp-windows-x86_64.zip zphp-windows-x86_64
+
+      # the zip is what ships: unpack it somewhere else and run those bytes
+      - name: execute packaged zip
+        run: |
+          set -euo pipefail
+          unset OPENSSL_CONF
+          export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '/mingw64/bin' | paste -sd:)
+          rm -rf /tmp/zphp-zip && mkdir -p /tmp/zphp-zip
+          unzip -q zphp-windows-x86_64.zip -d /tmp/zphp-zip
+          /tmp/zphp-zip/zphp-windows-x86_64/zphp.exe version
+          /tmp/zphp-zip/zphp-windows-x86_64/zphp.exe run .github/scripts/release_smoke.php
+
+      - uses: actions/attest-build-provenance@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          subject-path: zphp-windows-x86_64.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zphp-windows-x86_64
+          path: |
+            zphp-windows-x86_64.zip
+            zphp-windows-x86_64.libs.txt
+
   release:
-    needs: build
+    needs: [build, windows]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     steps:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Download builds from [GitHub Releases](https://github.com/nvms/zphp/releases).
 | `zphp-linux-x86_64` | Ubuntu 24.04 x86_64 | Links the system libraries listed in the matching `.libs.txt`. |
 | `zphp-linux-aarch64` | Ubuntu 24.04 aarch64 | Links the system libraries listed in the matching `.libs.txt`. |
 | `zphp-macos-aarch64` | macOS 15 or newer, Apple Silicon | Links Homebrew libraries listed in the matching `.libs.txt`. |
+| `zphp-windows-x86_64.zip` | Windows 10 or newer, x86_64 | `zphp.exe` with the mingw-w64 DLLs it needs in the same folder, listed in the matching `.libs.txt`. |
 
-The glibc and macOS builds run on the platform they were made for; the musl builds run anywhere, and for anything else, build from source. Every release ships a `SHA256SUMS` file, a `.libs.txt` per binary naming the native libraries it was linked against, and a build provenance attestation you can check with `gh attestation verify zphp-<platform> --repo nvms/zphp`.
+The glibc, macOS, and Windows builds run on the platform they were made for; the musl builds run on any Linux, and for anything else, build from source. Every release ships a `SHA256SUMS` file, a `.libs.txt` per binary naming the native libraries it was linked against, and a build provenance attestation you can check with `gh attestation verify zphp-<platform> --repo nvms/zphp`.
 
 See the [documentation](https://nvms.github.io/zphp/) for build instructions and usage guides.
 


### PR DESCRIPTION
Third and last of the Windows PRs. The release workflow gains a `windows` job that builds a ReleaseFast `zphp.exe` under MSYS2, resolves the DLL closure with `ldd`, copies every DLL found under `/mingw64` next to the exe, and packages the folder as `zphp-windows-x86_64.zip`. The smoke test runs with the MSYS2 bin directory removed from PATH, so only the bundled DLLs can satisfy the exe, and the zip is unpacked in another directory and executed once more before upload. The zip is attested and listed in `SHA256SUMS` like the other artifacts, and the matching `.libs.txt` records the `ldd` output and the mingw package versions.

The archive is about 49 MiB across 68 DLLs; libgd's image codec dependencies account for most of it. The README lists the new artifact.