### PR TITLE
validate digits in numeric string exponent

### DIFF
--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -1348,7 +1348,9 @@ pub const Value = union(enum) {
         if (i < s.len and (s[i] == 'e' or s[i] == 'E')) {
             i += 1;
             if (i < s.len and (s[i] == '-' or s[i] == '+')) i += 1;
+            const exponent_start = i;
             while (i < s.len and s[i] >= '0' and s[i] <= '9') i += 1;
+            if (i == exponent_start) return false;
         }
         while (i < s.len and (s[i] == ' ' or s[i] == '\t' or s[i] == '\n' or s[i] == '\r')) i += 1;
         return has_digit and i == s.len;
@@ -1955,6 +1957,22 @@ pub const Value = union(enum) {
         return .{ .int_kind = n };
     }
 };
+
+test "numeric string exponent requires digits" {
+    const invalid = [_][]const u8{
+        "0e", "1e", "1e+", "1e-", "1E", "1E-", " 1e ", "-1e+\t", "1e+ 2",
+    };
+    for (invalid) |s| {
+        try std.testing.expect(!Value.isNumericString(s));
+    }
+
+    const valid = [_][]const u8{
+        "1", "1.5", "1e2", "1E+2", "1e-2", " +1E+2\t", "-1e-2\r\n",
+    };
+    for (valid) |s| {
+        try std.testing.expect(Value.isNumericString(s));
+    }
+}
 
 test "truthiness" {
     try std.testing.expect(!Value.isTruthy(.null));

--- a/tests/numeric_string_exponent.php
+++ b/tests/numeric_string_exponent.php
@@ -1,0 +1,32 @@
+<?php
+// an exponent marker must have at least one exponent digit,
+// every false result below distinguishes php from the current Value.isNumericString path
+var_dump("0e" == 0);
+var_dump("1e" == 1);
+var_dump("1e+" == 1);
+var_dump("1e-" == 1);
+var_dump("1E" == 1);
+var_dump("1E-" == 1);
+
+// both-string comparisons must also avoid numeric comparison
+var_dump("1e" == "1");
+var_dump("0e" <=> "0");
+var_dump("1e" <=> "1");
+var_dump("1E-" <=> "1");
+
+// valid scientific notation remains numeric
+var_dump("1e2" == 100);
+var_dump("1E+2" == 100);
+var_dump("1e-2" == 0.01);
+var_dump("1e2" <=> "100");
+
+// existing native is_numeric behavior is a guard, not a reason to change its code
+var_dump(is_numeric("0e"));
+var_dump(is_numeric("1e"));
+var_dump(is_numeric("1e+"));
+var_dump(is_numeric("1e-"));
+var_dump(is_numeric("1E"));
+var_dump(is_numeric("1E-"));
+var_dump(is_numeric("1e2"));
+var_dump(is_numeric("1E+2"));
+var_dump(is_numeric("1e-2"));


### PR DESCRIPTION
In php 8.x, strings with an exponent indicator (`e`/`E`) require at least one digit after the exponent or sign to be considered numeric strings. Strings like `"0e"`, `"1e"`, or `"1e+"` must be treated as non-numeric.

Previously, `Value.isNumericString` in `src/runtime/value.zig` consumed the exponent marker without verifying that digits followed this caused false numeric comparisons such as:
- `"0e" == 0` returning `true`
- `"1e" == "1"` returning `true`
- `"0e" <=> "0"` returning `0` instead of `1`

While `stdlib/types.zig`'s native `is_numeric()` already rejected these strings, `Value.isNumericString()` was missing the check

### Solution

- Require at least one digit after the exponent marker (`e`/`E` and optional `+`/`-`) in `Value.isNumericString`
- Return `false` immediately if no exponent digits were consumed

### Tests

- Added unit tests in `src/runtime/value.zig` for valid and invalid exponent cases
- Added parity test in `tests/numeric_string_exponent.php` matching native php 8.x behavior
